### PR TITLE
feat: 소셜 로그인(Google/Kakao) API 구현

### DIFF
--- a/apps/api/src/main/java/com/eunhyehymn/application/ports/SocialTokenVerifier.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/ports/SocialTokenVerifier.java
@@ -1,0 +1,5 @@
+package com.eunhyehymn.application.ports;
+
+public interface SocialTokenVerifier {
+    SocialUserInfo verify(String provider, String token);
+}

--- a/apps/api/src/main/java/com/eunhyehymn/application/ports/SocialUserInfo.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/ports/SocialUserInfo.java
@@ -1,0 +1,4 @@
+package com.eunhyehymn.application.ports;
+
+public record SocialUserInfo(String providerSubject, String email, String displayName) {
+}

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/SocialLoginUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/SocialLoginUseCase.java
@@ -5,7 +5,6 @@ import com.eunhyehymn.application.ports.SocialUserInfo;
 import com.eunhyehymn.application.ports.TokenHashService;
 import com.eunhyehymn.application.ports.TokenService;
 import com.eunhyehymn.domain.model.AuthIdentity;
-import com.eunhyehymn.domain.model.InviteCode;
 import com.eunhyehymn.domain.model.RefreshToken;
 import com.eunhyehymn.domain.model.Role;
 import com.eunhyehymn.domain.model.User;
@@ -17,6 +16,7 @@ import com.eunhyehymn.domain.repository.UserRepository;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.transaction.annotation.Transactional;
 
 public class SocialLoginUseCase {
     private final SocialTokenVerifier socialTokenVerifier;
@@ -48,6 +48,7 @@ public class SocialLoginUseCase {
         this.refreshTokenTtlSeconds = refreshTokenTtlSeconds;
     }
 
+    @Transactional
     public LoginResult login(String provider, String token, String inviteCode) {
         // 1. 소셜 토큰 검증 → 사용자 정보 추출
         String normalizedProvider = provider.toUpperCase();
@@ -81,10 +82,13 @@ public class SocialLoginUseCase {
                 throw new InvalidInviteCodeException("초대코드가 필요합니다");
             }
 
-            InviteCode code = inviteCodeRepository.findByCode(inviteCode)
+            // 초대코드 존재 여부 확인
+            inviteCodeRepository.findByCode(inviteCode)
                 .orElseThrow(() -> new InvalidInviteCodeException("유효하지 않은 초대코드입니다"));
 
-            if (!isValidCode(code)) {
+            // 원자적으로 usedCount 증가 (enabled, maxUses, expiresAt 동시 검증)
+            boolean incremented = inviteCodeRepository.incrementUsedCount(inviteCode);
+            if (!incremented) {
                 throw new InvalidInviteCodeException("유효하지 않은 초대코드입니다");
             }
 
@@ -104,19 +108,6 @@ public class SocialLoginUseCase {
                 now
             );
             authIdentityRepository.save(identity);
-
-            // 초대코드 usedCount 증가
-            InviteCode updatedCode = new InviteCode(
-                code.code(),
-                code.createdBy(),
-                code.description(),
-                code.maxUses(),
-                code.usedCount() + 1,
-                code.enabled(),
-                code.expiresAt(),
-                code.createdAt()
-            );
-            inviteCodeRepository.save(updatedCode);
         }
 
         // 3. JWT 발급
@@ -134,19 +125,6 @@ public class SocialLoginUseCase {
         refreshTokenRepository.save(stored);
 
         return new LoginResult(accessToken, refreshToken, existingIdentity.isEmpty());
-    }
-
-    private boolean isValidCode(InviteCode inviteCode) {
-        if (!inviteCode.enabled()) {
-            return false;
-        }
-        if (inviteCode.expiresAt() != null && inviteCode.expiresAt().isBefore(Instant.now())) {
-            return false;
-        }
-        if (inviteCode.maxUses() != null && inviteCode.usedCount() >= inviteCode.maxUses()) {
-            return false;
-        }
-        return true;
     }
 
     public record LoginResult(String accessToken, String refreshToken, boolean newUser) {

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/SocialLoginUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/SocialLoginUseCase.java
@@ -1,0 +1,160 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.application.ports.SocialTokenVerifier;
+import com.eunhyehymn.application.ports.SocialUserInfo;
+import com.eunhyehymn.application.ports.TokenHashService;
+import com.eunhyehymn.application.ports.TokenService;
+import com.eunhyehymn.domain.model.AuthIdentity;
+import com.eunhyehymn.domain.model.InviteCode;
+import com.eunhyehymn.domain.model.RefreshToken;
+import com.eunhyehymn.domain.model.Role;
+import com.eunhyehymn.domain.model.User;
+import com.eunhyehymn.domain.model.UserStatus;
+import com.eunhyehymn.domain.repository.AuthIdentityRepository;
+import com.eunhyehymn.domain.repository.InviteCodeRepository;
+import com.eunhyehymn.domain.repository.RefreshTokenRepository;
+import com.eunhyehymn.domain.repository.UserRepository;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+public class SocialLoginUseCase {
+    private final SocialTokenVerifier socialTokenVerifier;
+    private final AuthIdentityRepository authIdentityRepository;
+    private final UserRepository userRepository;
+    private final InviteCodeRepository inviteCodeRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenService tokenService;
+    private final TokenHashService tokenHashService;
+    private final long refreshTokenTtlSeconds;
+
+    public SocialLoginUseCase(
+        SocialTokenVerifier socialTokenVerifier,
+        AuthIdentityRepository authIdentityRepository,
+        UserRepository userRepository,
+        InviteCodeRepository inviteCodeRepository,
+        RefreshTokenRepository refreshTokenRepository,
+        TokenService tokenService,
+        TokenHashService tokenHashService,
+        long refreshTokenTtlSeconds
+    ) {
+        this.socialTokenVerifier = socialTokenVerifier;
+        this.authIdentityRepository = authIdentityRepository;
+        this.userRepository = userRepository;
+        this.inviteCodeRepository = inviteCodeRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.tokenService = tokenService;
+        this.tokenHashService = tokenHashService;
+        this.refreshTokenTtlSeconds = refreshTokenTtlSeconds;
+    }
+
+    public LoginResult login(String provider, String token, String inviteCode) {
+        // 1. 소셜 토큰 검증 → 사용자 정보 추출
+        String normalizedProvider = provider.toUpperCase();
+        SocialUserInfo userInfo = socialTokenVerifier.verify(normalizedProvider, token);
+
+        // 2. AuthIdentity 조회
+        Optional<AuthIdentity> existingIdentity = authIdentityRepository
+            .findByProviderAndProviderSubject(normalizedProvider, userInfo.providerSubject());
+
+        Instant now = Instant.now();
+        User user;
+
+        if (existingIdentity.isPresent()) {
+            // 기존 사용자: 초대코드 검증 불필요, lastLoginAt 갱신
+            User existing = userRepository.findById(existingIdentity.get().userId())
+                .orElseThrow(() -> new IllegalStateException(
+                    "AuthIdentity에 연결된 User를 찾을 수 없습니다: " + existingIdentity.get().userId()));
+
+            user = new User(
+                existing.id(),
+                existing.displayName(),
+                existing.role(),
+                existing.status(),
+                existing.createdAt(),
+                now
+            );
+            userRepository.save(user);
+        } else {
+            // 신규 사용자: 초대코드 검증 필수
+            if (inviteCode == null || inviteCode.isBlank()) {
+                throw new InvalidInviteCodeException("초대코드가 필요합니다");
+            }
+
+            InviteCode code = inviteCodeRepository.findByCode(inviteCode)
+                .orElseThrow(() -> new InvalidInviteCodeException("유효하지 않은 초대코드입니다"));
+
+            if (!isValidCode(code)) {
+                throw new InvalidInviteCodeException("유효하지 않은 초대코드입니다");
+            }
+
+            // User 생성
+            UUID userId = UUID.randomUUID();
+            String displayName = userInfo.displayName() != null ? userInfo.displayName() : normalizedProvider + " User";
+            user = new User(userId, displayName, Role.USER, UserStatus.ACTIVE, now, now);
+            userRepository.save(user);
+
+            // AuthIdentity 생성
+            AuthIdentity identity = new AuthIdentity(
+                UUID.randomUUID(),
+                userId,
+                normalizedProvider,
+                userInfo.providerSubject(),
+                userInfo.email(),
+                now
+            );
+            authIdentityRepository.save(identity);
+
+            // 초대코드 usedCount 증가
+            InviteCode updatedCode = new InviteCode(
+                code.code(),
+                code.createdBy(),
+                code.description(),
+                code.maxUses(),
+                code.usedCount() + 1,
+                code.enabled(),
+                code.expiresAt(),
+                code.createdAt()
+            );
+            inviteCodeRepository.save(updatedCode);
+        }
+
+        // 3. JWT 발급
+        String accessToken = tokenService.issueAccessToken(user.id().toString(), user.role().name());
+        String refreshToken = tokenService.issueRefreshToken();
+        String hash = tokenHashService.hash(refreshToken);
+        RefreshToken stored = new RefreshToken(
+            UUID.randomUUID(),
+            user.id(),
+            hash,
+            now.plusSeconds(refreshTokenTtlSeconds),
+            null,
+            now
+        );
+        refreshTokenRepository.save(stored);
+
+        return new LoginResult(accessToken, refreshToken, existingIdentity.isEmpty());
+    }
+
+    private boolean isValidCode(InviteCode inviteCode) {
+        if (!inviteCode.enabled()) {
+            return false;
+        }
+        if (inviteCode.expiresAt() != null && inviteCode.expiresAt().isBefore(Instant.now())) {
+            return false;
+        }
+        if (inviteCode.maxUses() != null && inviteCode.usedCount() >= inviteCode.maxUses()) {
+            return false;
+        }
+        return true;
+    }
+
+    public record LoginResult(String accessToken, String refreshToken, boolean newUser) {
+    }
+
+    public static class InvalidInviteCodeException extends RuntimeException {
+        public InvalidInviteCodeException(String message) {
+            super(message);
+        }
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/AuthConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/AuthConfig.java
@@ -48,8 +48,11 @@ public class AuthConfig {
     }
 
     @Bean
-    SocialTokenVerifier socialTokenVerifier(ObjectMapper objectMapper) {
-        return new SocialTokenVerifierImpl(objectMapper);
+    SocialTokenVerifier socialTokenVerifier(
+        ObjectMapper objectMapper,
+        @Value("${security.social.google.client-id:}") String googleClientId
+    ) {
+        return new SocialTokenVerifierImpl(objectMapper, googleClientId);
     }
 
     @Bean

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/AuthConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/AuthConfig.java
@@ -1,16 +1,21 @@
 package com.eunhyehymn.common.config;
 
+import com.eunhyehymn.application.ports.SocialTokenVerifier;
 import com.eunhyehymn.application.ports.TokenHashService;
 import com.eunhyehymn.application.ports.TokenService;
 import com.eunhyehymn.application.usecases.DevLoginUseCase;
 import com.eunhyehymn.application.usecases.LogoutUseCase;
 import com.eunhyehymn.application.usecases.RefreshTokenUseCase;
+import com.eunhyehymn.application.usecases.SocialLoginUseCase;
+import com.eunhyehymn.domain.repository.AuthIdentityRepository;
+import com.eunhyehymn.domain.repository.InviteCodeRepository;
 import com.eunhyehymn.domain.repository.RefreshTokenRepository;
 import com.eunhyehymn.domain.repository.UserRepository;
 import com.eunhyehymn.infrastructure.security.JwtAuthenticationFilter;
 import com.eunhyehymn.infrastructure.security.JwtService;
 import com.eunhyehymn.infrastructure.security.JwtTokenService;
 import com.eunhyehymn.infrastructure.security.Sha256TokenHashService;
+import com.eunhyehymn.infrastructure.security.SocialTokenVerifierImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -40,6 +45,11 @@ public class AuthConfig {
     @Bean
     JwtAuthenticationFilter jwtAuthenticationFilter(JwtService jwtService) {
         return new JwtAuthenticationFilter(jwtService);
+    }
+
+    @Bean
+    SocialTokenVerifier socialTokenVerifier(ObjectMapper objectMapper) {
+        return new SocialTokenVerifierImpl(objectMapper);
     }
 
     @Bean
@@ -77,6 +87,29 @@ public class AuthConfig {
     ) {
         return new DevLoginUseCase(
             userRepository,
+            refreshTokenRepository,
+            tokenService,
+            tokenHashService,
+            refreshTokenTtlSeconds
+        );
+    }
+
+    @Bean
+    SocialLoginUseCase socialLoginUseCase(
+        SocialTokenVerifier socialTokenVerifier,
+        AuthIdentityRepository authIdentityRepository,
+        UserRepository userRepository,
+        InviteCodeRepository inviteCodeRepository,
+        RefreshTokenRepository refreshTokenRepository,
+        TokenService tokenService,
+        TokenHashService tokenHashService,
+        @Value("${security.jwt.refresh-token-ttl-seconds}") long refreshTokenTtlSeconds
+    ) {
+        return new SocialLoginUseCase(
+            socialTokenVerifier,
+            authIdentityRepository,
+            userRepository,
+            inviteCodeRepository,
             refreshTokenRepository,
             tokenService,
             tokenHashService,

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/AuthIdentityRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/AuthIdentityRepository.java
@@ -8,4 +8,6 @@ public interface AuthIdentityRepository {
     AuthIdentity save(AuthIdentity identity);
 
     Optional<AuthIdentity> findById(UUID id);
+
+    Optional<AuthIdentity> findByProviderAndProviderSubject(String provider, String providerSubject);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/InviteCodeRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/InviteCodeRepository.java
@@ -10,4 +10,12 @@ public interface InviteCodeRepository {
     Optional<InviteCode> findByCode(String code);
 
     List<InviteCode> findAll();
+
+    /**
+     * 초대코드의 usedCount를 원자적으로 1 증가시킵니다.
+     * maxUses가 null이거나 usedCount < maxUses인 경우에만 증가합니다.
+     *
+     * @return 증가 성공 시 true, 한도 초과 시 false
+     */
+    boolean incrementUsedCount(String code);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AuthIdentityJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AuthIdentityJpaRepository.java
@@ -1,7 +1,9 @@
 package com.eunhyehymn.infrastructure.persistence;
 
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AuthIdentityJpaRepository extends JpaRepository<AuthIdentityEntity, UUID> {
+    Optional<AuthIdentityEntity> findByProviderAndProviderSubject(String provider, String providerSubject);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AuthIdentityRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AuthIdentityRepositoryAdapter.java
@@ -1,0 +1,34 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import com.eunhyehymn.domain.model.AuthIdentity;
+import com.eunhyehymn.domain.repository.AuthIdentityRepository;
+import com.eunhyehymn.infrastructure.persistence.mapper.AuthIdentityMapper;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class AuthIdentityRepositoryAdapter implements AuthIdentityRepository {
+    private final AuthIdentityJpaRepository authIdentityJpaRepository;
+
+    public AuthIdentityRepositoryAdapter(AuthIdentityJpaRepository authIdentityJpaRepository) {
+        this.authIdentityJpaRepository = authIdentityJpaRepository;
+    }
+
+    @Override
+    public AuthIdentity save(AuthIdentity identity) {
+        AuthIdentityEntity saved = authIdentityJpaRepository.save(AuthIdentityMapper.toEntity(identity));
+        return AuthIdentityMapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<AuthIdentity> findById(UUID id) {
+        return authIdentityJpaRepository.findById(id).map(AuthIdentityMapper::toDomain);
+    }
+
+    @Override
+    public Optional<AuthIdentity> findByProviderAndProviderSubject(String provider, String providerSubject) {
+        return authIdentityJpaRepository.findByProviderAndProviderSubject(provider, providerSubject)
+            .map(AuthIdentityMapper::toDomain);
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/InviteCodeJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/InviteCodeJpaRepository.java
@@ -1,6 +1,16 @@
 package com.eunhyehymn.infrastructure.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface InviteCodeJpaRepository extends JpaRepository<InviteCodeEntity, String> {
+
+    @Modifying
+    @Query("UPDATE InviteCodeEntity e SET e.usedCount = e.usedCount + 1 " +
+           "WHERE e.code = :code AND e.enabled = true " +
+           "AND (e.maxUses IS NULL OR e.usedCount < e.maxUses) " +
+           "AND (e.expiresAt IS NULL OR e.expiresAt > CURRENT_TIMESTAMP)")
+    int incrementUsedCount(@Param("code") String code);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/InviteCodeRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/InviteCodeRepositoryAdapter.java
@@ -32,4 +32,9 @@ public class InviteCodeRepositoryAdapter implements InviteCodeRepository {
             .map(InviteCodeMapper::toDomain)
             .toList();
     }
+
+    @Override
+    public boolean incrementUsedCount(String code) {
+        return jpaRepository.incrementUsedCount(code) > 0;
+    }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/security/SocialLoginException.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/security/SocialLoginException.java
@@ -1,0 +1,7 @@
+package com.eunhyehymn.infrastructure.security;
+
+public class SocialLoginException extends RuntimeException {
+    public SocialLoginException(String message) {
+        super(message);
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/security/SocialTokenVerifierImpl.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/security/SocialTokenVerifierImpl.java
@@ -1,0 +1,108 @@
+package com.eunhyehymn.infrastructure.security;
+
+import com.eunhyehymn.application.ports.SocialTokenVerifier;
+import com.eunhyehymn.application.ports.SocialUserInfo;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+public class SocialTokenVerifierImpl implements SocialTokenVerifier {
+    private final ObjectMapper objectMapper;
+    private final HttpClient httpClient;
+
+    public SocialTokenVerifierImpl(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        this.httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
+    }
+
+    @Override
+    public SocialUserInfo verify(String provider, String token) {
+        return switch (provider.toUpperCase()) {
+            case "GOOGLE" -> verifyGoogle(token);
+            case "KAKAO" -> verifyKakao(token);
+            default -> throw new SocialLoginException("지원하지 않는 소셜 로그인 provider: " + provider);
+        };
+    }
+
+    private SocialUserInfo verifyGoogle(String idToken) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://oauth2.googleapis.com/tokeninfo?id_token=" + idToken))
+                .GET()
+                .timeout(Duration.ofSeconds(10))
+                .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() != 200) {
+                throw new SocialLoginException("Google 토큰 검증 실패: HTTP " + response.statusCode());
+            }
+
+            JsonNode body = objectMapper.readTree(response.body());
+
+            String sub = body.path("sub").asText(null);
+            String email = body.path("email").asText(null);
+            String name = body.path("name").asText("Google User");
+
+            if (sub == null || sub.isBlank()) {
+                throw new SocialLoginException("Google 토큰에서 사용자 ID를 추출할 수 없습니다");
+            }
+
+            return new SocialUserInfo(sub, email, name);
+        } catch (SocialLoginException e) {
+            throw e;
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new SocialLoginException("Google 토큰 검증 중 오류 발생: " + e.getMessage());
+        }
+    }
+
+    private SocialUserInfo verifyKakao(String accessToken) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://kapi.kakao.com/v2/user/me"))
+                .header("Authorization", "Bearer " + accessToken)
+                .header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+                .GET()
+                .timeout(Duration.ofSeconds(10))
+                .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() != 200) {
+                throw new SocialLoginException("Kakao 토큰 검증 실패: HTTP " + response.statusCode());
+            }
+
+            JsonNode body = objectMapper.readTree(response.body());
+
+            String id = String.valueOf(body.path("id").asLong());
+            if ("0".equals(id)) {
+                throw new SocialLoginException("Kakao 토큰에서 사용자 ID를 추출할 수 없습니다");
+            }
+
+            JsonNode kakaoAccount = body.path("kakao_account");
+            String email = kakaoAccount.path("email").asText(null);
+
+            JsonNode profile = kakaoAccount.path("profile");
+            String nickname = profile.path("nickname").asText("Kakao User");
+
+            return new SocialUserInfo(id, email, nickname);
+        } catch (SocialLoginException e) {
+            throw e;
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new SocialLoginException("Kakao 토큰 검증 중 오류 발생: " + e.getMessage());
+        }
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/security/SocialTokenVerifierImpl.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/security/SocialTokenVerifierImpl.java
@@ -6,17 +6,21 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
 public class SocialTokenVerifierImpl implements SocialTokenVerifier {
     private final ObjectMapper objectMapper;
     private final HttpClient httpClient;
+    private final String googleClientId;
 
-    public SocialTokenVerifierImpl(ObjectMapper objectMapper) {
+    public SocialTokenVerifierImpl(ObjectMapper objectMapper, String googleClientId) {
         this.objectMapper = objectMapper;
+        this.googleClientId = googleClientId;
         this.httpClient = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(5))
             .build();
@@ -33,8 +37,9 @@ public class SocialTokenVerifierImpl implements SocialTokenVerifier {
 
     private SocialUserInfo verifyGoogle(String idToken) {
         try {
+            String encodedToken = URLEncoder.encode(idToken, StandardCharsets.UTF_8);
             HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create("https://oauth2.googleapis.com/tokeninfo?id_token=" + idToken))
+                .uri(URI.create("https://oauth2.googleapis.com/tokeninfo?id_token=" + encodedToken))
                 .GET()
                 .timeout(Duration.ofSeconds(10))
                 .build();
@@ -46,6 +51,12 @@ public class SocialTokenVerifierImpl implements SocialTokenVerifier {
             }
 
             JsonNode body = objectMapper.readTree(response.body());
+
+            // aud 클레임 검증: 토큰이 우리 앱에 발급된 것인지 확인
+            String aud = body.path("aud").asText(null);
+            if (googleClientId != null && !googleClientId.isBlank() && !googleClientId.equals(aud)) {
+                throw new SocialLoginException("Google 토큰의 audience가 일치하지 않습니다");
+            }
 
             String sub = body.path("sub").asText(null);
             String email = body.path("email").asText(null);

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AuthController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AuthController.java
@@ -2,9 +2,13 @@ package com.eunhyehymn.presentation.controllers;
 
 import com.eunhyehymn.application.usecases.LogoutUseCase;
 import com.eunhyehymn.application.usecases.RefreshTokenUseCase;
+import com.eunhyehymn.application.usecases.SocialLoginUseCase;
 import com.eunhyehymn.application.usecases.ValidateInviteCodeUseCase;
+import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.common.response.ApiResponse;
+import com.eunhyehymn.infrastructure.security.SocialLoginException;
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,15 +22,34 @@ public class AuthController {
     private final RefreshTokenUseCase refreshTokenUseCase;
     private final LogoutUseCase logoutUseCase;
     private final ValidateInviteCodeUseCase validateInviteCodeUseCase;
+    private final SocialLoginUseCase socialLoginUseCase;
 
     public AuthController(
         RefreshTokenUseCase refreshTokenUseCase,
         LogoutUseCase logoutUseCase,
-        ValidateInviteCodeUseCase validateInviteCodeUseCase
+        ValidateInviteCodeUseCase validateInviteCodeUseCase,
+        SocialLoginUseCase socialLoginUseCase
     ) {
         this.refreshTokenUseCase = refreshTokenUseCase;
         this.logoutUseCase = logoutUseCase;
         this.validateInviteCodeUseCase = validateInviteCodeUseCase;
+        this.socialLoginUseCase = socialLoginUseCase;
+    }
+
+    @PostMapping("/social")
+    public ApiResponse<SocialLoginResponse> socialLogin(@RequestBody @Validated SocialLoginRequest request) {
+        try {
+            SocialLoginUseCase.LoginResult result = socialLoginUseCase.login(
+                request.provider(), request.token(), request.inviteCode()
+            );
+            return ApiResponse.success(new SocialLoginResponse(
+                result.accessToken(), result.refreshToken(), result.newUser()
+            ));
+        } catch (SocialLoginException e) {
+            throw new ApiException(HttpStatus.UNAUTHORIZED, "social_auth_failed", e.getMessage(), null);
+        } catch (SocialLoginUseCase.InvalidInviteCodeException e) {
+            throw new ApiException(HttpStatus.FORBIDDEN, "invalid_invite_code", e.getMessage(), null);
+        }
     }
 
     @PostMapping("/refresh")
@@ -45,6 +68,16 @@ public class AuthController {
     public ApiResponse<InviteValidateResponse> validateInvite(@RequestBody @Validated InviteValidateRequest request) {
         boolean valid = validateInviteCodeUseCase.validate(request.code());
         return ApiResponse.success(new InviteValidateResponse(valid));
+    }
+
+    public record SocialLoginRequest(
+        @NotBlank String provider,
+        @NotBlank String token,
+        String inviteCode
+    ) {
+    }
+
+    public record SocialLoginResponse(String accessToken, String refreshToken, boolean newUser) {
     }
 
     public record RefreshRequest(@NotBlank String refreshToken) {

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -34,6 +34,9 @@ security:
     refresh-token-ttl-seconds: ${JWT_REFRESH_TTL_SECONDS}
   invite:
     code: ${INVITE_CODE}
+  social:
+    google:
+      client-id: ${GOOGLE_CLIENT_ID:}
 
 storage:
   s3:

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/SocialLoginApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/SocialLoginApiTest.java
@@ -1,0 +1,297 @@
+package com.eunhyehymn.presentation.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.eunhyehymn.application.ports.SocialTokenVerifier;
+import com.eunhyehymn.application.ports.SocialUserInfo;
+import com.eunhyehymn.domain.model.Role;
+import com.eunhyehymn.domain.model.UserStatus;
+import com.eunhyehymn.infrastructure.persistence.AssetJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.AuthIdentityEntity;
+import com.eunhyehymn.infrastructure.persistence.AuthIdentityJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.EventJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.HymnJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.HymnNoteJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.InviteCodeEntity;
+import com.eunhyehymn.infrastructure.persistence.InviteCodeJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.RefreshTokenJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.UserEntity;
+import com.eunhyehymn.infrastructure.persistence.UserHymnStateJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.UserJpaRepository;
+import com.eunhyehymn.infrastructure.security.SocialLoginException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class SocialLoginApiTest {
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserJpaRepository userJpaRepository;
+    @Autowired private HymnJpaRepository hymnJpaRepository;
+    @Autowired private AssetJpaRepository assetJpaRepository;
+    @Autowired private HymnNoteJpaRepository hymnNoteJpaRepository;
+    @Autowired private UserHymnStateJpaRepository userHymnStateJpaRepository;
+    @Autowired private EventJpaRepository eventJpaRepository;
+    @Autowired private AuthIdentityJpaRepository authIdentityJpaRepository;
+    @Autowired private RefreshTokenJpaRepository refreshTokenJpaRepository;
+    @Autowired private InviteCodeJpaRepository inviteCodeJpaRepository;
+
+    @MockBean
+    private SocialTokenVerifier socialTokenVerifier;
+
+    @BeforeEach
+    void setUp() {
+        inviteCodeJpaRepository.deleteAll();
+        eventJpaRepository.deleteAll();
+        userHymnStateJpaRepository.deleteAll();
+        hymnNoteJpaRepository.deleteAll();
+        assetJpaRepository.deleteAll();
+        authIdentityJpaRepository.deleteAll();
+        refreshTokenJpaRepository.deleteAll();
+        hymnJpaRepository.deleteAll();
+        userJpaRepository.deleteAll();
+    }
+
+    @Test
+    void newUserWithValidInviteCodeCreatesAccountAndReturnsTokens() throws Exception {
+        // Given: 유효한 초대코드 생성
+        inviteCodeJpaRepository.save(new InviteCodeEntity(
+            "SOCIAL-TEST-CODE", null, "테스트", null, 0, true, null, Instant.now()
+        ));
+
+        // Mock: Google 소셜 토큰 검증 성공
+        when(socialTokenVerifier.verify(eq("GOOGLE"), eq("valid-google-token")))
+            .thenReturn(new SocialUserInfo("google-sub-123", "test@gmail.com", "테스트 사용자"));
+
+        // When
+        Map<String, String> request = new HashMap<>();
+        request.put("provider", "GOOGLE");
+        request.put("token", "valid-google-token");
+        request.put("inviteCode", "SOCIAL-TEST-CODE");
+
+        String response = mockMvc.perform(post("/auth/social")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+            .andExpect(jsonPath("$.data.refreshToken").isNotEmpty())
+            .andExpect(jsonPath("$.data.newUser").value(true))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        // Then: User, AuthIdentity 생성 확인
+        assertThat(userJpaRepository.count()).isEqualTo(1);
+        assertThat(authIdentityJpaRepository.count()).isEqualTo(1);
+
+        AuthIdentityEntity identity = authIdentityJpaRepository.findAll().get(0);
+        assertThat(identity.getProvider()).isEqualTo("GOOGLE");
+        assertThat(identity.getProviderSubject()).isEqualTo("google-sub-123");
+        assertThat(identity.getEmail()).isEqualTo("test@gmail.com");
+
+        // 초대코드 usedCount 증가 확인
+        assertThat(inviteCodeJpaRepository.findById("SOCIAL-TEST-CODE").get().getUsedCount()).isEqualTo(1);
+
+        // 발급된 accessToken으로 /me/profile 호출 가능 확인
+        JsonNode data = objectMapper.readTree(response).get("data");
+        String accessToken = data.get("accessToken").asText();
+
+        mockMvc.perform(get("/me/profile")
+                .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.role").value("USER"));
+    }
+
+    @Test
+    void existingUserCanLoginWithoutInviteCode() throws Exception {
+        // Given: 기존 사용자와 AuthIdentity 생성
+        UUID userId = UUID.randomUUID();
+        userJpaRepository.save(new UserEntity(
+            userId, "기존 사용자", Role.USER, UserStatus.ACTIVE, Instant.now(), Instant.now()
+        ));
+        authIdentityJpaRepository.save(new AuthIdentityEntity(
+            UUID.randomUUID(), userId, "KAKAO", "kakao-id-456", "existing@kakao.com", Instant.now()
+        ));
+
+        // Mock: Kakao 소셜 토큰 검증 성공
+        when(socialTokenVerifier.verify(eq("KAKAO"), eq("valid-kakao-token")))
+            .thenReturn(new SocialUserInfo("kakao-id-456", "existing@kakao.com", "카카오 사용자"));
+
+        // When: 초대코드 없이 로그인
+        Map<String, String> request = new HashMap<>();
+        request.put("provider", "KAKAO");
+        request.put("token", "valid-kakao-token");
+
+        mockMvc.perform(post("/auth/social")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+            .andExpect(jsonPath("$.data.refreshToken").isNotEmpty())
+            .andExpect(jsonPath("$.data.newUser").value(false));
+
+        // Then: 새 사용자가 생성되지 않음
+        assertThat(userJpaRepository.count()).isEqualTo(1);
+        assertThat(authIdentityJpaRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    void newUserWithoutInviteCodeIsForbidden() throws Exception {
+        // Mock: Google 소셜 토큰 검증 성공
+        when(socialTokenVerifier.verify(eq("GOOGLE"), eq("valid-google-token")))
+            .thenReturn(new SocialUserInfo("google-new-sub", "new@gmail.com", "신규 사용자"));
+
+        // When: 초대코드 없이 신규 사용자 로그인 시도
+        Map<String, String> request = new HashMap<>();
+        request.put("provider", "GOOGLE");
+        request.put("token", "valid-google-token");
+
+        mockMvc.perform(post("/auth/social")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("invalid_invite_code"));
+    }
+
+    @Test
+    void newUserWithInvalidInviteCodeIsForbidden() throws Exception {
+        // Mock: Google 소셜 토큰 검증 성공
+        when(socialTokenVerifier.verify(eq("GOOGLE"), eq("valid-google-token")))
+            .thenReturn(new SocialUserInfo("google-new-sub-2", "new2@gmail.com", "신규 사용자 2"));
+
+        // When: 잘못된 초대코드로 로그인 시도
+        Map<String, String> request = new HashMap<>();
+        request.put("provider", "GOOGLE");
+        request.put("token", "valid-google-token");
+        request.put("inviteCode", "INVALID-CODE");
+
+        mockMvc.perform(post("/auth/social")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("invalid_invite_code"));
+    }
+
+    @Test
+    void invalidSocialTokenReturnsUnauthorized() throws Exception {
+        // Mock: 소셜 토큰 검증 실패
+        when(socialTokenVerifier.verify(eq("GOOGLE"), eq("invalid-token")))
+            .thenThrow(new SocialLoginException("Google 토큰 검증 실패: HTTP 400"));
+
+        Map<String, String> request = new HashMap<>();
+        request.put("provider", "GOOGLE");
+        request.put("token", "invalid-token");
+        request.put("inviteCode", "ANY-CODE");
+
+        mockMvc.perform(post("/auth/social")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("social_auth_failed"));
+    }
+
+    @Test
+    void kakaoNewUserFlowWithInviteCode() throws Exception {
+        // Given: 유효한 초대코드
+        inviteCodeJpaRepository.save(new InviteCodeEntity(
+            "KAKAO-INVITE", null, "카카오 테스트", null, 0, true, null, Instant.now()
+        ));
+
+        // Mock: Kakao 소셜 토큰 검증 성공
+        when(socialTokenVerifier.verify(eq("KAKAO"), eq("kakao-access-token")))
+            .thenReturn(new SocialUserInfo("kakao-id-789", "kakao@test.com", "카카오 신규 사용자"));
+
+        Map<String, String> request = new HashMap<>();
+        request.put("provider", "KAKAO");
+        request.put("token", "kakao-access-token");
+        request.put("inviteCode", "KAKAO-INVITE");
+
+        mockMvc.perform(post("/auth/social")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.newUser").value(true))
+            .andExpect(jsonPath("$.data.accessToken").isNotEmpty());
+
+        // Then
+        AuthIdentityEntity identity = authIdentityJpaRepository.findAll().get(0);
+        assertThat(identity.getProvider()).isEqualTo("KAKAO");
+        assertThat(identity.getProviderSubject()).isEqualTo("kakao-id-789");
+
+        UserEntity user = userJpaRepository.findAll().get(0);
+        assertThat(user.getDisplayName()).isEqualTo("카카오 신규 사용자");
+        assertThat(user.getRole()).isEqualTo(Role.USER);
+    }
+
+    @Test
+    void disabledInviteCodeIsForbidden() throws Exception {
+        // Given: 비활성화된 초대코드
+        inviteCodeJpaRepository.save(new InviteCodeEntity(
+            "DISABLED-CODE", null, "비활성", null, 0, false, null, Instant.now()
+        ));
+
+        when(socialTokenVerifier.verify(eq("GOOGLE"), eq("valid-token")))
+            .thenReturn(new SocialUserInfo("google-sub-disabled", "disabled@gmail.com", "사용자"));
+
+        Map<String, String> request = new HashMap<>();
+        request.put("provider", "GOOGLE");
+        request.put("token", "valid-token");
+        request.put("inviteCode", "DISABLED-CODE");
+
+        mockMvc.perform(post("/auth/social")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.error.code").value("invalid_invite_code"));
+    }
+
+    @Test
+    void providerIsCaseInsensitive() throws Exception {
+        // Given
+        inviteCodeJpaRepository.save(new InviteCodeEntity(
+            "CASE-CODE", null, "case test", null, 0, true, null, Instant.now()
+        ));
+
+        // provider를 소문자로 전달해도 정상 동작
+        when(socialTokenVerifier.verify(eq("GOOGLE"), eq("case-token")))
+            .thenReturn(new SocialUserInfo("case-sub", "case@gmail.com", "Case User"));
+
+        Map<String, String> request = new HashMap<>();
+        request.put("provider", "google");
+        request.put("token", "case-token");
+        request.put("inviteCode", "CASE-CODE");
+
+        mockMvc.perform(post("/auth/social")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.newUser").value(true));
+    }
+}


### PR DESCRIPTION
## Summary
- SocialLoginUseCase: 초대코드 검증 → 토큰 검증 → 사용자 생성/조회 → JWT 발급
- SocialTokenVerifier 인터페이스 (DIP) + Google/Kakao 구현체
- AuthController에 `POST /auth/social` 엔드포인트 추가
- AuthIdentityRepositoryAdapter 구현
- SocialLoginApiTest 테스트 포함

## Test plan
- [ ] `./gradlew test` 전체 통과
- [ ] Google OAuth 토큰으로 로그인 플로우 확인
- [ ] Kakao OAuth 토큰으로 로그인 플로우 확인
- [ ] 잘못된 초대코드 거부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)