### PR TITLE
feat: 초대코드 CRUD API + Admin UI

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -7,6 +7,7 @@ import HymnListPage from "./pages/HymnListPage";
 import HymnCreatePage from "./pages/HymnCreatePage";
 import HymnEditPage from "./pages/HymnEditPage";
 import AdminAssetUploadPage from "./pages/AdminAssetUploadPage";
+import InviteListPage from "./pages/InviteListPage";
 
 export default function App() {
   return (
@@ -20,6 +21,7 @@ export default function App() {
               <Route path="/hymns/new" element={<HymnCreatePage />} />
               <Route path="/hymns/:id/edit" element={<HymnEditPage />} />
               <Route path="/assets/upload" element={<AdminAssetUploadPage />} />
+              <Route path="/invites" element={<InviteListPage />} />
               <Route path="/" element={<Navigate to="/hymns" replace />} />
             </Route>
           </Route>

--- a/apps/admin/src/api/invites.ts
+++ b/apps/admin/src/api/invites.ts
@@ -1,0 +1,29 @@
+import { apiGet, apiPost } from "./client";
+
+export interface InviteCode {
+  id: string;
+  code: string;
+  maxUses: number | null;
+  usedCount: number;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  createdAt: string;
+}
+
+export interface CreateInviteRequest {
+  code: string;
+  maxUses?: number;
+  expiresAt?: string;
+}
+
+export function listInvites(): Promise<InviteCode[]> {
+  return apiGet<InviteCode[]>("/admin/invites");
+}
+
+export function createInvite(request: CreateInviteRequest): Promise<InviteCode> {
+  return apiPost<InviteCode>("/admin/invites", request);
+}
+
+export function revokeInvite(id: string): Promise<InviteCode> {
+  return apiPost<InviteCode>(`/admin/invites/${id}/revoke`, {});
+}

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -27,6 +27,9 @@ export default function Layout() {
           <NavLink to="/assets/upload" className={linkClass}>
             에셋 업로드
           </NavLink>
+          <NavLink to="/invites" className={linkClass}>
+            초대코드
+          </NavLink>
         </nav>
         <div className="px-4 py-4 border-t border-indigo-700 text-sm">
           <div className="text-indigo-200 mb-2">{user?.role ?? ""}</div>

--- a/apps/admin/src/pages/InviteListPage.tsx
+++ b/apps/admin/src/pages/InviteListPage.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useState } from "react";
+import {
+  createInvite,
+  listInvites,
+  revokeInvite,
+  type InviteCode,
+} from "../api/invites";
+
+export default function InviteListPage() {
+  const [invites, setInvites] = useState<InviteCode[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [newCode, setNewCode] = useState("");
+  const [newMaxUses, setNewMaxUses] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  const load = () => {
+    setLoading(true);
+    listInvites()
+      .then(setInvites)
+      .catch((err) =>
+        setError(err instanceof Error ? err.message : "목록을 불러올 수 없습니다.")
+      )
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const handleCreate = async () => {
+    if (!newCode.trim()) return;
+    setCreating(true);
+    setError(null);
+    try {
+      await createInvite({
+        code: newCode.trim(),
+        maxUses: newMaxUses ? parseInt(newMaxUses, 10) : undefined,
+      });
+      setNewCode("");
+      setNewMaxUses("");
+      load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "생성에 실패했습니다.");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleRevoke = async (id: string) => {
+    setError(null);
+    try {
+      await revokeInvite(id);
+      load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "폐기에 실패했습니다.");
+    }
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-6">초대코드 관리</h1>
+
+      {/* Create form */}
+      <div className="flex items-end gap-3 mb-6">
+        <div className="flex-1">
+          <label className="block text-sm font-medium text-gray-700 mb-1">코드</label>
+          <input
+            type="text"
+            value={newCode}
+            onChange={(e) => setNewCode(e.target.value)}
+            placeholder="예: WELCOME2026"
+            className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+        <div className="w-32">
+          <label className="block text-sm font-medium text-gray-700 mb-1">최대 사용</label>
+          <input
+            type="number"
+            value={newMaxUses}
+            onChange={(e) => setNewMaxUses(e.target.value)}
+            placeholder="무제한"
+            className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={handleCreate}
+          disabled={!newCode.trim() || creating}
+          className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700 disabled:opacity-50 text-sm"
+        >
+          {creating ? "생성 중..." : "생성"}
+        </button>
+      </div>
+
+      {error && <p className="text-red-600 mb-4">{error}</p>}
+      {loading && <p className="text-gray-500">로딩 중...</p>}
+
+      {!loading && (
+        <div className="bg-white rounded-lg shadow overflow-hidden">
+          <table className="w-full text-left">
+            <thead className="bg-gray-50 border-b">
+              <tr>
+                <th className="px-4 py-3 text-sm font-semibold text-gray-600">코드</th>
+                <th className="px-4 py-3 text-sm font-semibold text-gray-600">사용</th>
+                <th className="px-4 py-3 text-sm font-semibold text-gray-600">상태</th>
+                <th className="px-4 py-3 text-sm font-semibold text-gray-600">생성일</th>
+                <th className="px-4 py-3 text-sm font-semibold text-gray-600"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {invites.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="px-4 py-8 text-center text-gray-400">
+                    등록된 초대코드가 없습니다.
+                  </td>
+                </tr>
+              )}
+              {invites.map((inv) => {
+                const isRevoked = inv.revokedAt !== null;
+                const isExpired = inv.expiresAt !== null && new Date(inv.expiresAt) < new Date();
+                const isMaxed = inv.maxUses !== null && inv.usedCount >= inv.maxUses;
+                const isActive = !isRevoked && !isExpired && !isMaxed;
+
+                return (
+                  <tr key={inv.id} className="border-b last:border-b-0 hover:bg-gray-50">
+                    <td className="px-4 py-3 font-mono text-sm">{inv.code}</td>
+                    <td className="px-4 py-3 text-sm">
+                      {inv.usedCount}{inv.maxUses !== null ? ` / ${inv.maxUses}` : ""}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${
+                          isActive
+                            ? "bg-green-100 text-green-700"
+                            : "bg-gray-100 text-gray-500"
+                        }`}
+                      >
+                        {isRevoked ? "폐기됨" : isExpired ? "만료" : isMaxed ? "소진" : "활성"}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-500">
+                      {new Date(inv.createdAt).toLocaleDateString("ko-KR")}
+                    </td>
+                    <td className="px-4 py-3">
+                      {isActive && (
+                        <button
+                          type="button"
+                          onClick={() => handleRevoke(inv.id)}
+                          className="text-red-600 hover:underline text-sm"
+                        >
+                          폐기
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/CreateInviteUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/CreateInviteUseCase.java
@@ -1,9 +1,11 @@
 package com.eunhyehymn.application.usecases;
 
+import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.domain.model.InviteCode;
 import com.eunhyehymn.domain.repository.InviteCodeRepository;
 import java.time.Instant;
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
 
 public class CreateInviteUseCase {
     private final InviteCodeRepository inviteCodeRepository;
@@ -13,6 +15,10 @@ public class CreateInviteUseCase {
     }
 
     public InviteCode create(String code, Integer maxUses, Instant expiresAt) {
+        if (inviteCodeRepository.findByCode(code).isPresent()) {
+            throw new ApiException(
+                HttpStatus.CONFLICT, "invite_code_duplicate", "이미 존재하는 초대코드입니다", null);
+        }
         InviteCode inviteCode = new InviteCode(
             UUID.randomUUID(), code, maxUses, 0, expiresAt, null, Instant.now()
         );

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/CreateInviteUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/CreateInviteUseCase.java
@@ -1,0 +1,21 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.domain.model.InviteCode;
+import com.eunhyehymn.domain.repository.InviteCodeRepository;
+import java.time.Instant;
+import java.util.UUID;
+
+public class CreateInviteUseCase {
+    private final InviteCodeRepository inviteCodeRepository;
+
+    public CreateInviteUseCase(InviteCodeRepository inviteCodeRepository) {
+        this.inviteCodeRepository = inviteCodeRepository;
+    }
+
+    public InviteCode create(String code, Integer maxUses, Instant expiresAt) {
+        InviteCode inviteCode = new InviteCode(
+            UUID.randomUUID(), code, maxUses, 0, expiresAt, null, Instant.now()
+        );
+        return inviteCodeRepository.save(inviteCode);
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/ListInvitesUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/ListInvitesUseCase.java
@@ -1,0 +1,17 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.domain.model.InviteCode;
+import com.eunhyehymn.domain.repository.InviteCodeRepository;
+import java.util.List;
+
+public class ListInvitesUseCase {
+    private final InviteCodeRepository inviteCodeRepository;
+
+    public ListInvitesUseCase(InviteCodeRepository inviteCodeRepository) {
+        this.inviteCodeRepository = inviteCodeRepository;
+    }
+
+    public List<InviteCode> listAll() {
+        return inviteCodeRepository.findAll();
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/RevokeInviteUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/RevokeInviteUseCase.java
@@ -1,9 +1,11 @@
 package com.eunhyehymn.application.usecases;
 
+import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.domain.model.InviteCode;
 import com.eunhyehymn.domain.repository.InviteCodeRepository;
 import java.time.Instant;
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
 
 public class RevokeInviteUseCase {
     private final InviteCodeRepository inviteCodeRepository;
@@ -14,7 +16,8 @@ public class RevokeInviteUseCase {
 
     public InviteCode revoke(UUID id) {
         InviteCode invite = inviteCodeRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("초대코드를 찾을 수 없습니다"));
+            .orElseThrow(() -> new ApiException(
+                HttpStatus.NOT_FOUND, "invite_not_found", "초대코드를 찾을 수 없습니다", null));
         InviteCode revoked = new InviteCode(
             invite.id(), invite.code(), invite.maxUses(), invite.usedCount(),
             invite.expiresAt(), Instant.now(), invite.createdAt()

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/RevokeInviteUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/RevokeInviteUseCase.java
@@ -1,0 +1,24 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.domain.model.InviteCode;
+import com.eunhyehymn.domain.repository.InviteCodeRepository;
+import java.time.Instant;
+import java.util.UUID;
+
+public class RevokeInviteUseCase {
+    private final InviteCodeRepository inviteCodeRepository;
+
+    public RevokeInviteUseCase(InviteCodeRepository inviteCodeRepository) {
+        this.inviteCodeRepository = inviteCodeRepository;
+    }
+
+    public InviteCode revoke(UUID id) {
+        InviteCode invite = inviteCodeRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("초대코드를 찾을 수 없습니다"));
+        InviteCode revoked = new InviteCode(
+            invite.id(), invite.code(), invite.maxUses(), invite.usedCount(),
+            invite.expiresAt(), Instant.now(), invite.createdAt()
+        );
+        return inviteCodeRepository.save(revoked);
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/ValidateInviteUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/ValidateInviteUseCase.java
@@ -1,0 +1,36 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.domain.model.InviteCode;
+import com.eunhyehymn.domain.repository.InviteCodeRepository;
+import java.time.Instant;
+import java.util.Optional;
+
+public class ValidateInviteUseCase {
+    private final InviteCodeRepository inviteCodeRepository;
+
+    public ValidateInviteUseCase(InviteCodeRepository inviteCodeRepository) {
+        this.inviteCodeRepository = inviteCodeRepository;
+    }
+
+    public Result validate(String code) {
+        Optional<InviteCode> found = inviteCodeRepository.findByCode(code);
+        if (found.isEmpty()) {
+            return new Result(false, null);
+        }
+        InviteCode invite = found.get();
+        if (!invite.isValid()) {
+            return new Result(false, invite.expiresAt());
+        }
+        // increment usedCount
+        InviteCode updated = new InviteCode(
+            invite.id(), invite.code(), invite.maxUses(),
+            invite.usedCount() + 1,
+            invite.expiresAt(), invite.revokedAt(), invite.createdAt()
+        );
+        inviteCodeRepository.save(updated);
+        return new Result(true, invite.expiresAt());
+    }
+
+    public record Result(boolean valid, Instant expiresAt) {
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/ValidateInviteUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/ValidateInviteUseCase.java
@@ -21,13 +21,6 @@ public class ValidateInviteUseCase {
         if (!invite.isValid()) {
             return new Result(false, invite.expiresAt());
         }
-        // increment usedCount
-        InviteCode updated = new InviteCode(
-            invite.id(), invite.code(), invite.maxUses(),
-            invite.usedCount() + 1,
-            invite.expiresAt(), invite.revokedAt(), invite.createdAt()
-        );
-        inviteCodeRepository.save(updated);
         return new Result(true, invite.expiresAt());
     }
 

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/InviteConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/InviteConfig.java
@@ -1,0 +1,32 @@
+package com.eunhyehymn.common.config;
+
+import com.eunhyehymn.application.usecases.CreateInviteUseCase;
+import com.eunhyehymn.application.usecases.ListInvitesUseCase;
+import com.eunhyehymn.application.usecases.RevokeInviteUseCase;
+import com.eunhyehymn.application.usecases.ValidateInviteUseCase;
+import com.eunhyehymn.domain.repository.InviteCodeRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class InviteConfig {
+    @Bean
+    ValidateInviteUseCase validateInviteUseCase(InviteCodeRepository inviteCodeRepository) {
+        return new ValidateInviteUseCase(inviteCodeRepository);
+    }
+
+    @Bean
+    CreateInviteUseCase createInviteUseCase(InviteCodeRepository inviteCodeRepository) {
+        return new CreateInviteUseCase(inviteCodeRepository);
+    }
+
+    @Bean
+    RevokeInviteUseCase revokeInviteUseCase(InviteCodeRepository inviteCodeRepository) {
+        return new RevokeInviteUseCase(inviteCodeRepository);
+    }
+
+    @Bean
+    ListInvitesUseCase listInvitesUseCase(InviteCodeRepository inviteCodeRepository) {
+        return new ListInvitesUseCase(inviteCodeRepository);
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/SecurityRequiredProperties.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/SecurityRequiredProperties.java
@@ -76,7 +76,7 @@ public class SecurityRequiredProperties {
     }
 
     public static class Invite {
-        @NotBlank(message = "INVITE_CODE는 필수값입니다.")
+        // DB 기반 초대코드 관리로 전환됨. 환경변수는 선택 사항.
         private String code;
 
         public String getCode() {

--- a/apps/api/src/main/java/com/eunhyehymn/domain/model/InviteCode.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/model/InviteCode.java
@@ -1,0 +1,21 @@
+package com.eunhyehymn.domain.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record InviteCode(
+    UUID id,
+    String code,
+    Integer maxUses,
+    int usedCount,
+    Instant expiresAt,
+    Instant revokedAt,
+    Instant createdAt
+) {
+    public boolean isValid() {
+        if (revokedAt != null) return false;
+        if (expiresAt != null && expiresAt.isBefore(Instant.now())) return false;
+        if (maxUses != null && usedCount >= maxUses) return false;
+        return true;
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/InviteCodeRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/InviteCodeRepository.java
@@ -1,0 +1,16 @@
+package com.eunhyehymn.domain.repository;
+
+import com.eunhyehymn.domain.model.InviteCode;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface InviteCodeRepository {
+    InviteCode save(InviteCode inviteCode);
+
+    Optional<InviteCode> findByCode(String code);
+
+    Optional<InviteCode> findById(UUID id);
+
+    List<InviteCode> findAll();
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/InviteCodeEntity.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/InviteCodeEntity.java
@@ -1,0 +1,56 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "invite_codes")
+public class InviteCodeEntity {
+    @Id
+    @Column(nullable = false)
+    private UUID id;
+
+    @Column(nullable = false, unique = true, length = 64)
+    private String code;
+
+    @Column(name = "max_uses")
+    private Integer maxUses;
+
+    @Column(name = "used_count", nullable = false)
+    private int usedCount;
+
+    @Column(name = "expires_at")
+    private Instant expiresAt;
+
+    @Column(name = "revoked_at")
+    private Instant revokedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    protected InviteCodeEntity() {
+    }
+
+    public InviteCodeEntity(UUID id, String code, Integer maxUses, int usedCount,
+                            Instant expiresAt, Instant revokedAt, Instant createdAt) {
+        this.id = id;
+        this.code = code;
+        this.maxUses = maxUses;
+        this.usedCount = usedCount;
+        this.expiresAt = expiresAt;
+        this.revokedAt = revokedAt;
+        this.createdAt = createdAt;
+    }
+
+    public UUID getId() { return id; }
+    public String getCode() { return code; }
+    public Integer getMaxUses() { return maxUses; }
+    public int getUsedCount() { return usedCount; }
+    public Instant getExpiresAt() { return expiresAt; }
+    public Instant getRevokedAt() { return revokedAt; }
+    public Instant getCreatedAt() { return createdAt; }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/InviteCodeJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/InviteCodeJpaRepository.java
@@ -1,0 +1,9 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InviteCodeJpaRepository extends JpaRepository<InviteCodeEntity, UUID> {
+    Optional<InviteCodeEntity> findByCode(String code);
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/InviteCodeRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/InviteCodeRepositoryAdapter.java
@@ -1,0 +1,39 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import com.eunhyehymn.domain.model.InviteCode;
+import com.eunhyehymn.domain.repository.InviteCodeRepository;
+import com.eunhyehymn.infrastructure.persistence.mapper.InviteCodeMapper;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InviteCodeRepositoryAdapter implements InviteCodeRepository {
+    private final InviteCodeJpaRepository jpaRepository;
+
+    public InviteCodeRepositoryAdapter(InviteCodeJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public InviteCode save(InviteCode inviteCode) {
+        InviteCodeEntity saved = jpaRepository.save(InviteCodeMapper.toEntity(inviteCode));
+        return InviteCodeMapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<InviteCode> findByCode(String code) {
+        return jpaRepository.findByCode(code).map(InviteCodeMapper::toDomain);
+    }
+
+    @Override
+    public Optional<InviteCode> findById(UUID id) {
+        return jpaRepository.findById(id).map(InviteCodeMapper::toDomain);
+    }
+
+    @Override
+    public List<InviteCode> findAll() {
+        return jpaRepository.findAll().stream().map(InviteCodeMapper::toDomain).toList();
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/mapper/InviteCodeMapper.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/mapper/InviteCodeMapper.java
@@ -1,0 +1,33 @@
+package com.eunhyehymn.infrastructure.persistence.mapper;
+
+import com.eunhyehymn.domain.model.InviteCode;
+import com.eunhyehymn.infrastructure.persistence.InviteCodeEntity;
+
+public final class InviteCodeMapper {
+    private InviteCodeMapper() {
+    }
+
+    public static InviteCode toDomain(InviteCodeEntity entity) {
+        return new InviteCode(
+            entity.getId(),
+            entity.getCode(),
+            entity.getMaxUses(),
+            entity.getUsedCount(),
+            entity.getExpiresAt(),
+            entity.getRevokedAt(),
+            entity.getCreatedAt()
+        );
+    }
+
+    public static InviteCodeEntity toEntity(InviteCode ic) {
+        return new InviteCodeEntity(
+            ic.id(),
+            ic.code(),
+            ic.maxUses(),
+            ic.usedCount(),
+            ic.expiresAt(),
+            ic.revokedAt(),
+            ic.createdAt()
+        );
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminInviteController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminInviteController.java
@@ -1,0 +1,83 @@
+package com.eunhyehymn.presentation.controllers;
+
+import com.eunhyehymn.application.usecases.CreateInviteUseCase;
+import com.eunhyehymn.application.usecases.ListInvitesUseCase;
+import com.eunhyehymn.application.usecases.RevokeInviteUseCase;
+import com.eunhyehymn.common.response.ApiResponse;
+import com.eunhyehymn.domain.model.InviteCode;
+import jakarta.validation.constraints.NotBlank;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/invites")
+@Validated
+public class AdminInviteController {
+    private final CreateInviteUseCase createInviteUseCase;
+    private final RevokeInviteUseCase revokeInviteUseCase;
+    private final ListInvitesUseCase listInvitesUseCase;
+
+    public AdminInviteController(
+        CreateInviteUseCase createInviteUseCase,
+        RevokeInviteUseCase revokeInviteUseCase,
+        ListInvitesUseCase listInvitesUseCase
+    ) {
+        this.createInviteUseCase = createInviteUseCase;
+        this.revokeInviteUseCase = revokeInviteUseCase;
+        this.listInvitesUseCase = listInvitesUseCase;
+    }
+
+    @PostMapping
+    public ApiResponse<InviteResponse> create(@RequestBody @Validated CreateRequest request) {
+        InviteCode created = createInviteUseCase.create(
+            request.code(), request.maxUses(), request.expiresAt()
+        );
+        return ApiResponse.success(InviteResponse.from(created));
+    }
+
+    @PostMapping("/{id}/revoke")
+    public ApiResponse<InviteResponse> revoke(@PathVariable UUID id) {
+        InviteCode revoked = revokeInviteUseCase.revoke(id);
+        return ApiResponse.success(InviteResponse.from(revoked));
+    }
+
+    @GetMapping
+    public ApiResponse<List<InviteResponse>> list() {
+        List<InviteResponse> items = listInvitesUseCase.listAll().stream()
+            .map(InviteResponse::from)
+            .toList();
+        return ApiResponse.success(items);
+    }
+
+    public record CreateRequest(
+        @NotBlank String code,
+        Integer maxUses,
+        Instant expiresAt
+    ) {
+    }
+
+    public record InviteResponse(
+        UUID id,
+        String code,
+        Integer maxUses,
+        int usedCount,
+        Instant expiresAt,
+        Instant revokedAt,
+        Instant createdAt
+    ) {
+        static InviteResponse from(InviteCode ic) {
+            return new InviteResponse(
+                ic.id(), ic.code(), ic.maxUses(), ic.usedCount(),
+                ic.expiresAt(), ic.revokedAt(), ic.createdAt()
+            );
+        }
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AuthController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AuthController.java
@@ -2,7 +2,9 @@ package com.eunhyehymn.presentation.controllers;
 
 import com.eunhyehymn.application.usecases.LogoutUseCase;
 import com.eunhyehymn.application.usecases.RefreshTokenUseCase;
+import com.eunhyehymn.application.usecases.ValidateInviteUseCase;
 import com.eunhyehymn.common.response.ApiResponse;
+import java.time.Instant;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,10 +18,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
     private final RefreshTokenUseCase refreshTokenUseCase;
     private final LogoutUseCase logoutUseCase;
+    private final ValidateInviteUseCase validateInviteUseCase;
 
-    public AuthController(RefreshTokenUseCase refreshTokenUseCase, LogoutUseCase logoutUseCase) {
+    public AuthController(
+        RefreshTokenUseCase refreshTokenUseCase,
+        LogoutUseCase logoutUseCase,
+        ValidateInviteUseCase validateInviteUseCase
+    ) {
         this.refreshTokenUseCase = refreshTokenUseCase;
         this.logoutUseCase = logoutUseCase;
+        this.validateInviteUseCase = validateInviteUseCase;
+    }
+
+    @PostMapping("/invite/validate")
+    public ApiResponse<InviteValidateResponse> validateInvite(
+        @RequestBody @Validated InviteValidateRequest request
+    ) {
+        ValidateInviteUseCase.Result result = validateInviteUseCase.validate(request.inviteCode());
+        return ApiResponse.success(new InviteValidateResponse(result.valid(), result.expiresAt()));
     }
 
     @PostMapping("/refresh")
@@ -41,5 +57,11 @@ public class AuthController {
     }
 
     public record TokenResponse(String accessToken, String refreshToken) {
+    }
+
+    public record InviteValidateRequest(@NotBlank String inviteCode) {
+    }
+
+    public record InviteValidateResponse(boolean valid, Instant expiresAt) {
     }
 }

--- a/apps/api/src/main/resources/db/migration/V6__create_invite_codes.sql
+++ b/apps/api/src/main/resources/db/migration/V6__create_invite_codes.sql
@@ -1,0 +1,11 @@
+CREATE TABLE invite_codes (
+    id          UUID PRIMARY KEY,
+    code        VARCHAR(64) NOT NULL UNIQUE,
+    max_uses    INTEGER,
+    used_count  INTEGER NOT NULL DEFAULT 0,
+    expires_at  TIMESTAMP WITH TIME ZONE,
+    revoked_at  TIMESTAMP WITH TIME ZONE,
+    created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_invite_codes_code ON invite_codes(code);

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminInviteApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminInviteApiTest.java
@@ -1,0 +1,164 @@
+package com.eunhyehymn.presentation.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.eunhyehymn.domain.model.Role;
+import com.eunhyehymn.domain.model.UserStatus;
+import com.eunhyehymn.infrastructure.persistence.InviteCodeJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.UserEntity;
+import com.eunhyehymn.infrastructure.persistence.UserJpaRepository;
+import com.eunhyehymn.infrastructure.security.JwtService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AdminInviteApiTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtService jwtService;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private InviteCodeJpaRepository inviteCodeJpaRepository;
+
+    private String adminToken;
+
+    @BeforeEach
+    void setUp() {
+        inviteCodeJpaRepository.deleteAll();
+        userJpaRepository.deleteAll();
+
+        UUID adminId = UUID.randomUUID();
+        userJpaRepository.save(new UserEntity(
+            adminId, "관리자", Role.ADMIN, UserStatus.ACTIVE, Instant.now(), Instant.now()
+        ));
+        adminToken = jwtService.issueAccessToken(adminId.toString(), Role.ADMIN.name());
+    }
+
+    @Test
+    void adminCanCreateInviteCode() throws Exception {
+        String payload = objectMapper.writeValueAsString(Map.of(
+            "code", "WELCOME2026"
+        ));
+
+        mockMvc.perform(post("/admin/invites")
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.code").value("WELCOME2026"))
+            .andExpect(jsonPath("$.data.usedCount").value(0));
+    }
+
+    @Test
+    void adminCanListInviteCodes() throws Exception {
+        // create one first
+        String payload = objectMapper.writeValueAsString(Map.of("code", "LIST_TEST"));
+        mockMvc.perform(post("/admin/invites")
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isOk());
+
+        mockMvc.perform(get("/admin/invites")
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.length()").value(1))
+            .andExpect(jsonPath("$.data[0].code").value("LIST_TEST"));
+    }
+
+    @Test
+    void adminCanRevokeInviteCode() throws Exception {
+        String payload = objectMapper.writeValueAsString(Map.of("code", "REVOKE_ME"));
+        String response = mockMvc.perform(post("/admin/invites")
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getContentAsString();
+
+        String id = objectMapper.readTree(response).get("data").get("id").asText();
+
+        mockMvc.perform(post("/admin/invites/" + id + "/revoke")
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.revokedAt").isNotEmpty());
+    }
+
+    @Test
+    void validateInviteCodeWorks() throws Exception {
+        // create code
+        String createPayload = objectMapper.writeValueAsString(Map.of("code", "VALID_CODE"));
+        mockMvc.perform(post("/admin/invites")
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createPayload))
+            .andExpect(status().isOk());
+
+        // validate (public endpoint)
+        String validatePayload = objectMapper.writeValueAsString(Map.of("inviteCode", "VALID_CODE"));
+        mockMvc.perform(post("/auth/invite/validate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validatePayload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.valid").value(true));
+    }
+
+    @Test
+    void validateRejectsInvalidCode() throws Exception {
+        String payload = objectMapper.writeValueAsString(Map.of("inviteCode", "WRONG"));
+        mockMvc.perform(post("/auth/invite/validate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.valid").value(false));
+    }
+
+    @Test
+    void validateRejectsRevokedCode() throws Exception {
+        // create and revoke
+        String createPayload = objectMapper.writeValueAsString(Map.of("code", "REVOKED"));
+        String response = mockMvc.perform(post("/admin/invites")
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createPayload))
+            .andExpect(status().isOk())
+            .andReturn().getResponse().getContentAsString();
+
+        String id = objectMapper.readTree(response).get("data").get("id").asText();
+
+        mockMvc.perform(post("/admin/invites/" + id + "/revoke")
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isOk());
+
+        // try validate
+        String validatePayload = objectMapper.writeValueAsString(Map.of("inviteCode", "REVOKED"));
+        mockMvc.perform(post("/auth/invite/validate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validatePayload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.valid").value(false));
+    }
+}

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminInviteApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminInviteApiTest.java
@@ -127,6 +127,31 @@ class AdminInviteApiTest {
     }
 
     @Test
+    void duplicateCodeReturnsConflict() throws Exception {
+        String payload = objectMapper.writeValueAsString(Map.of("code", "DUPLICATE"));
+        mockMvc.perform(post("/admin/invites")
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isOk());
+
+        mockMvc.perform(post("/admin/invites")
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.error.code").value("invite_code_duplicate"));
+    }
+
+    @Test
+    void revokeNonExistentReturnsNotFound() throws Exception {
+        mockMvc.perform(post("/admin/invites/" + UUID.randomUUID() + "/revoke")
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error.code").value("invite_not_found"));
+    }
+
+    @Test
     void validateRejectsInvalidCode() throws Exception {
         String payload = objectMapper.writeValueAsString(Map.of("inviteCode", "WRONG"));
         mockMvc.perform(post("/auth/invite/validate")


### PR DESCRIPTION
## Summary
- 초대코드 DB 기반 CRUD 전체 구현 (Clean Architecture)
- `POST /auth/invite/validate` 공개 엔드포인트 추가
- Admin API: 생성(`POST /admin/invites`), 목록(`GET`), 폐기(`POST /{id}/revoke`)
- Flyway V6: `invite_codes` 테이블 생성
- `INVITE_CODE` 환경변수 필수 → 선택으로 변경 (DB 기반 전환)
- Admin UI: 초대코드 관리 페이지 + 사이드바 링크

## Test plan
- [ ] `./gradlew test` 전체 통과 (AdminInviteApiTest 6개 포함)
- [ ] `npm run build` 성공
- [ ] Admin `/invites` 페이지에서 초대코드 생성/목록/폐기 확인
- [ ] `/auth/invite/validate` 로 유효/무효 코드 검증 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)