### PR TITLE
feat: Admin 찬양 삭제 API 및 UI 구현

### DIFF
--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminDeleteHymnUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminDeleteHymnUseCase.java
@@ -8,6 +8,7 @@ import com.eunhyehymn.domain.repository.HymnRepository;
 import com.eunhyehymn.domain.repository.UserHymnStateRepository;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
 
 public class AdminDeleteHymnUseCase {
     private final HymnRepository hymnRepository;
@@ -30,6 +31,7 @@ public class AdminDeleteHymnUseCase {
         this.eventRepository = eventRepository;
     }
 
+    @Transactional
     public void delete(UUID hymnId) {
         hymnRepository.findById(hymnId)
             .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "hymn_not_found", "찬송가를 찾을 수 없습니다", null));

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminDeleteHymnUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminDeleteHymnUseCase.java
@@ -1,0 +1,44 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.common.error.ApiException;
+import com.eunhyehymn.domain.repository.AssetRepository;
+import com.eunhyehymn.domain.repository.EventRepository;
+import com.eunhyehymn.domain.repository.HymnNoteRepository;
+import com.eunhyehymn.domain.repository.HymnRepository;
+import com.eunhyehymn.domain.repository.UserHymnStateRepository;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+
+public class AdminDeleteHymnUseCase {
+    private final HymnRepository hymnRepository;
+    private final AssetRepository assetRepository;
+    private final HymnNoteRepository hymnNoteRepository;
+    private final UserHymnStateRepository userHymnStateRepository;
+    private final EventRepository eventRepository;
+
+    public AdminDeleteHymnUseCase(
+        HymnRepository hymnRepository,
+        AssetRepository assetRepository,
+        HymnNoteRepository hymnNoteRepository,
+        UserHymnStateRepository userHymnStateRepository,
+        EventRepository eventRepository
+    ) {
+        this.hymnRepository = hymnRepository;
+        this.assetRepository = assetRepository;
+        this.hymnNoteRepository = hymnNoteRepository;
+        this.userHymnStateRepository = userHymnStateRepository;
+        this.eventRepository = eventRepository;
+    }
+
+    public void delete(UUID hymnId) {
+        hymnRepository.findById(hymnId)
+            .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "hymn_not_found", "찬송가를 찾을 수 없습니다", null));
+
+        // FK 제약조건에 ON DELETE CASCADE가 없으므로 관련 데이터를 먼저 삭제
+        eventRepository.deleteByHymnId(hymnId);
+        userHymnStateRepository.deleteByHymnId(hymnId);
+        hymnNoteRepository.deleteByHymnId(hymnId);
+        assetRepository.deleteByHymnId(hymnId);
+        hymnRepository.deleteById(hymnId);
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/UseCaseConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/UseCaseConfig.java
@@ -1,6 +1,7 @@
 package com.eunhyehymn.common.config;
 
 import com.eunhyehymn.application.usecases.AdminCreateHymnUseCase;
+import com.eunhyehymn.application.usecases.AdminDeleteHymnUseCase;
 import com.eunhyehymn.application.usecases.AdminListHymnsUseCase;
 import com.eunhyehymn.application.usecases.AdminListUsersUseCase;
 import com.eunhyehymn.application.usecases.AdminUpdateHymnUseCase;
@@ -65,6 +66,17 @@ public class UseCaseConfig {
     @Bean
     AdminUpdateHymnUseCase adminUpdateHymnUseCase(HymnRepository hymnRepository) {
         return new AdminUpdateHymnUseCase(hymnRepository);
+    }
+
+    @Bean
+    AdminDeleteHymnUseCase adminDeleteHymnUseCase(
+        HymnRepository hymnRepository,
+        AssetRepository assetRepository,
+        HymnNoteRepository hymnNoteRepository,
+        UserHymnStateRepository userHymnStateRepository,
+        EventRepository eventRepository
+    ) {
+        return new AdminDeleteHymnUseCase(hymnRepository, assetRepository, hymnNoteRepository, userHymnStateRepository, eventRepository);
     }
 
     @Bean

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/AssetRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/AssetRepository.java
@@ -12,5 +12,9 @@ public interface AssetRepository {
 
     List<Asset> findByHymnId(UUID hymnId);
 
+    void deleteById(UUID id);
+
+    void deleteByHymnId(UUID hymnId);
+
     void deleteByHymnIdAndTypeAndPart(UUID hymnId, com.eunhyehymn.domain.model.AssetType type, com.eunhyehymn.domain.model.PartType part);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/EventRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/EventRepository.java
@@ -11,4 +11,6 @@ public interface EventRepository {
     List<Event> saveAll(List<Event> events);
 
     Optional<Event> findById(UUID id);
+
+    void deleteByHymnId(UUID hymnId);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/HymnNoteRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/HymnNoteRepository.java
@@ -10,4 +10,6 @@ public interface HymnNoteRepository {
     Optional<HymnNote> findById(UUID id);
 
     Optional<HymnNote> findByUserIdAndHymnId(UUID userId, UUID hymnId);
+
+    void deleteByHymnId(UUID hymnId);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/HymnRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/HymnRepository.java
@@ -15,4 +15,6 @@ public interface HymnRepository {
     Optional<Hymn> findById(UUID id);
 
     List<Hymn> findByIdIn(List<UUID> ids);
+
+    void deleteById(UUID id);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/UserHymnStateRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/UserHymnStateRepository.java
@@ -11,4 +11,6 @@ public interface UserHymnStateRepository {
     Optional<UserHymnState> findByUserIdAndHymnId(UUID userId, UUID hymnId);
 
     List<UserHymnState> findByUserIdOrderByLastOpenedAtDesc(UUID userId);
+
+    void deleteByHymnId(UUID hymnId);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AssetJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AssetJpaRepository.java
@@ -11,5 +11,9 @@ public interface AssetJpaRepository extends JpaRepository<AssetEntity, UUID> {
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Transactional
+    void deleteByHymnId(UUID hymnId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
     void deleteByHymnIdAndTypeAndPart(UUID hymnId, com.eunhyehymn.domain.model.AssetType type, com.eunhyehymn.domain.model.PartType part);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AssetRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AssetRepositoryAdapter.java
@@ -33,6 +33,16 @@ public class AssetRepositoryAdapter implements AssetRepository {
     }
 
     @Override
+    public void deleteById(UUID id) {
+        assetJpaRepository.deleteById(id);
+    }
+
+    @Override
+    public void deleteByHymnId(UUID hymnId) {
+        assetJpaRepository.deleteByHymnId(hymnId);
+    }
+
+    @Override
     public void deleteByHymnIdAndTypeAndPart(UUID hymnId, com.eunhyehymn.domain.model.AssetType type, com.eunhyehymn.domain.model.PartType part) {
         assetJpaRepository.deleteByHymnIdAndTypeAndPart(hymnId, type, part);
     }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventJpaRepository.java
@@ -2,6 +2,11 @@ package com.eunhyehymn.infrastructure.persistence;
 
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface EventJpaRepository extends JpaRepository<EventEntity, UUID> {
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    void deleteByHymnId(UUID hymnId);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventRepositoryAdapter.java
@@ -32,4 +32,9 @@ public class EventRepositoryAdapter implements EventRepository {
     public Optional<Event> findById(UUID id) {
         return eventJpaRepository.findById(id).map(EventMapper::toDomain);
     }
+
+    @Override
+    public void deleteByHymnId(UUID hymnId) {
+        eventJpaRepository.deleteByHymnId(hymnId);
+    }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/HymnNoteJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/HymnNoteJpaRepository.java
@@ -3,7 +3,13 @@ package com.eunhyehymn.infrastructure.persistence;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface HymnNoteJpaRepository extends JpaRepository<HymnNoteEntity, UUID> {
     Optional<HymnNoteEntity> findByUserIdAndHymnId(UUID userId, UUID hymnId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    void deleteByHymnId(UUID hymnId);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/HymnNoteRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/HymnNoteRepositoryAdapter.java
@@ -30,4 +30,9 @@ public class HymnNoteRepositoryAdapter implements HymnNoteRepository {
     public Optional<HymnNote> findByUserIdAndHymnId(UUID userId, UUID hymnId) {
         return hymnNoteJpaRepository.findByUserIdAndHymnId(userId, hymnId).map(HymnNoteMapper::toDomain);
     }
+
+    @Override
+    public void deleteByHymnId(UUID hymnId) {
+        hymnNoteJpaRepository.deleteByHymnId(hymnId);
+    }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/HymnRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/HymnRepositoryAdapter.java
@@ -41,4 +41,9 @@ public class HymnRepositoryAdapter implements HymnRepository {
     public List<Hymn> findByIdIn(List<UUID> ids) {
         return hymnJpaRepository.findByIdIn(ids).stream().map(HymnMapper::toDomain).toList();
     }
+
+    @Override
+    public void deleteById(UUID id) {
+        hymnJpaRepository.deleteById(id);
+    }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserHymnStateJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserHymnStateJpaRepository.java
@@ -4,9 +4,15 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface UserHymnStateJpaRepository extends JpaRepository<UserHymnStateEntity, UserHymnStateId> {
     Optional<UserHymnStateEntity> findByIdUserIdAndIdHymnId(UUID userId, UUID hymnId);
 
     List<UserHymnStateEntity> findByIdUserIdOrderByLastOpenedAtDesc(UUID userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    void deleteByIdHymnId(UUID hymnId);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserHymnStateRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserHymnStateRepositoryAdapter.java
@@ -35,4 +35,9 @@ public class UserHymnStateRepositoryAdapter implements UserHymnStateRepository {
             .map(UserHymnStateMapper::toDomain)
             .toList();
     }
+
+    @Override
+    public void deleteByHymnId(UUID hymnId) {
+        userHymnStateJpaRepository.deleteByIdHymnId(hymnId);
+    }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminHymnController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminHymnController.java
@@ -1,6 +1,7 @@
 package com.eunhyehymn.presentation.controllers;
 
 import com.eunhyehymn.application.usecases.AdminCreateHymnUseCase;
+import com.eunhyehymn.application.usecases.AdminDeleteHymnUseCase;
 import com.eunhyehymn.application.usecases.AdminListHymnsUseCase;
 import com.eunhyehymn.application.usecases.AdminUpdateHymnUseCase;
 import com.eunhyehymn.common.error.ApiException;
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,15 +26,18 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class AdminHymnController {
     private final AdminCreateHymnUseCase adminCreateHymnUseCase;
+    private final AdminDeleteHymnUseCase adminDeleteHymnUseCase;
     private final AdminUpdateHymnUseCase adminUpdateHymnUseCase;
     private final AdminListHymnsUseCase adminListHymnsUseCase;
 
     public AdminHymnController(
         AdminCreateHymnUseCase adminCreateHymnUseCase,
+        AdminDeleteHymnUseCase adminDeleteHymnUseCase,
         AdminUpdateHymnUseCase adminUpdateHymnUseCase,
         AdminListHymnsUseCase adminListHymnsUseCase
     ) {
         this.adminCreateHymnUseCase = adminCreateHymnUseCase;
+        this.adminDeleteHymnUseCase = adminDeleteHymnUseCase;
         this.adminUpdateHymnUseCase = adminUpdateHymnUseCase;
         this.adminListHymnsUseCase = adminListHymnsUseCase;
     }
@@ -61,6 +66,12 @@ public class AdminHymnController {
             request.enabled()
         );
         return ApiResponse.success(HymnResponse.from(hymn));
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> delete(@PathVariable UUID id) {
+        adminDeleteHymnUseCase.delete(id);
+        return ApiResponse.success(null);
     }
 
     @GetMapping

--- a/apps/api/src/test/java/com/eunhyehymn/application/usecases/GetHistoryUseCaseTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/application/usecases/GetHistoryUseCaseTest.java
@@ -39,6 +39,10 @@ class GetHistoryUseCaseTest {
                     new UserHymnState(userId, hymnA, false, Instant.now().minusSeconds(60), null, null)
                 );
             }
+
+            @Override
+            public void deleteByHymnId(UUID hymnId) {
+            }
         };
 
         AtomicInteger batchCalls = new AtomicInteger();
@@ -70,6 +74,10 @@ class GetHistoryUseCaseTest {
                     new Hymn(hymnA, "A", "1", "tag", true, Instant.now()),
                     new Hymn(hymnB, "B", "2", "tag", true, Instant.now())
                 );
+            }
+
+            @Override
+            public void deleteById(UUID id) {
             }
         };
 

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminHymnApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminHymnApiTest.java
@@ -1,14 +1,18 @@
 package com.eunhyehymn.presentation.controllers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.eunhyehymn.domain.model.AssetType;
+import com.eunhyehymn.domain.model.PartType;
 import com.eunhyehymn.domain.model.Role;
 import com.eunhyehymn.domain.model.UserStatus;
+import com.eunhyehymn.infrastructure.persistence.AssetEntity;
 import com.eunhyehymn.infrastructure.persistence.AssetJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.AuthIdentityJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.EventJpaRepository;
@@ -170,5 +174,56 @@ class AdminHymnApiTest {
             }
         }
         assertThat(hasDisabled).isTrue();
+    }
+
+    @Test
+    void adminCanDeleteHymn() throws Exception {
+        UUID hymnId = UUID.randomUUID();
+        hymnJpaRepository.save(new HymnEntity(hymnId, "삭제 대상", "99", "tag", true, Instant.now()));
+
+        // 관련 에셋도 생성
+        assetJpaRepository.save(new AssetEntity(
+            UUID.randomUUID(), hymnId, AssetType.PNG, PartType.ALL,
+            "https://example.com/test.png", "hymns/" + hymnId + "/PNG/ALL/test.png",
+            null, null, Instant.now()
+        ));
+
+        // 삭제 요청
+        mockMvc.perform(delete("/admin/hymns/" + hymnId)
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true));
+
+        // 찬양이 삭제되었는지 확인
+        assertThat(hymnJpaRepository.findById(hymnId)).isEmpty();
+
+        // 관련 에셋도 삭제되었는지 확인
+        assertThat(assetJpaRepository.findByHymnId(hymnId)).isEmpty();
+    }
+
+    @Test
+    void deleteNonExistentHymnReturns404() throws Exception {
+        UUID nonExistentId = UUID.randomUUID();
+
+        mockMvc.perform(delete("/admin/hymns/" + nonExistentId)
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("hymn_not_found"));
+    }
+
+    @Test
+    void deleteHymnRequiresAdminRole() throws Exception {
+        UUID hymnId = UUID.randomUUID();
+        hymnJpaRepository.save(new HymnEntity(hymnId, "권한 테스트", "100", "tag", true, Instant.now()));
+
+        mockMvc.perform(delete("/admin/hymns/" + hymnId)
+                .header("Authorization", "Bearer " + userToken))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("forbidden"));
+
+        // 찬양이 삭제되지 않았는지 확인
+        assertThat(hymnJpaRepository.findById(hymnId)).isPresent();
     }
 }


### PR DESCRIPTION
## Summary
- AdminDeleteHymnUseCase: 찬양 및 관련 데이터(에셋, 메모, 상태, 이벤트) 일괄 삭제
- `DELETE /admin/hymns/{id}` 엔드포인트 추가
- 관련 Repository에 deleteByHymnId 메서드 추가
- AdminHymnApiTest에 삭제 테스트 추가

## Test plan
- [ ] `./gradlew test` 전체 통과
- [ ] Admin 찬양 목록에서 삭제 동작 확인
- [ ] 관련 에셋/메모/상태/이벤트 연쇄 삭제 확인
- [ ] 비인증 사용자 접근 거부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)