### PR TITLE
feat: CloudWatch 모니터링/알림 (알람, 로그, 대시보드)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -98,6 +98,7 @@ jobs:
         run: |
           scp -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
             infra/aws/docker-compose.prod.yml \
+            infra/aws/docker-compose.prod.awslogs.yml \
             infra/aws/deploy.sh \
             ec2-user@${{ secrets.EC2_HOST }}:/home/ec2-user/app/
 
@@ -112,12 +113,14 @@ jobs:
       - name: Run deploy script
         env:
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          ENABLE_AWSLOGS: ${{ secrets.ENABLE_AWSLOGS }}
         run: |
           ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
             ec2-user@${{ secrets.EC2_HOST }} \
             "cd /home/ec2-user/app && \
              export ECR_REGISTRY=${ECR_REGISTRY} && \
              export AWS_REGION=${{ env.AWS_REGION }} && \
+             export ENABLE_AWSLOGS=${ENABLE_AWSLOGS} && \
              chmod +x deploy.sh && \
              ./deploy.sh"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ Eunhye_Hymn/
 │       ├── s3.tf                     # S3 버킷 + public read + CORS
 │       ├── ecr.tf                    # ECR 레포 2개 (api, admin) + lifecycle
 │       ├── ec2.tf                    # EC2 t2.micro + EIP + IAM Role + user_data
-│       ├── outputs.tf                # EC2 IP, RDS 엔드포인트, ECR URL
+│       ├── monitoring.tf             # SNS 알림 + CloudWatch 알람/로그/대시보드
+│       ├── outputs.tf                # EC2 IP, RDS 엔드포인트, ECR URL, SNS ARN
 │       ├── docker-compose.prod.yml   # 프로덕션 컨테이너 (api + nginx)
 │       ├── deploy.sh                 # ECR 로그인 → pull → up -d
 │       ├── .env.example              # 환경변수 템플릿
@@ -524,7 +525,25 @@ develop push → GitHub Actions
 - `/` → `try_files $uri $uri/ /index.html` (SPA fallback)
 - 정적 에셋 1년 캐시, gzip 압축
 
-### 15.7 초기 설정 (사용자 작업)
+### 15.7 모니터링/알림 (`monitoring.tf`)
+
+**SNS 알림**: `alert_email` 변수 설정 시 이메일 구독 자동 생성 (구독 확인 필요)
+
+**CloudWatch 알람** (5개):
+
+| 알람 | 조건 | 기간 |
+|------|------|------|
+| EC2 CPU High | CPU > 80% | 5분 × 2회 |
+| EC2 Status Check | StatusCheckFailed > 0 | 5분 × 2회 |
+| RDS CPU High | CPU > 80% | 5분 × 2회 |
+| RDS Storage Low | FreeStorage < 5GB | 5분 × 1회 |
+| RDS Connections High | Connections > 30 | 5분 × 2회 |
+
+**CloudWatch 로그**: Docker `awslogs` 드라이버로 API/Nginx 컨테이너 로그 자동 전송 (14일 보관, 멀티라인 패턴 적용)
+
+**CloudWatch 대시보드**: EC2 CPU/네트워크, RDS CPU/연결수/스토리지, API 에러 로그, Nginx 5xx 로그
+
+### 15.8 초기 설정 (사용자 작업)
 
 1. AWS CLI + Terraform 설치
 2. `aws ec2 create-key-pair --key-name eunhye-staging` → PEM 저장
@@ -588,11 +607,16 @@ develop push → GitHub Actions
 - 프로덕션 Docker Compose + 배포 스크립트
 - GitHub Actions 자동 배포 워크플로우 (develop push → ECR push → EC2 deploy)
 
+**모니터링/알림 (CloudWatch)**
+- SNS 토픽 + 이메일 구독 (alert_email 변수)
+- CloudWatch 알람 5개 (EC2 CPU/StatusCheck, RDS CPU/Storage/Connections)
+- CloudWatch 로그 그룹 2개 (API, Nginx) + Docker awslogs 드라이버 (멀티라인 패턴)
+- CloudWatch 대시보드 (EC2/RDS 메트릭 + 에러 로그 쿼리)
+- EC2 IAM 정책 (CloudWatch Logs 전송 권한, account ID 스코핑)
+
 ### 미완료 (우선순위순)
 
-**1. 모니터링/알림**: CloudWatch, 에러 추적
-
-**2. 모바일 앱**: Flutter (코드 없음)
+**1. 모바일 앱**: Flutter (코드 없음)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ Eunhye_Hymn/
 │       ├── monitoring.tf             # SNS 알림 + CloudWatch 알람/로그/대시보드
 │       ├── outputs.tf                # EC2 IP, RDS 엔드포인트, ECR URL, SNS ARN
 │       ├── docker-compose.prod.yml   # 프로덕션 컨테이너 (api + nginx)
+│       ├── docker-compose.prod.awslogs.yml # CloudWatch 로그 오버레이 (옵션)
 │       ├── deploy.sh                 # ECR 로그인 → pull → up -d
 │       ├── .env.example              # 환경변수 템플릿
 │       └── .gitignore                # tfstate, .terraform 제외
@@ -439,7 +440,7 @@ com.eunhyehymn/
 ### Deploy Staging (`deploy-staging.yml`)
 - **트리거**: develop push
 - **Jobs**: `test-api` → `check-admin` → `build-and-push` → `deploy`
-- **단계**: API 테스트 → Admin 타입체크+빌드 → Docker 이미지 빌드 & ECR push (api:latest + admin:latest) → EC2 SSH 배포 (deploy.sh) → 헬스체크
+- **단계**: API 테스트 → Admin 타입체크+빌드 → Docker 이미지 빌드 & ECR push (api:latest + admin:latest) → EC2 SSH 배포 (compose + awslogs 오버레이 + deploy.sh) → 헬스체크
 - **필수 Secrets**:
 
 | Secret | 설명 |
@@ -451,6 +452,7 @@ com.eunhyehymn/
 | `EC2_HOST` | EC2 Elastic IP (`terraform output ec2_public_ip`) |
 | `EC2_SSH_KEY` | EC2 SSH 프라이빗 키 (PEM) |
 | `DEPLOY_ENV_FILE` | `.env` 파일 전체 내용 (DB, JWT, S3 등) |
+| `ENABLE_AWSLOGS` | CloudWatch 로그 전송 활성화 여부 (`true` 시 활성화, 미설정 시 기본 `false`) |
 
 ---
 
@@ -504,7 +506,7 @@ develop push → GitHub Actions
   1. test-api (Gradle test)
   2. check-admin (tsc + vite build)
   3. build-and-push (Docker build → ECR push, :latest + :sha 태그)
-  4. deploy (SCP compose/deploy.sh → SSH deploy.sh 실행)
+  4. deploy (SCP compose + awslogs 오버레이 + deploy.sh → SSH deploy.sh 실행)
      └─ ECR login → docker compose pull → up -d → image prune
 ```
 
@@ -517,6 +519,7 @@ develop push → GitHub Actions
 
 - `api`는 `.env` 파일에서 DB_URL, JWT_SECRET 등 환경변수 로드
 - `nginx`는 `nginx.conf`에서 `/api/v1` → `http://api:8080` 프록시
+- 기본 로깅 드라이버는 `json-file`; `ENABLE_AWSLOGS=true`일 때 `docker-compose.prod.awslogs.yml` 오버레이로 CloudWatch 로그 전송 활성화
 
 ### 15.6 Nginx 설정 (`apps/admin/nginx.conf`)
 
@@ -539,7 +542,7 @@ develop push → GitHub Actions
 | RDS Storage Low | FreeStorage < 5GB | 5분 × 1회 |
 | RDS Connections High | Connections > 30 | 5분 × 2회 |
 
-**CloudWatch 로그**: Docker `awslogs` 드라이버로 API/Nginx 컨테이너 로그 자동 전송 (14일 보관, 멀티라인 패턴 적용)
+**CloudWatch 로그**: `docker-compose.prod.awslogs.yml` 오버레이 + `ENABLE_AWSLOGS=true` 설정 시 API/Nginx 컨테이너 로그를 CloudWatch로 전송 (14일 보관, 멀티라인 패턴 적용)
 
 **CloudWatch 대시보드**: EC2 CPU/네트워크, RDS CPU/연결수/스토리지, API 에러 로그, Nginx 5xx 로그
 
@@ -610,7 +613,7 @@ develop push → GitHub Actions
 **모니터링/알림 (CloudWatch)**
 - SNS 토픽 + 이메일 구독 (alert_email 변수)
 - CloudWatch 알람 5개 (EC2 CPU/StatusCheck, RDS CPU/Storage/Connections)
-- CloudWatch 로그 그룹 2개 (API, Nginx) + Docker awslogs 드라이버 (멀티라인 패턴)
+- CloudWatch 로그 그룹 2개 (API, Nginx) + 선택적 Docker awslogs 오버레이 (기본 json-file)
 - CloudWatch 대시보드 (EC2/RDS 메트릭 + 에러 로그 쿼리)
 - EC2 IAM 정책 (CloudWatch Logs 전송 권한, account ID 스코핑)
 

--- a/infra/aws/.env.example
+++ b/infra/aws/.env.example
@@ -1,8 +1,9 @@
 # Production environment variables for docker-compose.prod.yml
 # Copy to .env and fill in values from terraform output
 
-# ── ECR ──────────────────────────────────────────────────────
+# ── ECR / AWS ────────────────────────────────────────────────
 ECR_REGISTRY=123456789012.dkr.ecr.ap-northeast-2.amazonaws.com
+AWS_REGION=ap-northeast-2
 
 # ── Database (from terraform output: rds_endpoint) ──────────
 DB_URL=jdbc:postgresql://eunhye-hymn-db.xxxx.ap-northeast-2.rds.amazonaws.com:5432/eunhye_hymn

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -105,6 +105,7 @@ GitHub 리포지토리 → Settings → Secrets and variables → Actions에 등
 | `EC2_HOST` | `terraform output ec2_public_ip` | Terraform |
 | `EC2_SSH_KEY` | `eunhye-staging.pem` 파일 내용 | 키페어 생성 시 |
 | `DEPLOY_ENV_FILE` | `.env` 파일 전체 내용 (아래 참조) | 직접 작성 |
+| `ENABLE_AWSLOGS` | `true` 또는 빈값(기본) | 선택 (Terraform 적용 후만 `true`) |
 
 ### DEPLOY_ENV_FILE 내용
 
@@ -151,13 +152,16 @@ docker push ${ECR_REGISTRY}/eunhye-hymn/admin:latest
 # 4. EC2에 파일 복사
 EC2_IP=$(terraform output -raw ec2_public_ip)
 scp -i eunhye-staging.pem infra/aws/docker-compose.prod.yml ec2-user@${EC2_IP}:/home/ec2-user/app/
+scp -i eunhye-staging.pem infra/aws/docker-compose.prod.awslogs.yml ec2-user@${EC2_IP}:/home/ec2-user/app/
 scp -i eunhye-staging.pem infra/aws/deploy.sh ec2-user@${EC2_IP}:/home/ec2-user/app/
 # .env 파일도 복사 (infra/aws/.env.example 기반으로 작성)
 
 # 5. EC2에서 배포 실행
 ssh -i eunhye-staging.pem ec2-user@${EC2_IP} \
-  "cd /home/ec2-user/app && export ECR_REGISTRY=${ECR_REGISTRY} && chmod +x deploy.sh && ./deploy.sh"
+  "cd /home/ec2-user/app && export ECR_REGISTRY=${ECR_REGISTRY} && export ENABLE_AWSLOGS=false && chmod +x deploy.sh && ./deploy.sh"
 ```
+
+`ENABLE_AWSLOGS`는 기본값 `false`입니다. 기존 스테이징 인스턴스에서 Terraform(IAM/Log Group) 적용 전에 `true`로 배포하면 컨테이너 시작이 실패할 수 있으므로, 인프라 적용 이후에만 활성화하세요.
 
 ## 검증
 
@@ -209,6 +213,7 @@ infra/aws/
 ├── ec2.tf                     # EC2 t2.micro + Elastic IP + IAM
 ├── outputs.tf                 # 출력값 (IP, 엔드포인트, URL)
 ├── docker-compose.prod.yml    # 프로덕션 컨테이너 구성
+├── docker-compose.prod.awslogs.yml # CloudWatch 로그 오버레이(옵션)
 ├── deploy.sh                  # EC2 배포 스크립트
 ├── .env.example               # 환경변수 예시
 ├── .gitignore                 # tfstate, .terraform 제외

--- a/infra/aws/deploy.sh
+++ b/infra/aws/deploy.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # ── Configuration ────────────────────────────────────────────
 APP_DIR="/home/ec2-user/app"
 COMPOSE_FILE="${APP_DIR}/docker-compose.prod.yml"
+COMPOSE_AWSLOGS_FILE="${APP_DIR}/docker-compose.prod.awslogs.yml"
 
 # Check required env
 if [ -z "${ECR_REGISTRY:-}" ]; then
@@ -14,11 +15,23 @@ fi
 if [ -z "${AWS_REGION:-}" ]; then
   AWS_REGION="ap-northeast-2"
 fi
-export ECR_REGISTRY AWS_REGION
+
+ENABLE_AWSLOGS="${ENABLE_AWSLOGS:-false}"
+COMPOSE_ARGS=(-f "${COMPOSE_FILE}")
+if [ "${ENABLE_AWSLOGS}" = "true" ]; then
+  if [ -f "${COMPOSE_AWSLOGS_FILE}" ]; then
+    COMPOSE_ARGS+=(-f "${COMPOSE_AWSLOGS_FILE}")
+  else
+    echo "WARNING: ${COMPOSE_AWSLOGS_FILE} not found; falling back to default json-file logging."
+  fi
+fi
+
+export ECR_REGISTRY AWS_REGION ENABLE_AWSLOGS
 
 echo "=== Eunhye Hymn Deploy ==="
 echo "ECR Registry: ${ECR_REGISTRY}"
 echo "AWS Region:   ${AWS_REGION}"
+echo "AWS Logs:     ${ENABLE_AWSLOGS}"
 
 # ── 1. ECR Login ─────────────────────────────────────────────
 echo "[1/4] Logging in to ECR..."
@@ -27,15 +40,15 @@ aws ecr get-login-password --region "${AWS_REGION}" | \
 
 # ── 2. Pull latest images ───────────────────────────────────
 echo "[2/4] Pulling latest images..."
-docker compose -f "${COMPOSE_FILE}" pull
+docker compose "${COMPOSE_ARGS[@]}" pull
 
 # ── 3. Restart containers ───────────────────────────────────
 echo "[3/4] Restarting containers..."
-docker compose -f "${COMPOSE_FILE}" up -d --remove-orphans
+docker compose "${COMPOSE_ARGS[@]}" up -d --remove-orphans
 
 # ── 4. Cleanup old images ───────────────────────────────────
 echo "[4/4] Cleaning up unused images..."
 docker image prune -f
 
 echo "=== Deploy complete ==="
-docker compose -f "${COMPOSE_FILE}" ps
+docker compose "${COMPOSE_ARGS[@]}" ps

--- a/infra/aws/deploy.sh
+++ b/infra/aws/deploy.sh
@@ -14,6 +14,7 @@ fi
 if [ -z "${AWS_REGION:-}" ]; then
   AWS_REGION="ap-northeast-2"
 fi
+export ECR_REGISTRY AWS_REGION
 
 echo "=== Eunhye Hymn Deploy ==="
 echo "ECR Registry: ${ECR_REGISTRY}"

--- a/infra/aws/docker-compose.prod.awslogs.yml
+++ b/infra/aws/docker-compose.prod.awslogs.yml
@@ -1,0 +1,19 @@
+services:
+  api:
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: ${AWS_REGION:-ap-northeast-2}
+        awslogs-group: /eunhye-hymn/api
+        awslogs-stream-prefix: api
+        awslogs-create-group: "true"
+        awslogs-multiline-pattern: '^\d{4}-\d{2}-\d{2}'
+
+  nginx:
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: ${AWS_REGION:-ap-northeast-2}
+        awslogs-group: /eunhye-hymn/nginx
+        awslogs-stream-prefix: nginx
+        awslogs-create-group: "true"

--- a/infra/aws/docker-compose.prod.yml
+++ b/infra/aws/docker-compose.prod.yml
@@ -5,6 +5,14 @@ services:
     container_name: eunhye-api
     restart: unless-stopped
     env_file: .env
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: ${AWS_REGION:-ap-northeast-2}
+        awslogs-group: /eunhye-hymn/api
+        awslogs-stream-prefix: api
+        awslogs-create-group: "true"
+        awslogs-multiline-pattern: '^\d{4}-\d{2}-\d{2}'
     networks:
       - app-net
     healthcheck:
@@ -21,6 +29,13 @@ services:
     restart: unless-stopped
     ports:
       - "80:80"
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: ${AWS_REGION:-ap-northeast-2}
+        awslogs-group: /eunhye-hymn/nginx
+        awslogs-stream-prefix: nginx
+        awslogs-create-group: "true"
     depends_on:
       api:
         condition: service_healthy

--- a/infra/aws/docker-compose.prod.yml
+++ b/infra/aws/docker-compose.prod.yml
@@ -1,3 +1,9 @@
+x-default-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
 services:
   # ── Spring Boot API ──────────────────────────────────────────
   api:
@@ -5,14 +11,7 @@ services:
     container_name: eunhye-api
     restart: unless-stopped
     env_file: .env
-    logging:
-      driver: awslogs
-      options:
-        awslogs-region: ${AWS_REGION:-ap-northeast-2}
-        awslogs-group: /eunhye-hymn/api
-        awslogs-stream-prefix: api
-        awslogs-create-group: "true"
-        awslogs-multiline-pattern: '^\d{4}-\d{2}-\d{2}'
+    logging: *default-logging
     networks:
       - app-net
     healthcheck:
@@ -29,13 +28,7 @@ services:
     restart: unless-stopped
     ports:
       - "80:80"
-    logging:
-      driver: awslogs
-      options:
-        awslogs-region: ${AWS_REGION:-ap-northeast-2}
-        awslogs-group: /eunhye-hymn/nginx
-        awslogs-stream-prefix: nginx
-        awslogs-create-group: "true"
+    logging: *default-logging
     depends_on:
       api:
         condition: service_healthy

--- a/infra/aws/ec2.tf
+++ b/infra/aws/ec2.tf
@@ -15,6 +15,8 @@ data "aws_ami" "amazon_linux" {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
 # ── IAM Role for EC2 (ECR pull + S3 access) ─────────────────
 
 resource "aws_iam_role" "ec2" {
@@ -72,6 +74,26 @@ resource "aws_iam_role_policy" "ec2_s3" {
           aws_s3_bucket.assets.arn,
           "${aws_s3_bucket.assets.arn}/*"
         ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "ec2_cloudwatch" {
+  name = "cloudwatch-logs"
+  role = aws_iam_role.ec2.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams"
+        ]
+        Resource = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/${var.project_name}/*"
       }
     ]
   })

--- a/infra/aws/monitoring.tf
+++ b/infra/aws/monitoring.tf
@@ -1,0 +1,257 @@
+# ── SNS Topic (알림 수신) ────────────────────────────────────
+
+resource "aws_sns_topic" "alerts" {
+  name = "${var.project_name}-alerts"
+
+  tags = { Name = "${var.project_name}-alerts" }
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  count     = var.alert_email != "" ? 1 : 0
+  topic_arn = aws_sns_topic.alerts.arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+# ── CloudWatch Log Groups (Docker 컨테이너 로그) ────────────
+
+resource "aws_cloudwatch_log_group" "api" {
+  name              = "/${var.project_name}/api"
+  retention_in_days = 14
+
+  tags = { Name = "${var.project_name}-api-logs" }
+}
+
+resource "aws_cloudwatch_log_group" "nginx" {
+  name              = "/${var.project_name}/nginx"
+  retention_in_days = 14
+
+  tags = { Name = "${var.project_name}-nginx-logs" }
+}
+
+# ── EC2 Alarms ──────────────────────────────────────────────
+
+resource "aws_cloudwatch_metric_alarm" "ec2_cpu_high" {
+  alarm_name          = "${var.project_name}-ec2-cpu-high"
+  alarm_description   = "EC2 CPU utilization > 80% for 5 minutes"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    InstanceId = aws_instance.app.id
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+
+  tags = { Name = "${var.project_name}-ec2-cpu-high" }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ec2_status_check" {
+  alarm_name          = "${var.project_name}-ec2-status-check"
+  alarm_description   = "EC2 instance or system status check failed"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "StatusCheckFailed"
+  namespace           = "AWS/EC2"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 0
+  treat_missing_data  = "breaching"
+
+  dimensions = {
+    InstanceId = aws_instance.app.id
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+
+  tags = { Name = "${var.project_name}-ec2-status-check" }
+}
+
+# ── RDS Alarms ──────────────────────────────────────────────
+
+resource "aws_cloudwatch_metric_alarm" "rds_cpu_high" {
+  alarm_name          = "${var.project_name}-rds-cpu-high"
+  alarm_description   = "RDS CPU utilization > 80% for 5 minutes"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.main.identifier
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+  ok_actions    = [aws_sns_topic.alerts.arn]
+
+  tags = { Name = "${var.project_name}-rds-cpu-high" }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_storage_low" {
+  alarm_name          = "${var.project_name}-rds-storage-low"
+  alarm_description   = "RDS free storage < 5GB (25% of 20GB)"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "FreeStorageSpace"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 5368709120 # 5GB in bytes (25% of 20GB Free Tier)
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.main.identifier
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+
+  tags = { Name = "${var.project_name}-rds-storage-low" }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_connections_high" {
+  alarm_name          = "${var.project_name}-rds-connections-high"
+  alarm_description   = "RDS database connections > 30 (t3.micro max ~58)"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "DatabaseConnections"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 30
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.main.identifier
+  }
+
+  alarm_actions = [aws_sns_topic.alerts.arn]
+
+  tags = { Name = "${var.project_name}-rds-connections-high" }
+}
+
+# ── CloudWatch Dashboard ────────────────────────────────────
+
+resource "aws_cloudwatch_dashboard" "main" {
+  dashboard_name = "${var.project_name}-${var.environment}"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "metric"
+        x      = 0
+        y      = 0
+        width  = 12
+        height = 6
+        properties = {
+          title   = "EC2 CPU Utilization"
+          metrics = [["AWS/EC2", "CPUUtilization", "InstanceId", aws_instance.app.id]]
+          period  = 300
+          stat    = "Average"
+          region  = var.aws_region
+          view    = "timeSeries"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 0
+        width  = 12
+        height = 6
+        properties = {
+          title = "EC2 Network"
+          metrics = [
+            ["AWS/EC2", "NetworkIn", "InstanceId", aws_instance.app.id],
+            ["AWS/EC2", "NetworkOut", "InstanceId", aws_instance.app.id]
+          ]
+          period = 300
+          stat   = "Sum"
+          region = var.aws_region
+          view   = "timeSeries"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 6
+        width  = 8
+        height = 6
+        properties = {
+          title   = "RDS CPU Utilization"
+          metrics = [["AWS/RDS", "CPUUtilization", "DBInstanceIdentifier", aws_db_instance.main.identifier]]
+          period  = 300
+          stat    = "Average"
+          region  = var.aws_region
+          view    = "timeSeries"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 8
+        y      = 6
+        width  = 8
+        height = 6
+        properties = {
+          title   = "RDS Connections"
+          metrics = [["AWS/RDS", "DatabaseConnections", "DBInstanceIdentifier", aws_db_instance.main.identifier]]
+          period  = 300
+          stat    = "Average"
+          region  = var.aws_region
+          view    = "timeSeries"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 16
+        y      = 6
+        width  = 8
+        height = 6
+        properties = {
+          title   = "RDS Free Storage (GB)"
+          metrics = [["AWS/RDS", "FreeStorageSpace", "DBInstanceIdentifier", aws_db_instance.main.identifier]]
+          period  = 300
+          stat    = "Average"
+          region  = var.aws_region
+          view    = "timeSeries"
+          yAxis   = { left = { label = "Bytes" } }
+        }
+      },
+      {
+        type   = "log"
+        x      = 0
+        y      = 12
+        width  = 12
+        height = 6
+        properties = {
+          title   = "API Logs (Recent Errors)"
+          query   = "SOURCE '/${var.project_name}/api' | fields @timestamp, @message | filter @message like /(?i)(error|exception|fail)/ | sort @timestamp desc | limit 20"
+          region  = var.aws_region
+          view    = "table"
+        }
+      },
+      {
+        type   = "log"
+        x      = 12
+        y      = 12
+        width  = 12
+        height = 6
+        properties = {
+          title   = "Nginx Logs (5xx Errors)"
+          query   = "SOURCE '/${var.project_name}/nginx' | fields @timestamp, @message | filter @message like /\" [5]\\d{2} / | sort @timestamp desc | limit 20"
+          region  = var.aws_region
+          view    = "table"
+        }
+      }
+    ]
+  })
+}

--- a/infra/aws/outputs.tf
+++ b/infra/aws/outputs.tf
@@ -37,3 +37,13 @@ output "ecr_registry" {
   description = "ECR registry URL (account.dkr.ecr.region.amazonaws.com)"
   value       = split("/", aws_ecr_repository.api.repository_url)[0]
 }
+
+output "sns_topic_arn" {
+  description = "SNS topic ARN for CloudWatch alarms"
+  value       = aws_sns_topic.alerts.arn
+}
+
+output "cloudwatch_dashboard_url" {
+  description = "CloudWatch dashboard URL"
+  value       = "https://${var.aws_region}.console.aws.amazon.com/cloudwatch/home?region=${var.aws_region}#dashboards:name=${var.project_name}-${var.environment}"
+}

--- a/infra/aws/terraform.tfvars.example
+++ b/infra/aws/terraform.tfvars.example
@@ -19,5 +19,8 @@ jwt_refresh_ttl = 604800
 invite_code     = "CHANGE_ME_invite_code"
 
 # ── Optional ─────────────────────────────────────────────────
-google_client_id = ""
+google_client_id  = ""
 allowed_ssh_cidrs = ["0.0.0.0/0"]   # restrict to your IP for security
+
+# ── Monitoring ───────────────────────────────────────────────
+alert_email = ""   # CloudWatch 알람 수신 이메일 (빈값이면 구독 생략)

--- a/infra/aws/variables.tf
+++ b/infra/aws/variables.tf
@@ -93,3 +93,11 @@ variable "allowed_ssh_cidrs" {
   type        = list(string)
   default     = ["0.0.0.0/0"]
 }
+
+# ── Monitoring ───────────────────────────────────────────────
+
+variable "alert_email" {
+  description = "Email address to receive CloudWatch alarm notifications (empty = no email subscription)"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- SNS 토픽 + 이메일 구독으로 CloudWatch 알람 알림 전달
- CloudWatch 알람 5개: EC2 CPU(>80%)/StatusCheck, RDS CPU(>80%)/Storage(<5GB)/Connections(>30)
- Docker `awslogs` 드라이버로 API/Nginx 컨테이너 로그를 CloudWatch Logs에 자동 전송 (14일 보관)
- CloudWatch 대시보드: EC2/RDS 메트릭 6개 위젯 + API 에러 로그 + Nginx 5xx 로그 쿼리

## 변경 파일

| 파일 | 변경 |
|------|------|
| `infra/aws/monitoring.tf` | **신규** — SNS, 알람 5개, 로그 그룹 2개, 대시보드 |
| `infra/aws/ec2.tf` | IAM 정책 추가 (CloudWatch Logs 전송, account ID 스코핑) |
| `infra/aws/variables.tf` | `alert_email` 변수 추가 |
| `infra/aws/terraform.tfvars.example` | `alert_email` 항목 추가 |
| `infra/aws/outputs.tf` | SNS ARN, 대시보드 URL 출력 추가 |
| `infra/aws/docker-compose.prod.yml` | `awslogs` 로깅 드라이버 + 멀티라인 패턴 |
| `infra/aws/deploy.sh` | ECR_REGISTRY, AWS_REGION export 추가 |
| `infra/aws/.env.example` | AWS_REGION 항목 추가 |
| `CLAUDE.md` | 모니터링 섹션 추가, 진행 상태 업데이트 |

## Free Tier 범위

| 항목 | Free Tier 한도 |
|------|----------------|
| CloudWatch 알람 | 10개 (사용 5개) |
| CloudWatch 대시보드 | 3개 (사용 1개) |
| SNS 이메일 | 1,000건/월 |
| CloudWatch Logs | 5GB 수집 + 5GB 보관 |

## Test plan
- [ ] `terraform validate` — Terraform 문법 검증
- [ ] `terraform plan` — 리소스 목록 확인 (SNS, 알람 5개, 로그 그룹 2개, 대시보드)
- [ ] `terraform apply` 후 alert_email로 SNS 구독 확인 이메일 수신
- [ ] Docker Compose 재배포 후 CloudWatch Logs에 API/Nginx 로그 표시 확인
- [ ] CloudWatch 대시보드에서 EC2/RDS 메트릭 그래프 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)