### PR TITLE
feat: 사용자/역할 관리 API + Admin UI

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -7,6 +7,7 @@ import HymnListPage from "./pages/HymnListPage";
 import HymnCreatePage from "./pages/HymnCreatePage";
 import HymnEditPage from "./pages/HymnEditPage";
 import AdminAssetUploadPage from "./pages/AdminAssetUploadPage";
+import UserListPage from "./pages/UserListPage";
 
 export default function App() {
   return (
@@ -20,6 +21,7 @@ export default function App() {
               <Route path="/hymns/new" element={<HymnCreatePage />} />
               <Route path="/hymns/:id/edit" element={<HymnEditPage />} />
               <Route path="/assets/upload" element={<AdminAssetUploadPage />} />
+              <Route path="/users" element={<UserListPage />} />
               <Route path="/" element={<Navigate to="/hymns" replace />} />
             </Route>
           </Route>

--- a/apps/admin/src/api/users.ts
+++ b/apps/admin/src/api/users.ts
@@ -1,0 +1,23 @@
+import { apiGet, apiPatch } from "./client";
+
+export interface UserInfo {
+  id: string;
+  displayName: string;
+  role: string;
+  status: string;
+  createdAt: string;
+  lastLoginAt: string | null;
+}
+
+export interface UpdateUserRequest {
+  role?: string;
+  status?: string;
+}
+
+export function listUsers(): Promise<UserInfo[]> {
+  return apiGet<UserInfo[]>("/admin/users");
+}
+
+export function updateUser(id: string, request: UpdateUserRequest): Promise<UserInfo> {
+  return apiPatch<UserInfo>(`/admin/users/${id}`, request);
+}

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -27,6 +27,9 @@ export default function Layout() {
           <NavLink to="/assets/upload" className={linkClass}>
             에셋 업로드
           </NavLink>
+          <NavLink to="/users" className={linkClass}>
+            사용자 관리
+          </NavLink>
         </nav>
         <div className="px-4 py-4 border-t border-indigo-700 text-sm">
           <div className="text-indigo-200 mb-2">{user?.role ?? ""}</div>

--- a/apps/admin/src/pages/UserListPage.tsx
+++ b/apps/admin/src/pages/UserListPage.tsx
@@ -46,7 +46,7 @@ export default function UserListPage() {
       {error && <p className="text-red-600 mb-4">{error}</p>}
       {loading && <p className="text-gray-500">로딩 중...</p>}
 
-      {!loading && (
+      {!loading && !error && (
         <div className="bg-white rounded-lg shadow overflow-hidden">
           <table className="w-full text-left">
             <thead className="bg-gray-50 border-b">

--- a/apps/admin/src/pages/UserListPage.tsx
+++ b/apps/admin/src/pages/UserListPage.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from "react";
+import { listUsers, updateUser, type UserInfo } from "../api/users";
+
+export default function UserListPage() {
+  const [users, setUsers] = useState<UserInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = () => {
+    setLoading(true);
+    listUsers()
+      .then(setUsers)
+      .catch((err) =>
+        setError(err instanceof Error ? err.message : "목록을 불러올 수 없습니다.")
+      )
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const handleRoleChange = async (id: string, role: string) => {
+    setError(null);
+    try {
+      await updateUser(id, { role });
+      load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "역할 변경에 실패했습니다.");
+    }
+  };
+
+  const handleStatusToggle = async (id: string, currentStatus: string) => {
+    const newStatus = currentStatus === "ACTIVE" ? "DISABLED" : "ACTIVE";
+    setError(null);
+    try {
+      await updateUser(id, { status: newStatus });
+      load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "상태 변경에 실패했습니다.");
+    }
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-6">사용자 관리</h1>
+
+      {error && <p className="text-red-600 mb-4">{error}</p>}
+      {loading && <p className="text-gray-500">로딩 중...</p>}
+
+      {!loading && (
+        <div className="bg-white rounded-lg shadow overflow-hidden">
+          <table className="w-full text-left">
+            <thead className="bg-gray-50 border-b">
+              <tr>
+                <th className="px-4 py-3 text-sm font-semibold text-gray-600">이름</th>
+                <th className="px-4 py-3 text-sm font-semibold text-gray-600">역할</th>
+                <th className="px-4 py-3 text-sm font-semibold text-gray-600">상태</th>
+                <th className="px-4 py-3 text-sm font-semibold text-gray-600">가입일</th>
+                <th className="px-4 py-3 text-sm font-semibold text-gray-600">최근 로그인</th>
+                <th className="px-4 py-3 text-sm font-semibold text-gray-600"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-4 py-8 text-center text-gray-400">
+                    등록된 사용자가 없습니다.
+                  </td>
+                </tr>
+              )}
+              {users.map((u) => (
+                <tr key={u.id} className="border-b last:border-b-0 hover:bg-gray-50">
+                  <td className="px-4 py-3 text-sm">{u.displayName}</td>
+                  <td className="px-4 py-3">
+                    <select
+                      value={u.role}
+                      onChange={(e) => handleRoleChange(u.id, e.target.value)}
+                      className="border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    >
+                      <option value="USER">USER</option>
+                      <option value="ADMIN">ADMIN</option>
+                    </select>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${
+                        u.status === "ACTIVE"
+                          ? "bg-green-100 text-green-700"
+                          : "bg-gray-100 text-gray-500"
+                      }`}
+                    >
+                      {u.status === "ACTIVE" ? "활성" : "비활성"}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500">
+                    {new Date(u.createdAt).toLocaleDateString("ko-KR")}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500">
+                    {u.lastLoginAt ? new Date(u.lastLoginAt).toLocaleDateString("ko-KR") : "-"}
+                  </td>
+                  <td className="px-4 py-3">
+                    <button
+                      type="button"
+                      onClick={() => handleStatusToggle(u.id, u.status)}
+                      className={`text-sm hover:underline ${
+                        u.status === "ACTIVE" ? "text-red-600" : "text-green-600"
+                      }`}
+                    >
+                      {u.status === "ACTIVE" ? "비활성화" : "활성화"}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminListUsersUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminListUsersUseCase.java
@@ -1,0 +1,17 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.domain.model.User;
+import com.eunhyehymn.domain.repository.UserRepository;
+import java.util.List;
+
+public class AdminListUsersUseCase {
+    private final UserRepository userRepository;
+
+    public AdminListUsersUseCase(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public List<User> listAll() {
+        return userRepository.findAll();
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminUpdateUserUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminUpdateUserUseCase.java
@@ -1,0 +1,24 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.domain.model.Role;
+import com.eunhyehymn.domain.model.User;
+import com.eunhyehymn.domain.model.UserStatus;
+import com.eunhyehymn.domain.repository.UserRepository;
+import java.util.UUID;
+
+public class AdminUpdateUserUseCase {
+    private final UserRepository userRepository;
+
+    public AdminUpdateUserUseCase(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public User update(UUID userId, Role role, UserStatus status) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+        Role newRole = role != null ? role : user.role();
+        UserStatus newStatus = status != null ? status : user.status();
+        User updated = new User(user.id(), user.displayName(), newRole, newStatus, user.createdAt(), user.lastLoginAt());
+        return userRepository.save(updated);
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminUpdateUserUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminUpdateUserUseCase.java
@@ -1,10 +1,12 @@
 package com.eunhyehymn.application.usecases;
 
+import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.domain.model.Role;
 import com.eunhyehymn.domain.model.User;
 import com.eunhyehymn.domain.model.UserStatus;
 import com.eunhyehymn.domain.repository.UserRepository;
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
 
 public class AdminUpdateUserUseCase {
     private final UserRepository userRepository;
@@ -15,7 +17,8 @@ public class AdminUpdateUserUseCase {
 
     public User update(UUID userId, Role role, UserStatus status) {
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+            .orElseThrow(() -> new ApiException(
+                HttpStatus.NOT_FOUND, "user_not_found", "사용자를 찾을 수 없습니다", null));
         Role newRole = role != null ? role : user.role();
         UserStatus newStatus = status != null ? status : user.status();
         User updated = new User(user.id(), user.displayName(), newRole, newStatus, user.createdAt(), user.lastLoginAt());

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/RefreshTokenUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/RefreshTokenUseCase.java
@@ -4,6 +4,8 @@ import com.eunhyehymn.application.ports.TokenHashService;
 import com.eunhyehymn.application.ports.TokenService;
 import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.domain.model.RefreshToken;
+import com.eunhyehymn.domain.model.User;
+import com.eunhyehymn.domain.model.UserStatus;
 import com.eunhyehymn.domain.repository.UserRepository;
 import com.eunhyehymn.domain.repository.RefreshTokenRepository;
 import java.time.Instant;
@@ -56,8 +58,11 @@ public class RefreshTokenUseCase {
         RefreshToken next = new RefreshToken(UUID.randomUUID(), existing.userId(), newHash, expiresAt, null, Instant.now());
         refreshTokenRepository.save(next);
 
-        var user = userRepository.findById(existing.userId())
+        User user = userRepository.findById(existing.userId())
             .orElseThrow(() -> new ApiException(HttpStatus.UNAUTHORIZED, "refresh_invalid", "사용자를 찾을 수 없습니다", null));
+        if (user.status() == UserStatus.DISABLED) {
+            throw new ApiException(HttpStatus.FORBIDDEN, "user_disabled", "비활성화된 사용자입니다", null);
+        }
         String accessToken = tokenService.issueAccessToken(existing.userId().toString(), user.role().name());
 
         return new TokenPair(accessToken, newRefresh);

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/UserConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/UserConfig.java
@@ -1,0 +1,20 @@
+package com.eunhyehymn.common.config;
+
+import com.eunhyehymn.application.usecases.AdminListUsersUseCase;
+import com.eunhyehymn.application.usecases.AdminUpdateUserUseCase;
+import com.eunhyehymn.domain.repository.UserRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class UserConfig {
+    @Bean
+    AdminListUsersUseCase adminListUsersUseCase(UserRepository userRepository) {
+        return new AdminListUsersUseCase(userRepository);
+    }
+
+    @Bean
+    AdminUpdateUserUseCase adminUpdateUserUseCase(UserRepository userRepository) {
+        return new AdminUpdateUserUseCase(userRepository);
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/UserRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.eunhyehymn.domain.repository;
 
 import com.eunhyehymn.domain.model.User;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -8,4 +9,6 @@ public interface UserRepository {
     User save(User user);
 
     Optional<User> findById(UUID id);
+
+    List<User> findAll();
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserRepositoryAdapter.java
@@ -3,6 +3,7 @@ package com.eunhyehymn.infrastructure.persistence;
 import com.eunhyehymn.domain.model.User;
 import com.eunhyehymn.domain.repository.UserRepository;
 import com.eunhyehymn.infrastructure.persistence.mapper.UserMapper;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Repository;
@@ -24,5 +25,10 @@ public class UserRepositoryAdapter implements UserRepository {
     @Override
     public Optional<User> findById(UUID id) {
         return userJpaRepository.findById(id).map(UserMapper::toDomain);
+    }
+
+    @Override
+    public List<User> findAll() {
+        return userJpaRepository.findAll().stream().map(UserMapper::toDomain).toList();
     }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminUserController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminUserController.java
@@ -1,0 +1,83 @@
+package com.eunhyehymn.presentation.controllers;
+
+import com.eunhyehymn.application.usecases.AdminListUsersUseCase;
+import com.eunhyehymn.application.usecases.AdminUpdateUserUseCase;
+import com.eunhyehymn.common.error.ApiException;
+import com.eunhyehymn.common.response.ApiResponse;
+import com.eunhyehymn.domain.model.Role;
+import com.eunhyehymn.domain.model.User;
+import com.eunhyehymn.domain.model.UserStatus;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/users")
+public class AdminUserController {
+    private final AdminListUsersUseCase adminListUsersUseCase;
+    private final AdminUpdateUserUseCase adminUpdateUserUseCase;
+
+    public AdminUserController(
+        AdminListUsersUseCase adminListUsersUseCase,
+        AdminUpdateUserUseCase adminUpdateUserUseCase
+    ) {
+        this.adminListUsersUseCase = adminListUsersUseCase;
+        this.adminUpdateUserUseCase = adminUpdateUserUseCase;
+    }
+
+    @GetMapping
+    public ApiResponse<List<UserResponse>> list() {
+        List<UserResponse> items = adminListUsersUseCase.listAll().stream()
+            .map(UserResponse::from)
+            .toList();
+        return ApiResponse.success(items);
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponse<UserResponse> update(@PathVariable UUID id, @RequestBody UpdateRequest request) {
+        Role role = null;
+        UserStatus status = null;
+        if (request.role() != null) {
+            try {
+                role = Role.valueOf(request.role());
+            } catch (IllegalArgumentException e) {
+                throw new ApiException(HttpStatus.BAD_REQUEST, "invalid_role", "유효하지 않은 역할입니다", null);
+            }
+        }
+        if (request.status() != null) {
+            try {
+                status = UserStatus.valueOf(request.status());
+            } catch (IllegalArgumentException e) {
+                throw new ApiException(HttpStatus.BAD_REQUEST, "invalid_status", "유효하지 않은 상태입니다", null);
+            }
+        }
+        User updated = adminUpdateUserUseCase.update(id, role, status);
+        return ApiResponse.success(UserResponse.from(updated));
+    }
+
+    public record UpdateRequest(String role, String status) {
+    }
+
+    public record UserResponse(
+        UUID id,
+        String displayName,
+        String role,
+        String status,
+        Instant createdAt,
+        Instant lastLoginAt
+    ) {
+        static UserResponse from(User user) {
+            return new UserResponse(
+                user.id(), user.displayName(), user.role().name(), user.status().name(),
+                user.createdAt(), user.lastLoginAt()
+            );
+        }
+    }
+}

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminUserApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminUserApiTest.java
@@ -1,0 +1,109 @@
+package com.eunhyehymn.presentation.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.eunhyehymn.domain.model.Role;
+import com.eunhyehymn.domain.model.UserStatus;
+import com.eunhyehymn.infrastructure.persistence.UserEntity;
+import com.eunhyehymn.infrastructure.persistence.UserJpaRepository;
+import com.eunhyehymn.infrastructure.security.JwtService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AdminUserApiTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtService jwtService;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    private String adminToken;
+    private UUID targetUserId;
+
+    @BeforeEach
+    void setUp() {
+        userJpaRepository.deleteAll();
+
+        UUID adminId = UUID.randomUUID();
+        userJpaRepository.save(new UserEntity(
+            adminId, "관리자", Role.ADMIN, UserStatus.ACTIVE, Instant.now(), Instant.now()
+        ));
+        adminToken = jwtService.issueAccessToken(adminId.toString(), Role.ADMIN.name());
+
+        targetUserId = UUID.randomUUID();
+        userJpaRepository.save(new UserEntity(
+            targetUserId, "일반회원", Role.USER, UserStatus.ACTIVE, Instant.now(), Instant.now()
+        ));
+    }
+
+    @Test
+    void adminCanListUsers() throws Exception {
+        mockMvc.perform(get("/admin/users")
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.length()").value(2));
+    }
+
+    @Test
+    void adminCanChangeUserRole() throws Exception {
+        String payload = objectMapper.writeValueAsString(Map.of("role", "ADMIN"));
+        mockMvc.perform(patch("/admin/users/" + targetUserId)
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.role").value("ADMIN"));
+    }
+
+    @Test
+    void adminCanDisableUser() throws Exception {
+        String payload = objectMapper.writeValueAsString(Map.of("status", "DISABLED"));
+        mockMvc.perform(patch("/admin/users/" + targetUserId)
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.status").value("DISABLED"));
+    }
+
+    @Test
+    void invalidRoleReturnsBadRequest() throws Exception {
+        String payload = objectMapper.writeValueAsString(Map.of("role", "INVALID"));
+        mockMvc.perform(patch("/admin/users/" + targetUserId)
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error.code").value("invalid_role"));
+    }
+
+    @Test
+    void nonAdminCannotAccessUserList() throws Exception {
+        String userToken = jwtService.issueAccessToken(targetUserId.toString(), Role.USER.name());
+        mockMvc.perform(get("/admin/users")
+                .header("Authorization", "Bearer " + userToken))
+            .andExpect(status().isForbidden());
+    }
+}

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminUserApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminUserApiTest.java
@@ -100,6 +100,17 @@ class AdminUserApiTest {
     }
 
     @Test
+    void updateNonExistentUserReturnsNotFound() throws Exception {
+        String payload = objectMapper.writeValueAsString(Map.of("role", "ADMIN"));
+        mockMvc.perform(patch("/admin/users/" + UUID.randomUUID())
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error.code").value("user_not_found"));
+    }
+
+    @Test
     void nonAdminCannotAccessUserList() throws Exception {
         String userToken = jwtService.issueAccessToken(targetUserId.toString(), Role.USER.name());
         mockMvc.perform(get("/admin/users")


### PR DESCRIPTION
## Summary
- 사용자 목록 조회 API (`GET /admin/users`)
- 사용자 역할/상태 변경 API (`PATCH /admin/users/{id}`)
- Admin UI: 사용자 목록, 역할 드롭다운 변경, 활성/비활성 상태 토글

## Test plan
- [ ] `./gradlew test` 전체 통과 (AdminUserApiTest 5개 포함)
- [ ] `npm run build` 성공
- [ ] Admin `/users` 페이지에서 사용자 목록 확인
- [ ] 역할 드롭다운으로 USER↔ADMIN 변경 확인
- [ ] 비활성화/활성화 버튼 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)