### PR TITLE
feat: Admin 에셋 삭제 API 및 UI 구현

### DIFF
--- a/apps/admin/src/api/adminAssets.ts
+++ b/apps/admin/src/api/adminAssets.ts
@@ -1,4 +1,4 @@
-import { apiPost } from "./client";
+import { apiDelete, apiPost } from "./client";
 
 export type AssetType = "PNG" | "MIDI";
 export type PartType = "S" | "A" | "T" | "B" | "ALL";
@@ -42,4 +42,8 @@ export function presignAsset(request: PresignRequest): Promise<PresignResponse> 
 
 export function confirmAsset(request: ConfirmRequest): Promise<ConfirmResponse> {
   return apiPost<ConfirmResponse>("/admin/assets/confirm", request);
+}
+
+export function deleteAsset(id: string): Promise<void> {
+  return apiDelete<void>(`/admin/assets/${id}`);
 }

--- a/apps/admin/src/pages/HymnEditPage.tsx
+++ b/apps/admin/src/pages/HymnEditPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { deleteAsset } from "../api/adminAssets";
 import { getHymnDetail, updateHymn, type HymnDetailResponse } from "../api/hymns";
 import AdminAssetUploadPage from "./AdminAssetUploadPage";
 
@@ -16,6 +17,7 @@ export default function HymnEditPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [deletingAssetId, setDeletingAssetId] = useState<string | null>(null);
 
   const loadHymn = useCallback(() => {
     if (!id) return;
@@ -70,6 +72,19 @@ export default function HymnEditPage() {
         // silently ignore refresh errors
       });
   }, [id]);
+
+  const handleDeleteAsset = async (assetId: string) => {
+    if (!window.confirm("이 에셋을 삭제하시겠습니까?")) return;
+    setDeletingAssetId(assetId);
+    try {
+      await deleteAsset(assetId);
+      handleAssetUploaded();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "에셋 삭제에 실패했습니다.");
+    } finally {
+      setDeletingAssetId(null);
+    }
+  };
 
   if (loading) return <p className="text-gray-500">로딩 중...</p>;
   if (!hymn && error) return <p className="text-red-600">{error}</p>;
@@ -161,6 +176,7 @@ export default function HymnEditPage() {
                     <th className="pb-2 font-medium text-gray-600">파트</th>
                     <th className="pb-2 font-medium text-gray-600">ObjectKey</th>
                     <th className="pb-2 font-medium text-gray-600">URL</th>
+                    <th className="pb-2 font-medium text-gray-600"></th>
                   </tr>
                 </thead>
                 <tbody>
@@ -178,6 +194,16 @@ export default function HymnEditPage() {
                         >
                           열기
                         </a>
+                      </td>
+                      <td className="py-2">
+                        <button
+                          type="button"
+                          onClick={() => handleDeleteAsset(a.id)}
+                          disabled={deletingAssetId === a.id}
+                          className="text-red-600 hover:text-red-800 disabled:opacity-50 text-sm font-medium"
+                        >
+                          {deletingAssetId === a.id ? "삭제 중..." : "삭제"}
+                        </button>
                       </td>
                     </tr>
                   ))}

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminDeleteAssetUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminDeleteAssetUseCase.java
@@ -1,0 +1,25 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.common.error.ApiException;
+import com.eunhyehymn.domain.repository.AssetRepository;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+
+public class AdminDeleteAssetUseCase {
+    private final AssetRepository assetRepository;
+
+    public AdminDeleteAssetUseCase(AssetRepository assetRepository) {
+        this.assetRepository = assetRepository;
+    }
+
+    public void delete(UUID assetId) {
+        assetRepository.findById(assetId)
+            .orElseThrow(() -> new ApiException(
+                HttpStatus.NOT_FOUND,
+                "asset_not_found",
+                "에셋을 찾을 수 없습니다: " + assetId,
+                null
+            ));
+        assetRepository.deleteById(assetId);
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/AssetConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/AssetConfig.java
@@ -2,6 +2,7 @@ package com.eunhyehymn.common.config;
 
 import com.eunhyehymn.application.ports.StorageService;
 import com.eunhyehymn.application.usecases.AdminConfirmAssetUseCase;
+import com.eunhyehymn.application.usecases.AdminDeleteAssetUseCase;
 import com.eunhyehymn.application.usecases.AdminPresignAssetUseCase;
 import com.eunhyehymn.domain.repository.AssetRepository;
 import com.eunhyehymn.domain.repository.HymnRepository;
@@ -45,5 +46,10 @@ public class AssetConfig {
         AssetRepository assetRepository
     ) {
         return new AdminConfirmAssetUseCase(hymnRepository, assetRepository);
+    }
+
+    @Bean
+    AdminDeleteAssetUseCase adminDeleteAssetUseCase(AssetRepository assetRepository) {
+        return new AdminDeleteAssetUseCase(assetRepository);
     }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/AssetRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/AssetRepository.java
@@ -12,5 +12,9 @@ public interface AssetRepository {
 
     List<Asset> findByHymnId(UUID hymnId);
 
+    void deleteById(UUID id);
+
+    void deleteByHymnId(UUID hymnId);
+
     void deleteByHymnIdAndTypeAndPart(UUID hymnId, com.eunhyehymn.domain.model.AssetType type, com.eunhyehymn.domain.model.PartType part);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AssetJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AssetJpaRepository.java
@@ -11,5 +11,9 @@ public interface AssetJpaRepository extends JpaRepository<AssetEntity, UUID> {
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Transactional
+    void deleteByHymnId(UUID hymnId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
     void deleteByHymnIdAndTypeAndPart(UUID hymnId, com.eunhyehymn.domain.model.AssetType type, com.eunhyehymn.domain.model.PartType part);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AssetRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AssetRepositoryAdapter.java
@@ -33,6 +33,16 @@ public class AssetRepositoryAdapter implements AssetRepository {
     }
 
     @Override
+    public void deleteById(UUID id) {
+        assetJpaRepository.deleteById(id);
+    }
+
+    @Override
+    public void deleteByHymnId(UUID hymnId) {
+        assetJpaRepository.deleteByHymnId(hymnId);
+    }
+
+    @Override
     public void deleteByHymnIdAndTypeAndPart(UUID hymnId, com.eunhyehymn.domain.model.AssetType type, com.eunhyehymn.domain.model.PartType part) {
         assetJpaRepository.deleteByHymnIdAndTypeAndPart(hymnId, type, part);
     }

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminAssetController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminAssetController.java
@@ -2,6 +2,7 @@ package com.eunhyehymn.presentation.controllers;
 
 import com.eunhyehymn.application.ports.StorageService;
 import com.eunhyehymn.application.usecases.AdminConfirmAssetUseCase;
+import com.eunhyehymn.application.usecases.AdminDeleteAssetUseCase;
 import com.eunhyehymn.application.usecases.AdminPresignAssetUseCase;
 import com.eunhyehymn.common.response.ApiResponse;
 import com.eunhyehymn.domain.model.Asset;
@@ -11,6 +12,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,13 +25,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminAssetController {
     private final AdminPresignAssetUseCase adminPresignAssetUseCase;
     private final AdminConfirmAssetUseCase adminConfirmAssetUseCase;
+    private final AdminDeleteAssetUseCase adminDeleteAssetUseCase;
 
     public AdminAssetController(
         AdminPresignAssetUseCase adminPresignAssetUseCase,
-        AdminConfirmAssetUseCase adminConfirmAssetUseCase
+        AdminConfirmAssetUseCase adminConfirmAssetUseCase,
+        AdminDeleteAssetUseCase adminDeleteAssetUseCase
     ) {
         this.adminPresignAssetUseCase = adminPresignAssetUseCase;
         this.adminConfirmAssetUseCase = adminConfirmAssetUseCase;
+        this.adminDeleteAssetUseCase = adminDeleteAssetUseCase;
     }
 
     @PostMapping("/presign")
@@ -62,6 +68,12 @@ public class AdminAssetController {
             asset.url(),
             asset.objectKey()
         ));
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> deleteAsset(@PathVariable UUID id) {
+        adminDeleteAssetUseCase.delete(id);
+        return ApiResponse.success(null);
     }
 
     public record PresignRequest(

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminAssetApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminAssetApiTest.java
@@ -3,6 +3,7 @@ package com.eunhyehymn.presentation.controllers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -258,5 +259,58 @@ class AdminAssetApiTest {
         UUID assetId = UUID.fromString(objectMapper.readTree(response).get("data").get("assetId").asText());
         var saved = assetJpaRepository.findById(assetId).orElseThrow();
         assertThat(saved.getPart()).isEqualTo(com.eunhyehymn.domain.model.PartType.ALL);
+    }
+
+    @Test
+    void adminCanDeleteAsset() throws Exception {
+        UUID assetId = UUID.randomUUID();
+        assetJpaRepository.save(new com.eunhyehymn.infrastructure.persistence.AssetEntity(
+            assetId,
+            hymnId,
+            AssetType.PNG,
+            com.eunhyehymn.domain.model.PartType.ALL,
+            "https://public.local/hymns/delete-me.png",
+            "hymns/" + hymnId + "/PNG/ALL/delete-me.png",
+            null,
+            null,
+            Instant.now()
+        ));
+
+        mockMvc.perform(delete("/admin/assets/" + assetId)
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true));
+
+        assertThat(assetJpaRepository.findById(assetId)).isEmpty();
+    }
+
+    @Test
+    void deleteReturnsNotFoundForNonExistentAsset() throws Exception {
+        UUID nonExistentId = UUID.randomUUID();
+
+        mockMvc.perform(delete("/admin/assets/" + nonExistentId)
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("asset_not_found"));
+    }
+
+    @Test
+    void deleteRequiresAdminRole() throws Exception {
+        UUID assetId = UUID.randomUUID();
+
+        mockMvc.perform(delete("/admin/assets/" + assetId)
+                .header("Authorization", "Bearer " + userToken))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("forbidden"));
+    }
+
+    @Test
+    void deleteRejectsUnauthenticatedUser() throws Exception {
+        UUID assetId = UUID.randomUUID();
+
+        mockMvc.perform(delete("/admin/assets/" + assetId))
+            .andExpect(status().isUnauthorized());
     }
 }


### PR DESCRIPTION
## Summary
- AdminDeleteAssetUseCase: 에셋 ID로 조회 후 삭제
- `DELETE /admin/assets/{id}` 엔드포인트 추가
- AssetRepository에 findById/deleteById 메서드 추가
- HymnEditPage에 에셋별 삭제 버튼 + 확인 대화상자
- adminAssets.ts에 deleteAsset API 함수 추가

## Test plan
- [ ] `./gradlew test` 전체 통과
- [ ] `npm run build` 성공
- [ ] HymnEditPage에서 에셋 삭제 동작 확인
- [ ] 비인증 사용자 접근 거부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)