### PR TITLE
feat(admin): add automatic access token refresh on 401

### DIFF
--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -12,12 +12,47 @@ function authHeaders(): Record<string, string> {
   return {};
 }
 
+let refreshPromise: Promise<boolean> | null = null;
+
+async function tryRefreshToken(): Promise<boolean> {
+  if (refreshPromise) return refreshPromise;
+
+  const rt = localStorage.getItem("refreshToken");
+  if (!rt) return false;
+
+  refreshPromise = (async () => {
+    try {
+      const response = await fetch(`${API_BASE}/auth/refresh`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken: rt }),
+      });
+      if (!response.ok) return false;
+      const data = await response.json();
+      if (!data.data) return false;
+      localStorage.setItem("accessToken", data.data.accessToken);
+      localStorage.setItem("refreshToken", data.data.refreshToken);
+      return true;
+    } catch {
+      return false;
+    } finally {
+      refreshPromise = null;
+    }
+  })();
+
+  return refreshPromise;
+}
+
+function redirectToLogin(): never {
+  localStorage.removeItem("accessToken");
+  localStorage.removeItem("refreshToken");
+  window.location.href = "/login";
+  throw new Error("인증이 만료되었습니다.");
+}
+
 async function handleResponse<T>(response: Response): Promise<T> {
   if (response.status === 401) {
-    localStorage.removeItem("accessToken");
-    localStorage.removeItem("refreshToken");
-    window.location.href = "/login";
-    throw new Error("인증이 만료되었습니다.");
+    return redirectToLogin();
   }
 
   const data = await response.json();
@@ -30,42 +65,51 @@ async function handleResponse<T>(response: Response): Promise<T> {
   return data.data as T;
 }
 
-export async function apiGet<T>(path: string): Promise<T> {
-  const response = await fetch(`${API_BASE}${path}`, {
-    method: "GET",
-    headers: { ...authHeaders() },
-  });
+interface RequestOptions {
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+async function apiFetch<T>(opts: RequestOptions): Promise<T> {
+  const doFetch = () => {
+    const headers: Record<string, string> = { ...authHeaders() };
+    if (opts.body !== undefined) {
+      headers["Content-Type"] = "application/json";
+    }
+    return fetch(`${API_BASE}${opts.path}`, {
+      method: opts.method,
+      headers,
+      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+    });
+  };
+
+  const response = await doFetch();
+
+  if (response.status === 401) {
+    const refreshed = await tryRefreshToken();
+    if (refreshed) {
+      const retryResponse = await doFetch();
+      return handleResponse<T>(retryResponse);
+    }
+    return redirectToLogin();
+  }
+
   return handleResponse<T>(response);
+}
+
+export async function apiGet<T>(path: string): Promise<T> {
+  return apiFetch<T>({ method: "GET", path });
 }
 
 export async function apiPost<T>(path: string, body?: unknown): Promise<T> {
-  const response = await fetch(`${API_BASE}${path}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...authHeaders(),
-    },
-    body: body != null ? JSON.stringify(body) : undefined,
-  });
-  return handleResponse<T>(response);
+  return apiFetch<T>({ method: "POST", path, body: body ?? null });
 }
 
 export async function apiPatch<T>(path: string, body: unknown): Promise<T> {
-  const response = await fetch(`${API_BASE}${path}`, {
-    method: "PATCH",
-    headers: {
-      "Content-Type": "application/json",
-      ...authHeaders(),
-    },
-    body: JSON.stringify(body),
-  });
-  return handleResponse<T>(response);
+  return apiFetch<T>({ method: "PATCH", path, body });
 }
 
 export async function apiDelete<T>(path: string): Promise<T> {
-  const response = await fetch(`${API_BASE}${path}`, {
-    method: "DELETE",
-    headers: { ...authHeaders() },
-  });
-  return handleResponse<T>(response);
+  return apiFetch<T>({ method: "DELETE", path });
 }

--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -1,10 +1,29 @@
 const API_BASE = "/api/v1";
 
+type UnauthorizedMode = "redirect" | "throw";
+
+export interface ApiRequestOptions {
+  unauthorized?: UnauthorizedMode;
+  includeAuth?: boolean;
+}
+
+interface ApiEnvelope<T = unknown> {
+  success?: boolean;
+  data?: T;
+  error?: {
+    message?: string;
+  };
+}
+
 function getToken(): string | null {
   return localStorage.getItem("accessToken");
 }
 
-function authHeaders(): Record<string, string> {
+function authHeaders(includeAuth: boolean): Record<string, string> {
+  if (!includeAuth) {
+    return {};
+  }
+
   const token = getToken();
   if (token) {
     return { Authorization: `Bearer ${token}` };
@@ -13,6 +32,11 @@ function authHeaders(): Record<string, string> {
 }
 
 let refreshPromise: Promise<boolean> | null = null;
+
+function clearTokens(): void {
+  localStorage.removeItem("accessToken");
+  localStorage.removeItem("refreshToken");
+}
 
 async function tryRefreshToken(): Promise<boolean> {
   if (refreshPromise) return refreshPromise;
@@ -27,11 +51,18 @@ async function tryRefreshToken(): Promise<boolean> {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ refreshToken: rt }),
       });
+
       if (!response.ok) return false;
-      const data = await response.json();
-      if (!data.data) return false;
-      localStorage.setItem("accessToken", data.data.accessToken);
-      localStorage.setItem("refreshToken", data.data.refreshToken);
+
+      const payload = (await response.json()) as ApiEnvelope<{
+        accessToken?: string;
+        refreshToken?: string;
+      }>;
+      const tokens = payload.data;
+      if (!tokens?.accessToken || !tokens?.refreshToken) return false;
+
+      localStorage.setItem("accessToken", tokens.accessToken);
+      localStorage.setItem("refreshToken", tokens.refreshToken);
       return true;
     } catch {
       return false;
@@ -44,72 +75,83 @@ async function tryRefreshToken(): Promise<boolean> {
 }
 
 function redirectToLogin(): never {
-  localStorage.removeItem("accessToken");
-  localStorage.removeItem("refreshToken");
+  clearTokens();
   window.location.href = "/login";
   throw new Error("인증이 만료되었습니다.");
 }
 
-async function handleResponse<T>(response: Response): Promise<T> {
-  if (response.status === 401) {
-    return redirectToLogin();
-  }
-
-  const data = await response.json();
-
-  if (!response.ok || data?.success === false) {
-    const message = data?.error?.message ?? "요청 처리 중 오류가 발생했습니다.";
-    throw new Error(message);
-  }
-
-  return data.data as T;
+function resolveErrorMessage(payload: ApiEnvelope | null, fallback: string): string {
+  return payload?.error?.message ?? fallback;
 }
 
-interface RequestOptions {
-  method: string;
+async function handleResponse<T>(response: Response, unauthorized: UnauthorizedMode): Promise<T> {
+  const payload = (await response.json().catch(() => null)) as ApiEnvelope<T> | null;
+
+  if (response.status === 401) {
+    if (unauthorized === "redirect") {
+      return redirectToLogin();
+    }
+    throw new Error(resolveErrorMessage(payload, "인증에 실패했습니다."));
+  }
+
+  if (!response.ok || payload?.success === false) {
+    throw new Error(resolveErrorMessage(payload, "요청 처리 중 오류가 발생했습니다."));
+  }
+
+  return payload?.data as T;
+}
+
+interface RequestOptions extends ApiRequestOptions {
+  method: "GET" | "POST" | "PATCH" | "DELETE";
   path: string;
   body?: unknown;
 }
 
-async function apiFetch<T>(opts: RequestOptions): Promise<T> {
+async function apiFetch<T>({
+  method,
+  path,
+  body,
+  includeAuth = true,
+  unauthorized = "redirect",
+}: RequestOptions): Promise<T> {
   const doFetch = () => {
-    const headers: Record<string, string> = { ...authHeaders() };
-    if (opts.body !== undefined) {
+    const headers: Record<string, string> = { ...authHeaders(includeAuth) };
+    if (body !== undefined) {
       headers["Content-Type"] = "application/json";
     }
-    return fetch(`${API_BASE}${opts.path}`, {
-      method: opts.method,
+
+    return fetch(`${API_BASE}${path}`, {
+      method,
       headers,
-      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
     });
   };
 
   const response = await doFetch();
 
-  if (response.status === 401) {
+  if (response.status === 401 && includeAuth && unauthorized === "redirect") {
     const refreshed = await tryRefreshToken();
     if (refreshed) {
       const retryResponse = await doFetch();
-      return handleResponse<T>(retryResponse);
+      return handleResponse<T>(retryResponse, unauthorized);
     }
-    return redirectToLogin();
   }
 
-  return handleResponse<T>(response);
+  return handleResponse<T>(response, unauthorized);
 }
 
-export async function apiGet<T>(path: string): Promise<T> {
-  return apiFetch<T>({ method: "GET", path });
+export async function apiGet<T>(path: string, options?: ApiRequestOptions): Promise<T> {
+  return apiFetch<T>({ method: "GET", path, ...options });
 }
 
-export async function apiPost<T>(path: string, body?: unknown): Promise<T> {
-  return apiFetch<T>({ method: "POST", path, body: body ?? null });
+export async function apiPost<T>(path: string, body?: unknown, options?: ApiRequestOptions): Promise<T> {
+  return apiFetch<T>({ method: "POST", path, body, ...options });
 }
 
-export async function apiPatch<T>(path: string, body: unknown): Promise<T> {
-  return apiFetch<T>({ method: "PATCH", path, body });
+export async function apiPatch<T>(path: string, body: unknown, options?: ApiRequestOptions): Promise<T> {
+  return apiFetch<T>({ method: "PATCH", path, body, ...options });
 }
 
-export async function apiDelete<T>(path: string): Promise<T> {
-  return apiFetch<T>({ method: "DELETE", path });
+export async function apiDelete<T>(path: string, options?: ApiRequestOptions): Promise<T> {
+  return apiFetch<T>({ method: "DELETE", path, ...options });
 }


### PR DESCRIPTION
## Summary
- 401 응답 시 자동으로 refresh token으로 access token 갱신
- 갱신 성공 시 원래 요청 재시도
- 동시 요청 시 중복 갱신 방지 (mutex 패턴)
- 갱신 실패 시 로그인 페이지로 리다이렉트
- API 함수를 공통 apiFetch()로 리팩토링

## Test plan
- [ ] Access token 만료 후 API 호출 시 자동 갱신
- [ ] 갱신 후 원래 요청 정상 처리
- [ ] Refresh token도 만료된 경우 로그인 페이지 이동
- [ ] 동시 다발 요청 시 refresh 한 번만 실행
- [ ] TypeScript 타입체크 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)