### PR TITLE
feat(admin): add hymn delete UI

### DIFF
--- a/apps/admin/src/api/hymns.ts
+++ b/apps/admin/src/api/hymns.ts
@@ -1,4 +1,4 @@
-import { apiGet, apiPatch, apiPost } from "./client";
+import { apiDelete, apiGet, apiPatch, apiPost } from "./client";
 
 export interface HymnResponse {
   id: string;
@@ -56,4 +56,8 @@ export function updateHymn(id: string, req: UpdateHymnRequest): Promise<HymnResp
 
 export function getHymnDetail(id: string): Promise<HymnDetailResponse> {
   return apiGet<HymnDetailResponse>(`/hymns/${id}`);
+}
+
+export function deleteHymn(id: string): Promise<void> {
+  return apiDelete<void>(`/admin/hymns/${id}`);
 }

--- a/apps/admin/src/pages/HymnEditPage.tsx
+++ b/apps/admin/src/pages/HymnEditPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { deleteAsset } from "../api/adminAssets";
-import { getHymnDetail, updateHymn, type HymnDetailResponse } from "../api/hymns";
+import { deleteHymn, getHymnDetail, updateHymn, type HymnDetailResponse } from "../api/hymns";
 import AdminAssetUploadPage from "./AdminAssetUploadPage";
 
 export default function HymnEditPage() {
@@ -17,10 +17,14 @@ export default function HymnEditPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [deletingAssetId, setDeletingAssetId] = useState<string | null>(null);
 
   const loadHymn = useCallback(() => {
-    if (!id) return;
+    if (!id) {
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     getHymnDetail(id)
       .then((data) => {
@@ -72,6 +76,21 @@ export default function HymnEditPage() {
         // silently ignore refresh errors
       });
   }, [id]);
+
+  const handleDeleteHymn = async () => {
+    if (!id || !hymn) return;
+    if (!window.confirm(`"${hymn.title}" 찬양을 삭제하시겠습니까? 관련된 에셋, 메모, 상태, 이벤트가 모두 삭제됩니다.`)) return;
+    setDeleting(true);
+    setError(null);
+    try {
+      await deleteHymn(id);
+      navigate("/hymns", { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "삭제에 실패했습니다.");
+    } finally {
+      setDeleting(false);
+    }
+  };
 
   const handleDeleteAsset = async (assetId: string) => {
     if (!window.confirm("이 에셋을 삭제하시겠습니까?")) return;
@@ -160,6 +179,14 @@ export default function HymnEditPage() {
           >
             취소
           </button>
+          <button
+            type="button"
+            onClick={handleDeleteHymn}
+            disabled={deleting}
+            className="ml-auto bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 disabled:opacity-50"
+          >
+            {deleting ? "삭제 중..." : "삭제"}
+          </button>
         </div>
       </form>
 
@@ -186,14 +213,18 @@ export default function HymnEditPage() {
                       <td className="py-2">{a.part}</td>
                       <td className="py-2 text-gray-500 truncate max-w-xs">{a.objectKey}</td>
                       <td className="py-2">
-                        <a
-                          href={a.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-indigo-600 hover:underline"
-                        >
-                          열기
-                        </a>
+                        {/^https?:\/\//i.test(a.url) ? (
+                          <a
+                            href={a.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-indigo-600 hover:underline"
+                          >
+                            열기
+                          </a>
+                        ) : (
+                          <span className="text-gray-400">-</span>
+                        )}
                       </td>
                       <td className="py-2">
                         <button

--- a/apps/admin/src/pages/HymnListPage.tsx
+++ b/apps/admin/src/pages/HymnListPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { listHymns, updateHymn, type HymnResponse } from "../api/hymns";
+import { deleteHymn, listHymns, updateHymn, type HymnResponse } from "../api/hymns";
 
 type EnabledFilter = "all" | "enabled" | "disabled";
 
@@ -11,6 +11,8 @@ export default function HymnListPage() {
   const [search, setSearch] = useState("");
   const [enabledFilter, setEnabledFilter] = useState<EnabledFilter>("all");
   const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set());
+  const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set());
+  const [actionError, setActionError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -51,13 +53,32 @@ export default function HymnListPage() {
 
   const handleToggleEnabled = async (hymn: HymnResponse) => {
     setTogglingIds((prev) => new Set(prev).add(hymn.id));
+    setActionError(null);
     try {
       const updated = await updateHymn(hymn.id, { enabled: !hymn.enabled });
       setHymns((prev) => prev.map((h) => (h.id === hymn.id ? { ...h, enabled: updated.enabled } : h)));
     } catch (err) {
-      setError(err instanceof Error ? err.message : "상태 변경에 실패했습니다.");
+      setActionError(err instanceof Error ? err.message : "상태 변경에 실패했습니다.");
     } finally {
       setTogglingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(hymn.id);
+        return next;
+      });
+    }
+  };
+
+  const handleDelete = async (hymn: HymnResponse) => {
+    if (!window.confirm(`"${hymn.title}" 찬양을 삭제하시겠습니까? 관련된 에셋, 메모, 상태, 이벤트가 모두 삭제됩니다.`)) return;
+    setDeletingIds((prev) => new Set(prev).add(hymn.id));
+    setActionError(null);
+    try {
+      await deleteHymn(hymn.id);
+      setHymns((prev) => prev.filter((h) => h.id !== hymn.id));
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "삭제에 실패했습니다.");
+    } finally {
+      setDeletingIds((prev) => {
         const next = new Set(prev);
         next.delete(hymn.id);
         return next;
@@ -99,6 +120,7 @@ export default function HymnListPage() {
 
       {loading && <p className="text-gray-500">로딩 중...</p>}
       {error && <p className="text-red-600 mb-4">{error}</p>}
+      {actionError && <p className="text-red-600 mb-4">{actionError}</p>}
 
       {!loading && !error && (
         <div className="bg-white rounded-lg shadow overflow-hidden">
@@ -109,12 +131,13 @@ export default function HymnListPage() {
                 <th className="px-4 py-3 text-sm font-semibold text-gray-600">제목</th>
                 <th className="px-4 py-3 text-sm font-semibold text-gray-600">태그</th>
                 <th className="px-4 py-3 text-sm font-semibold text-gray-600">상태</th>
+                <th className="px-4 py-3 text-sm font-semibold text-gray-600">작업</th>
               </tr>
             </thead>
             <tbody>
               {filteredHymns.length === 0 && (
                 <tr>
-                  <td colSpan={4} className="px-4 py-8 text-center text-gray-400">
+                  <td colSpan={5} className="px-4 py-8 text-center text-gray-400">
                     {search || enabledFilter !== "all"
                       ? "검색 결과가 없습니다."
                       : "등록된 찬양이 없습니다."}
@@ -142,6 +165,16 @@ export default function HymnListPage() {
                       }`}
                     >
                       {togglingIds.has(h.id) ? "..." : h.enabled ? "활성" : "비활성"}
+                    </button>
+                  </td>
+                  <td className="px-4 py-3">
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(h)}
+                      disabled={deletingIds.has(h.id)}
+                      className="text-red-600 hover:text-red-800 text-sm font-medium disabled:opacity-50"
+                    >
+                      {deletingIds.has(h.id) ? "삭제 중..." : "삭제"}
                     </button>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- `hymns.ts`에 `deleteHymn()` API 함수 추가
- HymnListPage에 삭제 버튼 + 확인 다이얼로그 추가 (작업 컬럼)
- HymnEditPage에 삭제 버튼 + 확인 다이얼로그 추가
- 버그 수정: 토글 에러 시 테이블 숨김 방지 (actionError 분리)
- 버그 수정: id 없을 때 loading 상태 고착 방지
- 보안 수정: 에셋 URL scheme 검증 (XSS 방지)

## Test plan
- [ ] 찬양 목록에서 삭제 버튼 클릭 시 확인 다이얼로그 표시
- [ ] 확인 후 찬양 삭제 및 목록에서 제거
- [ ] 수정 페이지에서 삭제 후 목록으로 이동
- [ ] 삭제 취소 시 아무 동작 없음
- [ ] TypeScript 타입체크 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)