### PR TITLE
chore: finalize monorepo structure and placeholders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,65 @@
+# Node
+node_modules/
+.npm/
+.yarn/
+.pnpm-store/
+.pnp.*
+
+# Java
+*.class
+*.jar
+*.war
+*.ear
+*.log
+*.ctxt
+hs_err_pid*
+
+# Flutter / Dart
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.pub-cache/
+.pub/
+.packages
+build/
+**/build/
+*.lock
+
+# Android (Flutter)
+android/.gradle/
+android/local.properties
+android/app/debug/
+android/app/profile/
+android/app/release/
+
+# iOS (Flutter)
+ios/Pods/
+ios/.symlinks/
+ios/Flutter/Flutter.framework
+ios/Flutter/Flutter.podspec
+ios/Flutter/Generated.xcconfig
+ios/Flutter/ephemeral/
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# IDEs
+.vscode/
+.idea/
+*.iml
+
+# Environment
+.env
+.env.*
+
+# Logs
+logs/
+*.log

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
-# Eunhye_Hymn
-은혜찬송가 in flutter
+# Eunhye Hymn Monorepo
+
+Internal church application suite for managing hymn content, scores, and part-practice media.
+This monorepo is structured to support multiple clients (web admin, mobile), a single API,
+shared infrastructure, and documentation designed for maintainability and AI-assisted
+development.
+
+## Repository Structure
+- `apps/`
+  - `apps/api`: Backend API service (no implementation yet)
+  - `apps/admin`: Admin web app (no implementation yet)
+  - `apps/mobile`: Mobile app (Flutter) (no implementation yet)
+- `infra/`
+  - `infra/docker`: Container and local dev orchestration
+  - `infra/aws`: AWS infrastructure definitions
+- `docs/`
+  - `docs/requirements.md`: MVP requirements
+  - `docs/architecture.md`: Architecture and Clean Architecture boundaries
+  - `docs/api-contract.md`: API contract definitions
+  - `docs/data-model.md`: Database schema and indexes
+  - `docs/events.md`: Event taxonomy and metadata schema
+  - `docs/dev-guide.md`: Local development guide (placeholder)
+  - `docs/runbook.md`: Staging runbook (placeholder)
+  - `docs/prompts`: AI prompt templates
+  - `docs/usecases`: Use case write-ups
+  - `docs/admin`: Admin-specific documentation
+  - `docs/mobile`: Mobile-specific documentation
+- `.github/workflows`: CI/CD workflows
+
+## Notes
+- Internal church use only.
+- Authentication: invite code + Google/Kakao login with JWT access/refresh tokens.
+- Media hosting: PDF scores and MP3 part-practice audio served from S3.
+
+---
+
+Suggested atomic commit message:
+- `chore: finalize monorepo structure and placeholders`

--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -1,0 +1,9 @@
+# Admin Documentation
+
+Reserved for admin portal specs, UI flows, and operational guidance.
+
+## Suggested Sections
+- Admin information architecture
+- Hymn management workflows
+- Invite and role management
+- Audit and analytics views

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -1,0 +1,188 @@
+# Eunhye Hymn API Contract (MVP)
+
+Base URL: `/api/v1`
+
+## 1. Auth
+### 1.1 Validate Invite Code
+- **POST** `/auth/invite/validate`
+- Request:
+```json
+{
+  "inviteCode": "ABC123"
+}
+```
+- Response:
+```json
+{
+  "valid": true,
+  "expiresAt": "2025-01-01T00:00:00Z"
+}
+```
+
+### 1.2 Social Login (Google/Kakao)
+- **POST** `/auth/social`
+- Request:
+```json
+{
+  "provider": "google",
+  "providerAccessToken": "...",
+  "inviteCode": "ABC123"
+}
+```
+- Response:
+```json
+{
+  "accessToken": "jwt-access",
+  "refreshToken": "jwt-refresh",
+  "expiresIn": 3600,
+  "user": {
+    "id": "usr_123",
+    "role": "member",
+    "name": "Grace Kim"
+  }
+}
+```
+
+### 1.3 Refresh Token
+- **POST** `/auth/refresh`
+- Request:
+```json
+{
+  "refreshToken": "jwt-refresh"
+}
+```
+- Response:
+```json
+{
+  "accessToken": "jwt-access",
+  "expiresIn": 3600
+}
+```
+
+## 2. Hymns
+### 2.1 List/Search Hymns
+- **GET** `/hymns?query=grace&tag=advent&key=C&tempo=80&page=1&pageSize=20`
+- Response:
+```json
+{
+  "items": [
+    {
+      "id": "hymn_001",
+      "number": 123,
+      "title": "Amazing Grace",
+      "key": "C",
+      "tempo": 80,
+      "tags": ["advent"],
+      "season": "advent"
+    }
+  ],
+  "page": 1,
+  "pageSize": 20,
+  "total": 200
+}
+```
+
+### 2.2 Get Hymn Detail
+- **GET** `/hymns/{id}`
+- Response:
+```json
+{
+  "id": "hymn_001",
+  "number": 123,
+  "title": "Amazing Grace",
+  "key": "C",
+  "tempo": 80,
+  "tags": ["advent"],
+  "season": "advent",
+  "scorePdfUrl": "https://s3.../score.pdf",
+  "parts": [
+    {
+      "part": "soprano",
+      "audioUrl": "https://s3.../soprano.mp3"
+    }
+  ]
+}
+```
+
+### 2.3 Create/Update Hymn (Admin)
+- **POST** `/hymns`
+- **PUT** `/hymns/{id}`
+- Request:
+```json
+{
+  "number": 123,
+  "title": "Amazing Grace",
+  "key": "C",
+  "tempo": 80,
+  "tags": ["advent"],
+  "season": "advent",
+  "scorePdfKey": "scores/amazing-grace.pdf",
+  "parts": [
+    {
+      "part": "soprano",
+      "audioKey": "audio/amazing-grace-soprano.mp3"
+    }
+  ]
+}
+```
+- Response:
+```json
+{
+  "id": "hymn_001"
+}
+```
+
+### 2.4 Archive Hymn (Admin)
+- **DELETE** `/hymns/{id}`
+- Response:
+```json
+{
+  "archived": true
+}
+```
+
+## 3. Invites (Admin)
+### 3.1 Create Invite
+- **POST** `/invites`
+- Request:
+```json
+{
+  "maxUses": 10,
+  "expiresAt": "2025-01-01T00:00:00Z"
+}
+```
+- Response:
+```json
+{
+  "inviteCode": "ABC123",
+  "expiresAt": "2025-01-01T00:00:00Z",
+  "maxUses": 10
+}
+```
+
+### 3.2 Revoke Invite
+- **POST** `/invites/{code}/revoke`
+- Response:
+```json
+{
+  "revoked": true
+}
+```
+
+## 4. Media
+### 4.1 Get Signed URL
+- **POST** `/media/sign`
+- Request:
+```json
+{
+  "objectKey": "scores/amazing-grace.pdf",
+  "contentType": "application/pdf"
+}
+```
+- Response:
+```json
+{
+  "signedUrl": "https://s3...",
+  "expiresIn": 300
+}
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,61 @@
+# Eunhye Hymn Architecture
+
+## 1. Goals
+- Maintainable, testable services with strict boundaries.
+- Clear API contracts to enable AI-assisted development.
+- Support web admin and mobile clients from a single API.
+
+## 2. System Overview
+- **Client Apps**:
+  - Admin Web (apps/admin)
+  - Mobile App (apps/mobile)
+- **API Service** (apps/api):
+  - Authentication, hymn metadata, media access, invites.
+- **Storage**:
+  - Relational DB for metadata.
+  - S3 for PDFs and MP3s.
+
+## 3. Clean Architecture Boundaries
+### 3.1 Layers
+- **Domain (Entities + Value Objects)**
+  - Core hymn/user/invite models.
+  - No framework dependencies.
+- **Use Cases (Application Services)**
+  - Orchestrate business logic (create hymn, issue invite).
+  - Depend on interfaces (ports) for persistence and external services.
+- **Interface Adapters**
+  - Controllers, presenters, DTOs, mappers.
+  - Translate HTTP requests into use case calls.
+- **Infrastructure**
+  - Database implementation, S3 client, OAuth clients.
+
+### 3.2 Dependency Rule
+- Dependencies must point inward.
+- Outer layers must not be referenced by inner layers.
+- Cross-cutting concerns (logging, metrics) are provided via interfaces.
+
+## 4. Bounded Contexts
+- **Identity & Access**: invite codes, social login, JWT issuance.
+- **Hymn Catalog**: hymn metadata, tags, and search.
+- **Media Access**: S3 pre-signed URL generation.
+- **Audit & Analytics**: basic events (view counts, admin changes).
+
+## 5. API Contract First
+- API request/response structures defined in `docs/api-contract.md`.
+- Versioning via `/api/v1`.
+- Additive changes only in minor versions.
+
+## 6. Data Management
+- Relational DB with indexed search fields.
+- Use soft deletes for hymns and invites.
+- Maintain audit tables for admin actions.
+
+## 7. Security
+- JWT access/refresh with rotation.
+- Role-based authorization in use case layer.
+- S3 access via short-lived signed URLs.
+
+## 8. AI-Assisted Development Practices
+- Keep documentation explicit and structured.
+- Use stable interfaces and DTOs for predictable code generation.
+- Maintain consistent naming for entities and endpoints.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,78 @@
+# Eunhye Hymn Data Model (MVP)
+
+## 1. Tables
+### 1.1 users
+- `id` (PK, UUID)
+- `email` (unique, nullable for Kakao if not provided)
+- `name`
+- `role` (enum: admin, member)
+- `provider` (enum: google, kakao)
+- `provider_user_id`
+- `created_at`, `updated_at`
+
+### 1.2 invites
+- `code` (PK, string)
+- `max_uses`
+- `use_count`
+- `expires_at`
+- `revoked` (bool)
+- `created_by` (FK -> users.id)
+- `created_at`, `updated_at`
+
+### 1.3 hymns
+- `id` (PK, UUID)
+- `number` (int)
+- `title` (string)
+- `key` (string)
+- `tempo` (int)
+- `season` (string)
+- `tags` (string[])
+- `score_pdf_key` (string)
+- `archived` (bool)
+- `created_at`, `updated_at`
+
+### 1.4 hymn_parts
+- `id` (PK, UUID)
+- `hymn_id` (FK -> hymns.id)
+- `part` (enum: soprano, alto, tenor, bass, piano, etc.)
+- `audio_key` (string)
+- `created_at`, `updated_at`
+
+### 1.5 refresh_tokens
+- `id` (PK, UUID)
+- `user_id` (FK -> users.id)
+- `token_hash` (string)
+- `expires_at`
+- `revoked` (bool)
+- `created_at`, `updated_at`
+
+### 1.6 hymn_views
+- `id` (PK, UUID)
+- `hymn_id` (FK -> hymns.id)
+- `user_id` (FK -> users.id)
+- `viewed_at`
+
+### 1.7 admin_audit_log
+- `id` (PK, UUID)
+- `actor_id` (FK -> users.id)
+- `action` (string)
+- `entity_type` (string)
+- `entity_id` (string)
+- `metadata` (json)
+- `created_at`
+
+## 2. Indexes
+- `users(provider, provider_user_id)` unique
+- `users(email)` unique (nullable)
+- `invites(expires_at)`
+- `hymns(number)`
+- `hymns(title)`
+- `hymns(tags)` (GIN index if supported)
+- `hymn_parts(hymn_id)`
+- `refresh_tokens(user_id)`
+- `hymn_views(hymn_id, viewed_at)`
+- `admin_audit_log(actor_id, created_at)`
+
+## 3. Notes
+- Use soft delete via `archived` on hymns and `revoked` on invites/tokens.
+- `score_pdf_key` and `audio_key` map to S3 object keys.

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -1,0 +1,30 @@
+# Eunhye Hymn Development Guide
+
+## 1. Local Development Plan
+- Use Docker for DB and local service dependencies.
+- Run the API locally with mocked S3 (or localstack).
+- Admin web and mobile apps run against `http://localhost` API.
+
+## 2. Prerequisites (Placeholder)
+- Node.js LTS
+- Java 17+ (if API is JVM-based)
+- Flutter stable
+- Docker + Docker Compose
+
+## 3. Setup Steps (Placeholder)
+1. Clone repository.
+2. Copy `.env.example` to `.env` (to be added later).
+3. Start local dependencies via Docker.
+4. Run API, then admin web, then mobile.
+
+## 4. Environment Variables (Placeholder)
+- `DATABASE_URL`
+- `JWT_SECRET`
+- `GOOGLE_CLIENT_ID`
+- `KAKAO_CLIENT_ID`
+- `S3_BUCKET`
+
+## 5. AI-Assisted Development Guidelines
+- Keep doc updates explicit and structured.
+- Prefer small, atomic changes with clear commit messages.
+- Update API contract before changing behavior.

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,76 @@
+# Eunhye Hymn Event Types
+
+## 1. Event Metadata Schema
+All events share a common envelope:
+```json
+{
+  "eventId": "evt_123",
+  "eventType": "hymn.viewed",
+  "occurredAt": "2025-01-01T00:00:00Z",
+  "actor": {
+    "userId": "usr_123",
+    "role": "member"
+  },
+  "source": {
+    "app": "mobile",
+    "version": "1.0.0"
+  },
+  "payload": {}
+}
+```
+
+## 2. MVP Event Types
+### 2.1 hymn.viewed
+- Payload:
+```json
+{
+  "hymnId": "hymn_001"
+}
+```
+
+### 2.2 hymn.created
+- Payload:
+```json
+{
+  "hymnId": "hymn_001",
+  "title": "Amazing Grace"
+}
+```
+
+### 2.3 hymn.updated
+- Payload:
+```json
+{
+  "hymnId": "hymn_001",
+  "changedFields": ["tempo", "tags"]
+}
+```
+
+### 2.4 invite.created
+- Payload:
+```json
+{
+  "inviteCode": "ABC123",
+  "maxUses": 10
+}
+```
+
+### 2.5 invite.revoked
+- Payload:
+```json
+{
+  "inviteCode": "ABC123"
+}
+```
+
+### 2.6 auth.login
+- Payload:
+```json
+{
+  "provider": "google"
+}
+```
+
+## 3. Notes
+- Events are used for audit, analytics, and debugging.
+- Event publication can be a no-op in MVP; ensure schema is stable for future.

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -1,0 +1,9 @@
+# Mobile Documentation
+
+Reserved for mobile app requirements, screen lists, and UX notes.
+
+## Suggested Sections
+- Screen inventory
+- Navigation map
+- Offline considerations
+- Media playback UX

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,86 @@
+# Eunhye Hymn MVP Requirements
+
+## 1. Purpose
+- Provide an internal church platform to manage hymn content, scores, and part-practice audio.
+- Support administrators with content curation and member access management.
+- Enable members to discover hymns and practice parts with PDFs/MP3s.
+
+## 2. Scope (MVP)
+### 2.1 In Scope
+- User authentication via:
+  - Invite code (required for first-time access).
+  - Google login.
+  - Kakao login.
+  - JWT access/refresh token flow.
+- Hymn content management:
+  - Create, update, archive hymns.
+  - Manage hymn metadata (title, number, key, tempo, tags).
+- Media delivery:
+  - PDF score files served from S3.
+  - MP3 part-practice audio served from S3.
+- Search and browse:
+  - Text search (title, number).
+  - Filter by tag, key, tempo, and service season.
+- Admin portal:
+  - Manage hymns and media links.
+  - Manage invites and user roles.
+- Basic analytics:
+  - View counts for hymns.
+
+### 2.2 Out of Scope (Future)
+- MIDI automation for part extraction.
+- In-app audio processing or mixing.
+- Public access or anonymous users.
+
+## 3. Personas
+- **Admin**: Curates hymns, uploads media, manages users and invite codes.
+- **Member**: Searches hymns, views scores, listens to part audio.
+
+## 4. Functional Requirements
+### 4.1 Authentication & Authorization
+- Invite code must be validated before social login succeeds.
+- Social login providers: Google, Kakao.
+- Access token (short-lived) + refresh token (long-lived, revocable).
+- Roles: `admin`, `member`.
+
+### 4.2 Hymn Management
+- Create hymn records with required fields:
+  - Hymn number, title, key, tempo, tags, season.
+- Attach media references:
+  - Score PDF URL (S3).
+  - Part audio URLs (S3, multiple parts allowed).
+- Soft-delete/archiving support.
+
+### 4.3 Search & Browse
+- Search by title or number.
+- Filter by tags, key, season, tempo.
+- Paginated results.
+
+### 4.4 Media Access
+- Secure S3 access via signed URLs.
+- Download/view score PDF.
+- Stream or download MP3s.
+
+### 4.5 Admin Functions
+- Create and revoke invite codes.
+- Assign roles to users.
+- Audit recent changes.
+
+## 5. Non-Functional Requirements
+- Maintainable structure with clear boundaries (Clean Architecture).
+- API-first design with explicit contracts.
+- Logs and audit trail for admin actions.
+- Basic monitoring hooks (health checks).
+- Compatibility:
+  - Web admin (React or similar).
+  - Mobile (Flutter).
+
+## 6. Success Criteria
+- Admin can publish a hymn with valid PDF + MP3 links.
+- Member can login with invite code and access hymns within 3 minutes.
+- Search results return within 1 second for typical query sizes.
+
+## 7. Risks & Assumptions
+- Assumes S3 bucket exists and access is controlled by signed URLs.
+- Assumes availability of Google/Kakao OAuth credentials.
+- Data volume is modest (church-level scale).

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,28 @@
+# Eunhye Hymn Runbook (Staging)
+
+## 1. Purpose
+- Provide a staged deployment checklist and operational procedures.
+
+## 2. Deployment Checklist (Placeholder)
+- [ ] Confirm CI build success.
+- [ ] Validate migrations.
+- [ ] Deploy API service.
+- [ ] Deploy admin web app.
+- [ ] Deploy mobile build (internal distribution).
+- [ ] Verify health checks and basic flows.
+
+## 3. Rollback Procedure (Placeholder)
+- Identify last known good build.
+- Revert API deployment.
+- Revert admin web deployment.
+- Notify stakeholders.
+
+## 4. Monitoring & Alerts (Placeholder)
+- API health endpoint availability.
+- Error rate thresholds.
+- S3 access errors.
+
+## 5. Incident Response (Placeholder)
+- Capture logs for timeframe.
+- Identify affected users and actions.
+- Document root cause and remediation.

--- a/docs/usecases/README.md
+++ b/docs/usecases/README.md
@@ -1,0 +1,12 @@
+# Use Case Documentation
+
+Use this folder to capture user journeys and functional workflows.
+
+## Template
+- **Title**: Short name of the use case
+- **Primary actor**: Admin or member
+- **Preconditions**: Required state before starting
+- **Happy path**: Step-by-step flow
+- **Alternate flows**: Variations and exceptions
+- **Data touched**: Entities or tables involved
+- **API endpoints**: Relevant contract references

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -1,0 +1,10 @@
+# AWS Infrastructure
+
+Placeholder for AWS infrastructure definitions and deployment notes.
+
+## Planned Content
+- VPC and networking
+- ECS/EKS or alternative compute
+- RDS/PostgreSQL
+- S3 buckets and policies
+- IAM roles and secrets

--- a/infra/docker/README.md
+++ b/infra/docker/README.md
@@ -1,0 +1,9 @@
+# Docker Infrastructure
+
+Placeholder for Docker and local orchestration assets.
+
+## Planned Content
+- Docker Compose configuration
+- Service dependencies
+- Localstack or S3 mock
+- Environment variable mapping


### PR DESCRIPTION
### Motivation
- Enforce a clear monorepo layout and a single source of truth for documentation under `docs/` to improve discoverability and developer onboarding.
- Reserve placeholder docs for infra, admin, mobile, and use-case areas to guide future implementation and prevent misplaced root-level markdown files.
- Update the root `README.md` to explicitly reference `apps/`, `infra/`, and `docs/` so the repository structure is documented upfront.

### Description
- Updated `README.md` to document the monorepo layout and list key docs and directories under `apps/`, `infra/`, and `docs/`.
- Added placeholder README files: `docs/usecases/README.md`, `docs/admin/README.md`, `docs/mobile/README.md`, `infra/aws/README.md`, and `infra/docker/README.md`.
- Ensured the core documentation files exist under `docs/`: `requirements.md`, `architecture.md`, `api-contract.md`, `data-model.md`, `events.md`, `dev-guide.md`, and `runbook.md`.
- Changes were committed with the atomic message `chore: finalize monorepo structure placeholders`.

### Testing
- No automated tests were executed because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980b979de0c832baf01a305aa7c806b)