### PR TITLE
feat(mobile): Flutter MVP 앱 추가 (로그인/찬양/메모/히스토리)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
 ```
 Eunhye_Hymn/
 ├── apps/
-│   ├── api/              # Spring Boot 백엔드 (Java 17, Gradle) ← MVP 완료 (24 UseCase)
+│   ├── api/              # Spring Boot 백엔드 (Java 17, Gradle) ← MVP 완료 (25 UseCase)
 │   │   └── Dockerfile    # Multi-stage (JDK build → JRE run + curl for healthcheck)
 │   ├── admin/            # React + Vite + TypeScript 관리자 웹  ← 7페이지 완료
 │   │   ├── Dockerfile    # Multi-stage (Node build → Nginx serve)
@@ -143,7 +143,7 @@ com.eunhyehymn/
 │   └── repository/     # Repository 인터페이스
 ├── application/
 │   ├── ports/          # 외부 서비스 인터페이스 (SocialTokenVerifier)
-│   └── usecases/       # 비즈니스 로직 Use Cases (24개)
+│   └── usecases/       # 비즈니스 로직 Use Cases (25개)
 ├── presentation/
 │   ├── controllers/    # REST 컨트롤러 (10개)
 │   └── dto/            # Request/Response DTOs
@@ -245,6 +245,7 @@ com.eunhyehymn/
 | Method | Path | 인증 | 설명 |
 |--------|------|------|------|
 | GET | `/me/profile` | 필요 | 프로필 → `{userId, role}` |
+| GET | `/me/favorites/{hymnId}` | 필요 | 즐겨찾기 상태 조회 → `FavoriteResponse` |
 | POST | `/me/favorites/{hymnId}` | 필요 | 즐겨찾기 토글 → `FavoriteResponse` |
 | GET | `/me/hymns/{hymnId}/note` | 필요 | 메모 조회 → `NoteResponse` |
 | PUT | `/me/hymns/{hymnId}/note` | 필요 | 메모 저장 (NoteRequest) |
@@ -265,7 +266,7 @@ com.eunhyehymn/
 
 ---
 
-## 8. Use Cases (24개)
+## 8. Use Cases (25개)
 
 | Use Case | 메서드 | 핵심 로직 |
 |----------|--------|-----------|
@@ -280,6 +281,7 @@ com.eunhyehymn/
 | `AdminDeleteAssetUseCase` | `delete(assetId)` | 단일 에셋 삭제 |
 | `GetHymnNoteUseCase` | `get(userId, hymnId)` | 메모 조회 |
 | `SaveHymnNoteUseCase` | `save(userId, hymnId, content)` | 메모 upsert |
+| `GetFavoriteUseCase` | `get(userId, hymnId)` | 즐겨찾기 상태 조회 (없으면 false) |
 | `ToggleFavoriteUseCase` | `toggle(userId, hymnId)` | 즐겨찾기 토글 (없으면 true, 있으면 반전) |
 | `GetHistoryUseCase` | `getHistory(userId)` | lastOpenedAt desc 정렬 |
 | `SocialLoginUseCase` | `login(provider, token, inviteCode?)` | Google/Kakao 토큰 검증, 신규 사용자는 초대코드 필요 |
@@ -604,7 +606,7 @@ develop push → GitHub Actions
 
 ### 완료
 
-**백엔드 API (24 UseCase, 10 Controller)**
+**백엔드 API (25 UseCase, 10 Controller)**
 - 찬양 CRUD + 삭제 (cascade: 에셋/메모/상태/이벤트)
 - S3 에셋 관리 (presign/confirm/삭제)
 - JWT 인증 + 소셜 로그인 (Google/Kakao) + 토큰 회전

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Eunhye_Hymn/
 │   ├── admin/            # React + Vite + TypeScript 관리자 웹  ← 7페이지 완료
 │   │   ├── Dockerfile    # Multi-stage (Node build → Nginx serve)
 │   │   └── nginx.conf    # 정적 파일 serve + /api/v1 프록시 + SPA fallback
-│   └── mobile/           # Flutter 모바일 (placeholder)
+│   └── mobile/           # Flutter 모바일 앱 (MVP: 로그인/목록/상세/메모/히스토리)
 ├── infra/
 │   ├── docker/           # 로컬 Docker Compose (PostgreSQL + LocalStack + API)
 │   └── aws/              # AWS Staging 인프라 (아래 상세)
@@ -70,6 +70,7 @@ Eunhye_Hymn/
 | Security | Spring Security + JWT | - |
 | Frontend | React + TypeScript | 18.3.1 / 5.6.3 |
 | Frontend Build | Vite | 5.4.10 |
+| Mobile | Flutter + Dart | 3.24+ / 3.4+ |
 | CI/CD | GitHub Actions | - |
 | IaC | Terraform | ~> 5.0 (AWS provider) |
 | Container | Docker + Nginx | - |
@@ -377,7 +378,7 @@ com.eunhyehymn/
 
 ---
 
-## 13. Admin 프론트엔드 현황
+## 13. 프론트엔드 현황 (Admin + Mobile)
 
 ### 기술 스택
 - React 18 + TypeScript + Vite (ESM, `"type": "module"`)
@@ -420,6 +421,36 @@ com.eunhyehymn/
 | `/assets/upload` | AdminAssetUploadPage | 필요 |
 | `/users` | UserListPage | 필요 |
 | `/invite-codes` | InviteCodePage | 필요 |
+
+### Mobile 앱 (Flutter MVP)
+
+#### 기술 스택
+- Flutter (Material 3) + Dart
+- `http` 기반 API 클라이언트
+- `shared_preferences` 토큰 저장
+- API Base URL: `--dart-define=API_BASE_URL=...` 주입
+
+#### 구현된 기능
+
+| 파일 | 역할 |
+|------|------|
+| `lib/src/core/network/api_client.dart` | 공통 HTTP 클라이언트, API envelope 파싱, **401 시 자동 토큰 갱신 후 재시도** |
+| `lib/src/core/storage/token_storage.dart` | Access/Refresh 토큰 로컬 저장/조회/삭제 |
+| `lib/src/features/auth/auth_repository.dart` | 소셜/Dev 로그인, 프로필 조회, 로그아웃 |
+| `lib/src/features/auth/login_page.dart` | 소셜 토큰 입력 로그인 + Dev 로그인 UI |
+| `lib/src/features/hymn/hymn_repository.dart` | 찬양 목록/상세, 즐겨찾기, 메모, 히스토리 API |
+| `lib/src/features/hymn/hymn_list_page.dart` | 찬양 목록 + 검색 |
+| `lib/src/features/hymn/hymn_detail_page.dart` | 찬양 상세 + PNG 에셋 표시 + 즐겨찾기 + 메모 저장 |
+| `lib/src/features/history/history_page.dart` | 최근 열람 히스토리 목록 |
+| `lib/src/app.dart` | 앱 부트스트랩, 세션 복구, 탭 네비게이션(찬양/히스토리), 로그아웃 |
+
+#### 화면/네비게이션
+
+| 화면 | 경로(개념) | 설명 |
+|------|------------|------|
+| LoginPage | 앱 시작 | 소셜 토큰/Dev 로그인 |
+| Home(탭) | 로그인 후 기본 | 찬양 목록 탭 + 최근 열람 탭 |
+| HymnDetailPage | 목록/히스토리 진입 | 상세 정보, 에셋, 메모, 즐겨찾기 |
 
 ---
 
@@ -593,6 +624,14 @@ develop push → GitHub Actions
 - 인증 컨텍스트 (`loginWithSocial`, `setTokensAndUser`), 공통 API 클라이언트, 사이드바 레이아웃
 - Dev Login (개발용, 접이식)
 
+**Mobile 앱 (Flutter MVP)**
+- 소셜 토큰 입력 로그인 + Dev 로그인
+- 찬양 목록/검색 + 상세 조회
+- PNG 에셋 표시 + 메모 조회/저장
+- 즐겨찾기 토글 + 최근 열람 히스토리
+- Access Token 자동 갱신 (401 → refresh → 재시도)
+- 토큰 로컬 저장(shared_preferences) + 세션 복구
+
 **인프라/CI**
 - Docker Compose (PostgreSQL + LocalStack + API)
 - API Dockerfile (multi-stage)
@@ -619,7 +658,13 @@ develop push → GitHub Actions
 
 ### 미완료 (우선순위순)
 
-**1. 모바일 앱**: Flutter (코드 없음)
+**1. 모바일 고도화**
+- 소셜 SDK 직접 연동 (현재는 토큰 입력 방식)
+- MIDI 재생 UX (앱 내 플레이어)
+- 오프라인 캐시/동기화
+
+**2. 모바일 CI**
+- mobile lint/test 워크플로우 추가
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ PostgreSQL, LocalStack(S3), API 서버가 함께 실행됩니다.
 | | `PATCH /admin/users/{id}` | 역할/상태 변경 |
 | 초대코드 (관리자) | `POST /admin/invite-codes` | 초대코드 생성 |
 | | `DELETE /admin/invite-codes/{code}` | 비활성화 |
-| 멤버 | `POST /me/favorites/{hymnId}` | 즐겨찾기 토글 |
+| 멤버 | `GET /me/favorites/{hymnId}` | 즐겨찾기 상태 조회 |
+| | `POST /me/favorites/{hymnId}` | 즐겨찾기 토글 |
 | | `PUT /me/hymns/{hymnId}/note` | 메모 저장 |
 | | `GET /me/history` | 히스토리 |
 | 헬스체크 | `GET /ping` | `{ "ok": true }` |

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 apps/
   api/      Spring Boot 백엔드 (Java 17, Gradle)
   admin/    React 관리자 웹 (TypeScript, Vite, Tailwind CSS)
-  mobile/   Flutter 모바일 앱 (미구현)
+  mobile/   Flutter 모바일 앱 (MVP)
 infra/
   docker/   Docker Compose (PostgreSQL + LocalStack + API)
-  aws/      AWS 인프라 (미구현)
+  aws/      AWS Staging 인프라 (Terraform)
 docs/       프로젝트 문서
 ```
 
@@ -37,10 +37,22 @@ docs/       프로젝트 문서
 - Google/Kakao 소셜 로그인 + Dev 로그인 (개발용)
 - Access Token 만료 시 자동 갱신
 
+### 모바일 앱 (Flutter MVP)
+
+- 소셜 토큰 기반 로그인 + Dev 로그인
+- 찬양 목록 조회 + 검색
+- 찬양 상세 조회 (PNG 에셋 미리보기)
+- 즐겨찾기 토글
+- 메모 조회/저장
+- 최근 열람 히스토리
+- Access Token 만료 시 자동 갱신
+
 ## 문서
 
 - 현재 사용 가능 범위: [docs/current-usable-scope.md](./docs/current-usable-scope.md)
 - 운영 런북(스테이징): [docs/runbook.md](./docs/runbook.md)
+- 모바일 문서: [docs/mobile/README.md](./docs/mobile/README.md)
+- 모바일 앱 README: [apps/mobile/README.md](./apps/mobile/README.md)
 - 작업 기준 문서: [CLAUDE.md](./CLAUDE.md)
 
 ## 시작하기
@@ -50,6 +62,7 @@ docs/       프로젝트 문서
 - Java 17
 - Node.js 20+
 - PostgreSQL 15 (또는 Docker)
+- Flutter 3.24+
 
 ### 백엔드 실행
 
@@ -83,6 +96,16 @@ npm run dev
 ```
 
 `http://localhost:5173` 에서 실행됩니다. API 요청은 Vite 프록시를 통해 `localhost:8080`으로 전달됩니다.
+
+### 모바일 앱 실행
+
+```bash
+cd apps/mobile
+flutter pub get
+flutter run --dart-define=API_BASE_URL=http://10.0.2.2:8080/api/v1
+```
+
+실기기에서는 `10.0.2.2` 대신 로컬 서버 IP를 사용하세요.
 
 ### Docker로 한 번에 실행
 

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/GetFavoriteUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/GetFavoriteUseCase.java
@@ -1,0 +1,18 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.domain.repository.UserHymnStateRepository;
+import java.util.UUID;
+
+public class GetFavoriteUseCase {
+    private final UserHymnStateRepository userHymnStateRepository;
+
+    public GetFavoriteUseCase(UserHymnStateRepository userHymnStateRepository) {
+        this.userHymnStateRepository = userHymnStateRepository;
+    }
+
+    public boolean get(UUID userId, UUID hymnId) {
+        return userHymnStateRepository.findByUserIdAndHymnId(userId, hymnId)
+            .map(state -> state.favorite())
+            .orElse(false);
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/UseCaseConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/UseCaseConfig.java
@@ -6,6 +6,7 @@ import com.eunhyehymn.application.usecases.AdminListHymnsUseCase;
 import com.eunhyehymn.application.usecases.AdminListUsersUseCase;
 import com.eunhyehymn.application.usecases.AdminUpdateHymnUseCase;
 import com.eunhyehymn.application.usecases.AdminUpdateUserUseCase;
+import com.eunhyehymn.application.usecases.GetFavoriteUseCase;
 import com.eunhyehymn.application.usecases.GetHistoryUseCase;
 import com.eunhyehymn.application.usecases.GetHymnDetailUseCase;
 import com.eunhyehymn.application.usecases.GetHymnNoteUseCase;
@@ -41,6 +42,11 @@ public class UseCaseConfig {
     @Bean
     ToggleFavoriteUseCase toggleFavoriteUseCase(UserHymnStateRepository userHymnStateRepository) {
         return new ToggleFavoriteUseCase(userHymnStateRepository);
+    }
+
+    @Bean
+    GetFavoriteUseCase getFavoriteUseCase(UserHymnStateRepository userHymnStateRepository) {
+        return new GetFavoriteUseCase(userHymnStateRepository);
     }
 
     @Bean

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/MeController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/MeController.java
@@ -1,6 +1,7 @@
 package com.eunhyehymn.presentation.controllers;
 
 import com.eunhyehymn.application.usecases.GetHistoryUseCase;
+import com.eunhyehymn.application.usecases.GetFavoriteUseCase;
 import com.eunhyehymn.application.usecases.GetHymnNoteUseCase;
 import com.eunhyehymn.application.usecases.SaveHymnNoteUseCase;
 import com.eunhyehymn.application.usecases.ToggleFavoriteUseCase;
@@ -23,17 +24,20 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public class MeController {
     private final ToggleFavoriteUseCase toggleFavoriteUseCase;
+    private final GetFavoriteUseCase getFavoriteUseCase;
     private final GetHymnNoteUseCase getHymnNoteUseCase;
     private final SaveHymnNoteUseCase saveHymnNoteUseCase;
     private final GetHistoryUseCase getHistoryUseCase;
 
     public MeController(
         ToggleFavoriteUseCase toggleFavoriteUseCase,
+        GetFavoriteUseCase getFavoriteUseCase,
         GetHymnNoteUseCase getHymnNoteUseCase,
         SaveHymnNoteUseCase saveHymnNoteUseCase,
         GetHistoryUseCase getHistoryUseCase
     ) {
         this.toggleFavoriteUseCase = toggleFavoriteUseCase;
+        this.getFavoriteUseCase = getFavoriteUseCase;
         this.getHymnNoteUseCase = getHymnNoteUseCase;
         this.saveHymnNoteUseCase = saveHymnNoteUseCase;
         this.getHistoryUseCase = getHistoryUseCase;
@@ -52,6 +56,13 @@ public class MeController {
     public ApiResponse<FavoriteResponse> toggleFavorite(@PathVariable UUID hymnId, Authentication authentication) {
         UUID userId = UUID.fromString(authentication.getName());
         boolean favorite = toggleFavoriteUseCase.toggle(userId, hymnId).favorite();
+        return ApiResponse.success(new FavoriteResponse(favorite));
+    }
+
+    @GetMapping("/favorites/{hymnId}")
+    public ApiResponse<FavoriteResponse> getFavorite(@PathVariable UUID hymnId, Authentication authentication) {
+        UUID userId = UUID.fromString(authentication.getName());
+        boolean favorite = getFavoriteUseCase.get(userId, hymnId);
         return ApiResponse.success(new FavoriteResponse(favorite));
     }
 

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/HymnApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/HymnApiTest.java
@@ -143,7 +143,17 @@ class HymnApiTest {
         UUID hymnId = UUID.randomUUID();
         hymnJpaRepository.save(new HymnEntity(hymnId, "즐겨찾기", "4", "tag", true, Instant.now()));
 
+        mockMvc.perform(get("/me/favorites/" + hymnId)
+                .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.favorite").value(false));
+
         mockMvc.perform(post("/me/favorites/" + hymnId)
+                .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.favorite").value(true));
+
+        mockMvc.perform(get("/me/favorites/" + hymnId)
                 .header("Authorization", "Bearer " + accessToken))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.favorite").value(true));

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,0 +1,62 @@
+# Eunhye Hymn Mobile (Flutter MVP)
+
+교회 멤버용 모바일 앱 MVP입니다.
+
+## 구현 범위
+
+- 로그인
+  - 소셜 로그인 API 토큰 입력 방식 (Google/Kakao)
+  - Dev 로그인 (개발 환경)
+- 찬양
+  - 목록 조회 및 검색
+  - 상세 조회 (에셋 표시)
+- 개인화
+  - 즐겨찾기 토글
+  - 메모 조회/저장
+  - 최근 열람 히스토리 조회
+- 인증
+  - Access/Refresh 토큰 로컬 저장
+  - 401 발생 시 `/auth/refresh` 자동 재시도
+
+## 실행
+
+Flutter SDK가 설치된 환경에서 실행합니다.
+
+```bash
+cd apps/mobile
+flutter pub get
+flutter run --dart-define=API_BASE_URL=http://10.0.2.2:8080/api/v1
+```
+
+기본 `API_BASE_URL`:
+
+- Android Emulator: `http://10.0.2.2:8080/api/v1`
+
+실기기 사용 시 로컬 PC IP로 변경:
+
+```bash
+flutter run --dart-define=API_BASE_URL=http://<PC_IP>:8080/api/v1
+```
+
+## 구조
+
+```
+lib/
+  main.dart
+  src/
+    app.dart
+    core/
+      config/app_config.dart
+      network/api_client.dart
+      network/api_exception.dart
+      storage/token_storage.dart
+    features/
+      auth/
+      hymn/
+      history/
+```
+
+## 주의사항
+
+- API Base path는 반드시 `/api/v1`를 포함해야 합니다.
+- Dev 로그인은 백엔드 `dev` 프로필에서만 동작합니다.

--- a/apps/mobile/analysis_options.yaml
+++ b/apps/mobile/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    avoid_print: true

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+import 'src/app.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const EunhyeMobileApp());
+}

--- a/apps/mobile/lib/src/app.dart
+++ b/apps/mobile/lib/src/app.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+
+import 'core/config/app_config.dart';
+import 'core/network/api_client.dart';
+import 'core/storage/token_storage.dart';
+import 'features/auth/auth_repository.dart';
+import 'features/auth/login_page.dart';
+import 'features/history/history_page.dart';
+import 'features/hymn/hymn_detail_page.dart';
+import 'features/hymn/hymn_list_page.dart';
+import 'features/hymn/hymn_repository.dart';
+
+class EunhyeMobileApp extends StatefulWidget {
+  const EunhyeMobileApp({super.key});
+
+  @override
+  State<EunhyeMobileApp> createState() => _EunhyeMobileAppState();
+}
+
+class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
+  late final TokenStorage _tokenStorage;
+  late final ApiClient _apiClient;
+  late final AuthRepository _authRepository;
+  late final HymnRepository _hymnRepository;
+
+  bool _initializing = true;
+  SessionProfile? _profile;
+  String? _initError;
+
+  @override
+  void initState() {
+    super.initState();
+    _tokenStorage = TokenStorage();
+    _apiClient = ApiClient(
+      baseUrl: AppConfig.apiBaseUrl,
+      tokenStorage: _tokenStorage,
+    );
+    _authRepository = AuthRepository(
+      apiClient: _apiClient,
+      tokenStorage: _tokenStorage,
+    );
+    _hymnRepository = HymnRepository(apiClient: _apiClient);
+    _bootstrap();
+  }
+
+  Future<void> _bootstrap() async {
+    setState(() {
+      _initializing = true;
+      _initError = null;
+    });
+
+    try {
+      final hasSession = await _authRepository.hasSession();
+      if (!hasSession) {
+        setState(() {
+          _profile = null;
+        });
+        return;
+      }
+
+      final profile = await _authRepository.fetchProfile();
+      if (profile == null) {
+        await _authRepository.clearSession();
+        setState(() {
+          _profile = null;
+        });
+        return;
+      }
+
+      setState(() {
+        _profile = profile;
+      });
+    } catch (e) {
+      setState(() {
+        _initError = e.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _initializing = false;
+        });
+      }
+    }
+  }
+
+  void _onLoggedIn(SessionProfile profile) {
+    setState(() {
+      _profile = profile;
+    });
+  }
+
+  Future<void> _onLogout() async {
+    await _authRepository.logout();
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _profile = null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Eunhye Hymn',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+        useMaterial3: true,
+      ),
+      home: _buildHome(),
+    );
+  }
+
+  Widget _buildHome() {
+    if (_initializing) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (_initError != null) {
+      return Scaffold(
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(_initError!, style: const TextStyle(color: Colors.red)),
+                const SizedBox(height: 12),
+                FilledButton(
+                  onPressed: _bootstrap,
+                  child: const Text('다시 시도'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    if (_profile == null) {
+      return LoginPage(
+        authRepository: _authRepository,
+        onLoggedIn: _onLoggedIn,
+      );
+    }
+
+    return _HomeShell(
+      profile: _profile!,
+      authRepository: _authRepository,
+      hymnRepository: _hymnRepository,
+      onLogout: _onLogout,
+    );
+  }
+}
+
+class _HomeShell extends StatefulWidget {
+  final SessionProfile profile;
+  final AuthRepository authRepository;
+  final HymnRepository hymnRepository;
+  final Future<void> Function() onLogout;
+
+  const _HomeShell({
+    required this.profile,
+    required this.authRepository,
+    required this.hymnRepository,
+    required this.onLogout,
+  });
+
+  @override
+  State<_HomeShell> createState() => _HomeShellState();
+}
+
+class _HomeShellState extends State<_HomeShell> {
+  int _index = 0;
+  bool _loggingOut = false;
+
+  Future<void> _openHymnDetail(String hymnId) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => HymnDetailPage(
+          hymnId: hymnId,
+          hymnRepository: widget.hymnRepository,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _handleLogout() async {
+    if (_loggingOut) {
+      return;
+    }
+    setState(() {
+      _loggingOut = true;
+    });
+    try {
+      await widget.onLogout();
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loggingOut = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final pages = <Widget>[
+      HymnListPage(
+        hymnRepository: widget.hymnRepository,
+        onOpenHymnDetail: _openHymnDetail,
+      ),
+      HistoryPage(
+        hymnRepository: widget.hymnRepository,
+        onOpenHymnDetail: _openHymnDetail,
+      ),
+    ];
+
+    final titles = ['찬양 목록', '최근 열람'];
+    final roleLabel = widget.profile.role == UserRole.admin ? 'ADMIN' : 'USER';
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('${titles[_index]} · $roleLabel'),
+        actions: [
+          IconButton(
+            onPressed: _loggingOut ? null : _handleLogout,
+            icon: const Icon(Icons.logout),
+            tooltip: '로그아웃',
+          ),
+        ],
+      ),
+      body: pages[_index],
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: _index,
+        onDestinationSelected: (index) {
+          setState(() => _index = index);
+        },
+        destinations: const [
+          NavigationDestination(
+            icon: Icon(Icons.library_music_outlined),
+            selectedIcon: Icon(Icons.library_music),
+            label: '찬양',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.history_outlined),
+            selectedIcon: Icon(Icons.history),
+            label: '히스토리',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/src/core/config/app_config.dart
+++ b/apps/mobile/lib/src/core/config/app_config.dart
@@ -1,0 +1,6 @@
+class AppConfig {
+  static const apiBaseUrl = String.fromEnvironment(
+    'API_BASE_URL',
+    defaultValue: 'http://10.0.2.2:8080/api/v1',
+  );
+}

--- a/apps/mobile/lib/src/core/network/api_client.dart
+++ b/apps/mobile/lib/src/core/network/api_client.dart
@@ -1,0 +1,301 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../storage/token_storage.dart';
+import 'api_exception.dart';
+
+class ApiClient {
+  final String baseUrl;
+  final TokenStorage tokenStorage;
+
+  Future<bool>? _refreshInFlight;
+
+  ApiClient({
+    required this.baseUrl,
+    required this.tokenStorage,
+  });
+
+  Future<dynamic> get(
+    String path, {
+    bool includeAuth = true,
+  }) {
+    return _request(
+      method: 'GET',
+      path: path,
+      includeAuth: includeAuth,
+    );
+  }
+
+  Future<dynamic> post(
+    String path, {
+    Object? body,
+    bool includeAuth = true,
+  }) {
+    return _request(
+      method: 'POST',
+      path: path,
+      body: body,
+      includeAuth: includeAuth,
+    );
+  }
+
+  Future<dynamic> put(
+    String path, {
+    Object? body,
+    bool includeAuth = true,
+  }) {
+    return _request(
+      method: 'PUT',
+      path: path,
+      body: body,
+      includeAuth: includeAuth,
+    );
+  }
+
+  Future<dynamic> patch(
+    String path, {
+    Object? body,
+    bool includeAuth = true,
+  }) {
+    return _request(
+      method: 'PATCH',
+      path: path,
+      body: body,
+      includeAuth: includeAuth,
+    );
+  }
+
+  Future<dynamic> delete(
+    String path, {
+    bool includeAuth = true,
+  }) {
+    return _request(
+      method: 'DELETE',
+      path: path,
+      includeAuth: includeAuth,
+    );
+  }
+
+  Future<dynamic> _request({
+    required String method,
+    required String path,
+    Object? body,
+    required bool includeAuth,
+  }) async {
+    final response = await _send(
+      method: method,
+      path: path,
+      body: body,
+      includeAuth: includeAuth,
+    );
+
+    if (response.statusCode == 401 &&
+        includeAuth &&
+        path != '/auth/refresh' &&
+        method != 'OPTIONS') {
+      final refreshed = await _refreshToken();
+      if (refreshed) {
+        final retried = await _send(
+          method: method,
+          path: path,
+          body: body,
+          includeAuth: includeAuth,
+        );
+        return _decodeEnvelope(retried);
+      }
+    }
+
+    return _decodeEnvelope(response);
+  }
+
+  Future<http.Response> _send({
+    required String method,
+    required String path,
+    Object? body,
+    required bool includeAuth,
+  }) async {
+    final uri = Uri.parse('$baseUrl$path');
+    final headers = <String, String>{};
+
+    if (body != null) {
+      headers['Content-Type'] = 'application/json';
+    }
+
+    if (includeAuth) {
+      final accessToken = await tokenStorage.getAccessToken();
+      if (accessToken != null && accessToken.isNotEmpty) {
+        headers['Authorization'] = 'Bearer $accessToken';
+      }
+    }
+
+    switch (method) {
+      case 'GET':
+        return http.get(uri, headers: headers);
+      case 'POST':
+        return http.post(uri, headers: headers, body: _encodeBody(body));
+      case 'PUT':
+        return http.put(uri, headers: headers, body: _encodeBody(body));
+      case 'PATCH':
+        return http.patch(uri, headers: headers, body: _encodeBody(body));
+      case 'DELETE':
+        return http.delete(uri, headers: headers);
+      default:
+        throw ApiException('지원하지 않는 HTTP 메서드입니다: $method');
+    }
+  }
+
+  String? _encodeBody(Object? body) {
+    if (body == null) {
+      return null;
+    }
+    return jsonEncode(body);
+  }
+
+  Future<bool> _refreshToken() async {
+    final inFlight = _refreshInFlight;
+    if (inFlight != null) {
+      return inFlight;
+    }
+
+    final task = _performRefresh();
+    _refreshInFlight = task;
+    try {
+      return await task;
+    } finally {
+      _refreshInFlight = null;
+    }
+  }
+
+  Future<bool> _performRefresh() async {
+    final refreshToken = await tokenStorage.getRefreshToken();
+    if (refreshToken == null || refreshToken.isEmpty) {
+      return false;
+    }
+
+    final uri = Uri.parse('$baseUrl/auth/refresh');
+    final response = await http.post(
+      uri,
+      headers: const {'Content-Type': 'application/json'},
+      body: jsonEncode({'refreshToken': refreshToken}),
+    );
+
+    final envelope = _decodeJsonObject(response.body);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      return false;
+    }
+    if (envelope == null || envelope['success'] != true) {
+      return false;
+    }
+
+    final data = envelope['data'];
+    if (data is! Map<String, dynamic>) {
+      return false;
+    }
+
+    final accessToken = data['accessToken']?.toString();
+    final rotatedRefreshToken = data['refreshToken']?.toString();
+    if (accessToken == null ||
+        accessToken.isEmpty ||
+        rotatedRefreshToken == null ||
+        rotatedRefreshToken.isEmpty) {
+      return false;
+    }
+
+    await tokenStorage.saveTokens(
+      accessToken: accessToken,
+      refreshToken: rotatedRefreshToken,
+    );
+    return true;
+  }
+
+  dynamic _decodeEnvelope(http.Response response) {
+    final hasBody = response.body.trim().isNotEmpty;
+    final jsonMap = hasBody ? _decodeJsonObject(response.body) : null;
+
+    if (response.statusCode == 401) {
+      final message = _errorMessage(jsonMap, fallback: '인증이 만료되었습니다.');
+      throw ApiException(
+        message,
+        statusCode: response.statusCode,
+        code: _errorCode(jsonMap),
+        details: _errorDetails(jsonMap),
+      );
+    }
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      final message = _errorMessage(jsonMap, fallback: '요청 처리 중 오류가 발생했습니다.');
+      throw ApiException(
+        message,
+        statusCode: response.statusCode,
+        code: _errorCode(jsonMap),
+        details: _errorDetails(jsonMap),
+      );
+    }
+
+    if (jsonMap == null) {
+      return null;
+    }
+
+    if (jsonMap.containsKey('success')) {
+      if (jsonMap['success'] != true) {
+        final message = _errorMessage(jsonMap, fallback: '요청 처리 중 오류가 발생했습니다.');
+        throw ApiException(
+          message,
+          statusCode: response.statusCode,
+          code: _errorCode(jsonMap),
+          details: _errorDetails(jsonMap),
+        );
+      }
+      return jsonMap['data'];
+    }
+
+    return jsonMap;
+  }
+
+  Map<String, dynamic>? _decodeJsonObject(String body) {
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is Map<String, dynamic>) {
+        return decoded;
+      }
+      return null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  String _errorMessage(
+    Map<String, dynamic>? envelope, {
+    required String fallback,
+  }) {
+    final error = envelope?['error'];
+    if (error is Map<String, dynamic>) {
+      final message = error['message']?.toString();
+      if (message != null && message.isNotEmpty) {
+        return message;
+      }
+    }
+    return fallback;
+  }
+
+  String? _errorCode(Map<String, dynamic>? envelope) {
+    final error = envelope?['error'];
+    if (error is Map<String, dynamic>) {
+      final code = error['code']?.toString();
+      if (code != null && code.isNotEmpty) {
+        return code;
+      }
+    }
+    return null;
+  }
+
+  Object? _errorDetails(Map<String, dynamic>? envelope) {
+    final error = envelope?['error'];
+    if (error is Map<String, dynamic>) {
+      return error['details'];
+    }
+    return null;
+  }
+}

--- a/apps/mobile/lib/src/core/network/api_exception.dart
+++ b/apps/mobile/lib/src/core/network/api_exception.dart
@@ -1,0 +1,20 @@
+class ApiException implements Exception {
+  final String message;
+  final int? statusCode;
+  final String? code;
+  final Object? details;
+
+  ApiException(
+    this.message, {
+    this.statusCode,
+    this.code,
+    this.details,
+  });
+
+  @override
+  String toString() {
+    final status = statusCode != null ? ' [$statusCode]' : '';
+    final errCode = code != null ? ' ($code)' : '';
+    return '$message$status$errCode';
+  }
+}

--- a/apps/mobile/lib/src/core/storage/token_storage.dart
+++ b/apps/mobile/lib/src/core/storage/token_storage.dart
@@ -1,0 +1,41 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class TokenStorage {
+  static const _accessTokenKey = 'accessToken';
+  static const _refreshTokenKey = 'refreshToken';
+
+  Future<void> saveTokens({
+    required String accessToken,
+    required String refreshToken,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_accessTokenKey, accessToken);
+    await prefs.setString(_refreshTokenKey, refreshToken);
+  }
+
+  Future<String?> getAccessToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_accessTokenKey);
+  }
+
+  Future<String?> getRefreshToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_refreshTokenKey);
+  }
+
+  Future<bool> hasTokens() async {
+    final prefs = await SharedPreferences.getInstance();
+    final accessToken = prefs.getString(_accessTokenKey);
+    final refreshToken = prefs.getString(_refreshTokenKey);
+    return accessToken != null &&
+        accessToken.isNotEmpty &&
+        refreshToken != null &&
+        refreshToken.isNotEmpty;
+  }
+
+  Future<void> clear() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_accessTokenKey);
+    await prefs.remove(_refreshTokenKey);
+  }
+}

--- a/apps/mobile/lib/src/features/auth/auth_repository.dart
+++ b/apps/mobile/lib/src/features/auth/auth_repository.dart
@@ -36,8 +36,11 @@ class AuthRepository {
         throw ApiException('프로필 응답 형식이 올바르지 않습니다.');
       }
       return _toSessionProfile(raw);
-    } on ApiException catch (_) {
-      return null;
+    } on ApiException catch (e) {
+      if (_isUnauthorized(e)) {
+        return null;
+      }
+      rethrow;
     }
   }
 
@@ -64,6 +67,7 @@ class AuthRepository {
 
     final profile = await fetchProfile();
     if (profile == null) {
+      await tokenStorage.clear();
       throw ApiException('로그인 후 프로필 조회에 실패했습니다.');
     }
     return profile;
@@ -92,6 +96,7 @@ class AuthRepository {
 
     final profile = await fetchProfile();
     if (profile == null) {
+      await tokenStorage.clear();
       throw ApiException('Dev 로그인 후 프로필 조회에 실패했습니다.');
     }
     return profile;
@@ -126,6 +131,10 @@ class AuthRepository {
 
     final role = roleText == 'ADMIN' ? UserRole.admin : UserRole.user;
     return SessionProfile(userId: userId, role: role);
+  }
+
+  bool _isUnauthorized(ApiException exception) {
+    return exception.statusCode == 401 || exception.code == 'unauthorized';
   }
 
   (String, String) _extractTokens(Object? raw) {

--- a/apps/mobile/lib/src/features/auth/auth_repository.dart
+++ b/apps/mobile/lib/src/features/auth/auth_repository.dart
@@ -1,0 +1,147 @@
+import '../../core/network/api_client.dart';
+import '../../core/network/api_exception.dart';
+import '../../core/storage/token_storage.dart';
+
+enum SocialProvider { google, kakao }
+
+enum UserRole { user, admin }
+
+class SessionProfile {
+  final String userId;
+  final UserRole role;
+
+  const SessionProfile({
+    required this.userId,
+    required this.role,
+  });
+}
+
+class AuthRepository {
+  final ApiClient apiClient;
+  final TokenStorage tokenStorage;
+
+  AuthRepository({
+    required this.apiClient,
+    required this.tokenStorage,
+  });
+
+  Future<bool> hasSession() {
+    return tokenStorage.hasTokens();
+  }
+
+  Future<SessionProfile?> fetchProfile() async {
+    try {
+      final raw = await apiClient.get('/me/profile');
+      if (raw is! Map<String, dynamic>) {
+        throw ApiException('프로필 응답 형식이 올바르지 않습니다.');
+      }
+      return _toSessionProfile(raw);
+    } on ApiException catch (_) {
+      return null;
+    }
+  }
+
+  Future<SessionProfile> loginWithSocial({
+    required SocialProvider provider,
+    required String token,
+    String? inviteCode,
+  }) async {
+    final raw = await apiClient.post(
+      '/auth/social',
+      includeAuth: false,
+      body: {
+        'provider': provider == SocialProvider.google ? 'GOOGLE' : 'KAKAO',
+        'token': token,
+        if (inviteCode != null && inviteCode.isNotEmpty) 'inviteCode': inviteCode,
+      },
+    );
+
+    final tokens = _extractTokens(raw);
+    await tokenStorage.saveTokens(
+      accessToken: tokens.$1,
+      refreshToken: tokens.$2,
+    );
+
+    final profile = await fetchProfile();
+    if (profile == null) {
+      throw ApiException('로그인 후 프로필 조회에 실패했습니다.');
+    }
+    return profile;
+  }
+
+  Future<SessionProfile> loginWithDev({
+    required String displayName,
+    required String userId,
+    required UserRole role,
+  }) async {
+    final raw = await apiClient.post(
+      '/auth/dev/login',
+      includeAuth: false,
+      body: {
+        'userId': userId,
+        'role': role == UserRole.admin ? 'ADMIN' : 'USER',
+        'displayName': displayName,
+      },
+    );
+
+    final tokens = _extractTokens(raw);
+    await tokenStorage.saveTokens(
+      accessToken: tokens.$1,
+      refreshToken: tokens.$2,
+    );
+
+    final profile = await fetchProfile();
+    if (profile == null) {
+      throw ApiException('Dev 로그인 후 프로필 조회에 실패했습니다.');
+    }
+    return profile;
+  }
+
+  Future<void> logout() async {
+    final refreshToken = await tokenStorage.getRefreshToken();
+    if (refreshToken != null && refreshToken.isNotEmpty) {
+      try {
+        await apiClient.post(
+          '/auth/logout',
+          includeAuth: false,
+          body: {'refreshToken': refreshToken},
+        );
+      } on ApiException {
+        // 토큰 만료/폐기 상태에서도 로컬 세션 정리는 계속 진행한다.
+      }
+    }
+    await tokenStorage.clear();
+  }
+
+  Future<void> clearSession() {
+    return tokenStorage.clear();
+  }
+
+  SessionProfile _toSessionProfile(Map<String, dynamic> raw) {
+    final userId = raw['userId']?.toString();
+    final roleText = raw['role']?.toString().toUpperCase();
+    if (userId == null || userId.isEmpty || roleText == null || roleText.isEmpty) {
+      throw ApiException('프로필 응답에 필수 값이 없습니다.');
+    }
+
+    final role = roleText == 'ADMIN' ? UserRole.admin : UserRole.user;
+    return SessionProfile(userId: userId, role: role);
+  }
+
+  (String, String) _extractTokens(Object? raw) {
+    if (raw is! Map<String, dynamic>) {
+      throw ApiException('토큰 응답 형식이 올바르지 않습니다.');
+    }
+
+    final accessToken = raw['accessToken']?.toString();
+    final refreshToken = raw['refreshToken']?.toString();
+    if (accessToken == null ||
+        accessToken.isEmpty ||
+        refreshToken == null ||
+        refreshToken.isEmpty) {
+      throw ApiException('토큰 응답에 필수 값이 없습니다.');
+    }
+
+    return (accessToken, refreshToken);
+  }
+}

--- a/apps/mobile/lib/src/features/auth/login_page.dart
+++ b/apps/mobile/lib/src/features/auth/login_page.dart
@@ -1,0 +1,253 @@
+import 'package:flutter/material.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../core/network/api_exception.dart';
+import 'auth_repository.dart';
+
+class LoginPage extends StatefulWidget {
+  final AuthRepository authRepository;
+  final void Function(SessionProfile profile) onLoggedIn;
+
+  const LoginPage({
+    super.key,
+    required this.authRepository,
+    required this.onLoggedIn,
+  });
+
+  @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final _socialTokenController = TextEditingController();
+  final _inviteCodeController = TextEditingController();
+  final _displayNameController = TextEditingController(text: '모바일관리자');
+
+  SocialProvider _provider = SocialProvider.google;
+  UserRole _devRole = UserRole.user;
+  bool _loading = false;
+  bool _showDevLogin = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _socialTokenController.dispose();
+    _inviteCodeController.dispose();
+    _displayNameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleSocialLogin() async {
+    if (_socialTokenController.text.trim().isEmpty) {
+      setState(() {
+        _error = '소셜 토큰을 입력하세요.';
+      });
+      return;
+    }
+
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final profile = await widget.authRepository.loginWithSocial(
+        provider: _provider,
+        token: _socialTokenController.text.trim(),
+        inviteCode: _inviteCodeController.text.trim().isEmpty
+            ? null
+            : _inviteCodeController.text.trim(),
+      );
+      widget.onLoggedIn(profile);
+    } on ApiException catch (e) {
+      setState(() {
+        _error = e.message;
+      });
+    } catch (_) {
+      setState(() {
+        _error = '로그인 중 알 수 없는 오류가 발생했습니다.';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _handleDevLogin() async {
+    if (_displayNameController.text.trim().isEmpty) {
+      setState(() {
+        _error = '표시 이름을 입력하세요.';
+      });
+      return;
+    }
+
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final profile = await widget.authRepository.loginWithDev(
+        displayName: _displayNameController.text.trim(),
+        userId: const Uuid().v4(),
+        role: _devRole,
+      );
+      widget.onLoggedIn(profile);
+    } on ApiException catch (e) {
+      setState(() {
+        _error = e.message;
+      });
+    } catch (_) {
+      setState(() {
+        _error = 'Dev 로그인 중 알 수 없는 오류가 발생했습니다.';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Eunhye Hymn 로그인'),
+      ),
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 480),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (_error != null)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 12),
+                      child: Text(
+                        _error!,
+                        style: const TextStyle(color: Colors.red),
+                      ),
+                    ),
+                  const Text(
+                    '소셜 로그인',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  DropdownButtonFormField<SocialProvider>(
+                    value: _provider,
+                    decoration: const InputDecoration(
+                      labelText: 'Provider',
+                      border: OutlineInputBorder(),
+                    ),
+                    items: const [
+                      DropdownMenuItem(
+                        value: SocialProvider.google,
+                        child: Text('Google'),
+                      ),
+                      DropdownMenuItem(
+                        value: SocialProvider.kakao,
+                        child: Text('Kakao'),
+                      ),
+                    ],
+                    onChanged: _loading
+                        ? null
+                        : (value) {
+                            if (value != null) {
+                              setState(() => _provider = value);
+                            }
+                          },
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: _socialTokenController,
+                    enabled: !_loading,
+                    decoration: const InputDecoration(
+                      labelText: 'ID Token',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: _inviteCodeController,
+                    enabled: !_loading,
+                    decoration: const InputDecoration(
+                      labelText: '초대코드 (신규 사용자만)',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  FilledButton(
+                    onPressed: _loading ? null : _handleSocialLogin,
+                    child: Text(_loading ? '로그인 중...' : '소셜 로그인'),
+                  ),
+                  const SizedBox(height: 20),
+                  OutlinedButton.icon(
+                    onPressed: _loading
+                        ? null
+                        : () {
+                            setState(() => _showDevLogin = !_showDevLogin);
+                          },
+                    icon: Icon(_showDevLogin ? Icons.expand_less : Icons.expand_more),
+                    label: const Text('Dev 로그인 (개발용)'),
+                  ),
+                  if (_showDevLogin) ...[
+                    const SizedBox(height: 12),
+                    TextField(
+                      controller: _displayNameController,
+                      enabled: !_loading,
+                      decoration: const InputDecoration(
+                        labelText: '표시 이름',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    DropdownButtonFormField<UserRole>(
+                      value: _devRole,
+                      decoration: const InputDecoration(
+                        labelText: '역할',
+                        border: OutlineInputBorder(),
+                      ),
+                      items: const [
+                        DropdownMenuItem(
+                          value: UserRole.user,
+                          child: Text('USER'),
+                        ),
+                        DropdownMenuItem(
+                          value: UserRole.admin,
+                          child: Text('ADMIN'),
+                        ),
+                      ],
+                      onChanged: _loading
+                          ? null
+                          : (value) {
+                              if (value != null) {
+                                setState(() => _devRole = value);
+                              }
+                            },
+                    ),
+                    const SizedBox(height: 12),
+                    FilledButton.tonal(
+                      onPressed: _loading ? null : _handleDevLogin,
+                      child: Text(_loading ? '처리 중...' : 'Dev 로그인'),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/src/features/history/history_page.dart
+++ b/apps/mobile/lib/src/features/history/history_page.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+import '../hymn/hymn_repository.dart';
+
+class HistoryPage extends StatefulWidget {
+  final HymnRepository hymnRepository;
+  final void Function(String hymnId) onOpenHymnDetail;
+
+  const HistoryPage({
+    super.key,
+    required this.hymnRepository,
+    required this.onOpenHymnDetail,
+  });
+
+  @override
+  State<HistoryPage> createState() => _HistoryPageState();
+}
+
+class _HistoryPageState extends State<HistoryPage> {
+  bool _loading = true;
+  String? _error;
+  List<HistoryItem> _items = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final items = await widget.hymnRepository.getHistory();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _items = items;
+      });
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = e.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(_error!, style: const TextStyle(color: Colors.red)),
+              const SizedBox(height: 12),
+              FilledButton(
+                onPressed: _load,
+                child: const Text('다시 시도'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (_items.isEmpty) {
+      return RefreshIndicator(
+        onRefresh: _load,
+        child: ListView(
+          children: const [
+            SizedBox(height: 80),
+            Center(child: Text('최근 열람 히스토리가 없습니다.')),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView.separated(
+        itemCount: _items.length,
+        separatorBuilder: (_, __) => const Divider(height: 1),
+        itemBuilder: (context, index) {
+          final item = _items[index];
+          final subtitle = [
+            if (item.number != null && item.number!.isNotEmpty) '#${item.number}',
+            if (item.tags != null && item.tags!.isNotEmpty) item.tags,
+            if (item.lastOpenedAt != null && item.lastOpenedAt!.isNotEmpty) item.lastOpenedAt,
+          ].join(' · ');
+
+          return ListTile(
+            title: Text(item.title),
+            subtitle: subtitle.isEmpty ? null : Text(subtitle),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => widget.onOpenHymnDetail(item.id),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/src/features/hymn/hymn_detail_page.dart
+++ b/apps/mobile/lib/src/features/hymn/hymn_detail_page.dart
@@ -1,0 +1,297 @@
+import 'package:flutter/material.dart';
+
+import '../../core/network/api_exception.dart';
+import 'hymn_repository.dart';
+
+class HymnDetailPage extends StatefulWidget {
+  final String hymnId;
+  final HymnRepository hymnRepository;
+
+  const HymnDetailPage({
+    super.key,
+    required this.hymnId,
+    required this.hymnRepository,
+  });
+
+  @override
+  State<HymnDetailPage> createState() => _HymnDetailPageState();
+}
+
+class _HymnDetailPageState extends State<HymnDetailPage> {
+  final _noteController = TextEditingController();
+
+  bool _loading = true;
+  bool _favorite = false;
+  bool _savingNote = false;
+  bool _togglingFavorite = false;
+  String? _error;
+  HymnDetail? _detail;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _noteController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final detail = await widget.hymnRepository.getHymnDetail(widget.hymnId);
+      final note = await widget.hymnRepository.getNote(widget.hymnId);
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _detail = detail;
+        _noteController.text = note ?? '';
+      });
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = e.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _toggleFavorite() async {
+    if (_togglingFavorite) {
+      return;
+    }
+
+    setState(() {
+      _togglingFavorite = true;
+    });
+
+    try {
+      final favorite = await widget.hymnRepository.toggleFavorite(widget.hymnId);
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _favorite = favorite;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(favorite ? '즐겨찾기에 추가했습니다.' : '즐겨찾기를 해제했습니다.'),
+        ),
+      );
+    } on ApiException catch (e) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(e.message)),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _togglingFavorite = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _saveNote() async {
+    if (_savingNote) {
+      return;
+    }
+    final content = _noteController.text.trim();
+    if (content.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('메모를 입력한 뒤 저장하세요.')),
+      );
+      return;
+    }
+
+    setState(() {
+      _savingNote = true;
+    });
+
+    try {
+      await widget.hymnRepository.saveNote(widget.hymnId, content);
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('메모를 저장했습니다.')),
+      );
+    } on ApiException catch (e) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(e.message)),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _savingNote = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('찬양 상세')),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (_error != null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('찬양 상세')),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(_error!, style: const TextStyle(color: Colors.red)),
+                const SizedBox(height: 12),
+                FilledButton(
+                  onPressed: _load,
+                  child: const Text('다시 시도'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    final detail = _detail;
+    if (detail == null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('찬양 상세')),
+        body: const Center(child: Text('데이터가 없습니다.')),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(detail.title),
+        actions: [
+          IconButton(
+            onPressed: _togglingFavorite ? null : _toggleFavorite,
+            icon: Icon(_favorite ? Icons.favorite : Icons.favorite_border),
+            tooltip: '즐겨찾기',
+          ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    detail.title,
+                    style: Theme.of(context).textTheme.titleLarge,
+                  ),
+                  const SizedBox(height: 8),
+                  Text('번호: ${detail.number ?? "-"}'),
+                  Text('태그: ${detail.tags ?? "-"}'),
+                  Text('활성화: ${detail.enabled ? "예" : "아니오"}'),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            '에셋',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          if (detail.assets.isEmpty)
+            const Text('등록된 에셋이 없습니다.')
+          else
+            ...detail.assets.map((asset) => _AssetCard(asset: asset)),
+          const SizedBox(height: 20),
+          Text(
+            '메모',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _noteController,
+            minLines: 4,
+            maxLines: 8,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              hintText: '찬양 메모를 입력하세요.',
+            ),
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: FilledButton(
+              onPressed: _savingNote ? null : _saveNote,
+              child: Text(_savingNote ? '저장 중...' : '메모 저장'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AssetCard extends StatelessWidget {
+  final HymnAsset asset;
+
+  const _AssetCard({required this.asset});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('타입: ${asset.type} / 파트: ${asset.part ?? "-"}'),
+            const SizedBox(height: 6),
+            if (asset.isImage && asset.url.startsWith('http'))
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: Image.network(
+                  asset.url,
+                  fit: BoxFit.cover,
+                  errorBuilder: (_, __, ___) => const Padding(
+                    padding: EdgeInsets.all(12),
+                    child: Text('이미지를 불러올 수 없습니다.'),
+                  ),
+                ),
+              )
+            else
+              SelectableText(asset.url),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/src/features/hymn/hymn_detail_page.dart
+++ b/apps/mobile/lib/src/features/hymn/hymn_detail_page.dart
@@ -48,12 +48,14 @@ class _HymnDetailPageState extends State<HymnDetailPage> {
     try {
       final detail = await widget.hymnRepository.getHymnDetail(widget.hymnId);
       final note = await widget.hymnRepository.getNote(widget.hymnId);
+      final favorite = await widget.hymnRepository.getFavorite(widget.hymnId);
       if (!mounted) {
         return;
       }
       setState(() {
         _detail = detail;
         _noteController.text = note ?? '';
+        _favorite = favorite;
       });
     } catch (e) {
       if (!mounted) {

--- a/apps/mobile/lib/src/features/hymn/hymn_list_page.dart
+++ b/apps/mobile/lib/src/features/hymn/hymn_list_page.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+
+import 'hymn_repository.dart';
+
+class HymnListPage extends StatefulWidget {
+  final HymnRepository hymnRepository;
+  final void Function(String hymnId) onOpenHymnDetail;
+
+  const HymnListPage({
+    super.key,
+    required this.hymnRepository,
+    required this.onOpenHymnDetail,
+  });
+
+  @override
+  State<HymnListPage> createState() => _HymnListPageState();
+}
+
+class _HymnListPageState extends State<HymnListPage> {
+  bool _loading = true;
+  String? _error;
+  List<HymnSummary> _items = const [];
+  String _query = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    try {
+      final items = await widget.hymnRepository.listHymns();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _items = items;
+      });
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = e.toString();
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(_error!, style: const TextStyle(color: Colors.red)),
+              const SizedBox(height: 12),
+              FilledButton(
+                onPressed: _load,
+                child: const Text('다시 시도'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final filtered = _items.where((item) {
+      final q = _query.trim().toLowerCase();
+      if (q.isEmpty) {
+        return true;
+      }
+      return item.title.toLowerCase().contains(q) ||
+          (item.number ?? '').toLowerCase().contains(q) ||
+          (item.tags ?? '').toLowerCase().contains(q);
+    }).toList();
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+          child: TextField(
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              hintText: '제목, 번호, 태그 검색',
+              prefixIcon: Icon(Icons.search),
+            ),
+            onChanged: (value) {
+              setState(() {
+                _query = value;
+              });
+            },
+          ),
+        ),
+        Expanded(
+          child: RefreshIndicator(
+            onRefresh: _load,
+            child: filtered.isEmpty
+                ? ListView(
+                    children: const [
+                      SizedBox(height: 80),
+                      Center(child: Text('검색 결과가 없습니다.')),
+                    ],
+                  )
+                : ListView.separated(
+                    itemCount: filtered.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, index) {
+                      final hymn = filtered[index];
+                      final subtitle = [
+                        if (hymn.number != null && hymn.number!.isNotEmpty) '#${hymn.number}',
+                        if (hymn.tags != null && hymn.tags!.isNotEmpty) hymn.tags,
+                      ].join(' · ');
+                      return ListTile(
+                        title: Text(hymn.title),
+                        subtitle: subtitle.isEmpty ? null : Text(subtitle),
+                        trailing: const Icon(Icons.chevron_right),
+                        onTap: () => widget.onOpenHymnDetail(hymn.id),
+                      );
+                    },
+                  ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/mobile/lib/src/features/hymn/hymn_repository.dart
+++ b/apps/mobile/lib/src/features/hymn/hymn_repository.dart
@@ -133,6 +133,14 @@ class HymnRepository {
     return raw['favorite'] == true;
   }
 
+  Future<bool> getFavorite(String hymnId) async {
+    final raw = await apiClient.get('/me/favorites/$hymnId');
+    if (raw is! Map<String, dynamic>) {
+      throw ApiException('즐겨찾기 조회 응답 형식이 올바르지 않습니다.');
+    }
+    return raw['favorite'] == true;
+  }
+
   Future<String?> getNote(String hymnId) async {
     final raw = await apiClient.get('/me/hymns/$hymnId/note');
     if (raw is! Map<String, dynamic>) {

--- a/apps/mobile/lib/src/features/hymn/hymn_repository.dart
+++ b/apps/mobile/lib/src/features/hymn/hymn_repository.dart
@@ -1,0 +1,177 @@
+import '../../core/network/api_client.dart';
+import '../../core/network/api_exception.dart';
+
+class HymnSummary {
+  final String id;
+  final String title;
+  final String? number;
+  final String? tags;
+
+  const HymnSummary({
+    required this.id,
+    required this.title,
+    required this.number,
+    required this.tags,
+  });
+}
+
+class HymnAsset {
+  final String id;
+  final String type;
+  final String? part;
+  final String url;
+  final String? checksum;
+  final String? version;
+
+  const HymnAsset({
+    required this.id,
+    required this.type,
+    required this.part,
+    required this.url,
+    required this.checksum,
+    required this.version,
+  });
+
+  bool get isImage => type.toUpperCase() == 'PNG';
+}
+
+class HymnDetail {
+  final String id;
+  final String title;
+  final String? number;
+  final String? tags;
+  final bool enabled;
+  final String? lastOpenedAt;
+  final List<HymnAsset> assets;
+
+  const HymnDetail({
+    required this.id,
+    required this.title,
+    required this.number,
+    required this.tags,
+    required this.enabled,
+    required this.lastOpenedAt,
+    required this.assets,
+  });
+}
+
+class HistoryItem {
+  final String id;
+  final String title;
+  final String? number;
+  final String? tags;
+  final String? lastOpenedAt;
+
+  const HistoryItem({
+    required this.id,
+    required this.title,
+    required this.number,
+    required this.tags,
+    required this.lastOpenedAt,
+  });
+}
+
+class HymnRepository {
+  final ApiClient apiClient;
+
+  HymnRepository({required this.apiClient});
+
+  Future<List<HymnSummary>> listHymns() async {
+    final raw = await apiClient.get('/hymns', includeAuth: false);
+    if (raw is! List) {
+      throw ApiException('찬양 목록 응답 형식이 올바르지 않습니다.');
+    }
+
+    return raw
+        .whereType<Map<String, dynamic>>()
+        .map((item) => HymnSummary(
+              id: item['id'].toString(),
+              title: item['title']?.toString() ?? '(제목 없음)',
+              number: item['number']?.toString(),
+              tags: item['tags']?.toString(),
+            ))
+        .toList();
+  }
+
+  Future<HymnDetail> getHymnDetail(String hymnId) async {
+    final raw = await apiClient.get('/hymns/$hymnId');
+    if (raw is! Map<String, dynamic>) {
+      throw ApiException('찬양 상세 응답 형식이 올바르지 않습니다.');
+    }
+
+    final assetsRaw = raw['assets'];
+    final assets = <HymnAsset>[];
+    if (assetsRaw is List) {
+      for (final item in assetsRaw.whereType<Map<String, dynamic>>()) {
+        assets.add(HymnAsset(
+          id: item['id'].toString(),
+          type: item['type']?.toString() ?? '',
+          part: item['part']?.toString(),
+          url: item['url']?.toString() ?? '',
+          checksum: item['checksum']?.toString(),
+          version: item['version']?.toString(),
+        ));
+      }
+    }
+
+    return HymnDetail(
+      id: raw['id'].toString(),
+      title: raw['title']?.toString() ?? '(제목 없음)',
+      number: raw['number']?.toString(),
+      tags: raw['tags']?.toString(),
+      enabled: raw['enabled'] == true,
+      lastOpenedAt: raw['lastOpenedAt']?.toString(),
+      assets: assets,
+    );
+  }
+
+  Future<bool> toggleFavorite(String hymnId) async {
+    final raw = await apiClient.post('/me/favorites/$hymnId');
+    if (raw is! Map<String, dynamic>) {
+      throw ApiException('즐겨찾기 응답 형식이 올바르지 않습니다.');
+    }
+    return raw['favorite'] == true;
+  }
+
+  Future<String?> getNote(String hymnId) async {
+    final raw = await apiClient.get('/me/hymns/$hymnId/note');
+    if (raw is! Map<String, dynamic>) {
+      throw ApiException('메모 응답 형식이 올바르지 않습니다.');
+    }
+    return raw['content']?.toString();
+  }
+
+  Future<String?> saveNote(String hymnId, String content) async {
+    final trimmed = content.trim();
+    if (trimmed.isEmpty) {
+      throw ApiException('메모는 빈 값으로 저장할 수 없습니다.');
+    }
+
+    final raw = await apiClient.put(
+      '/me/hymns/$hymnId/note',
+      body: {'content': trimmed},
+    );
+    if (raw is! Map<String, dynamic>) {
+      throw ApiException('메모 저장 응답 형식이 올바르지 않습니다.');
+    }
+    return raw['content']?.toString();
+  }
+
+  Future<List<HistoryItem>> getHistory() async {
+    final raw = await apiClient.get('/me/history');
+    if (raw is! List) {
+      throw ApiException('히스토리 응답 형식이 올바르지 않습니다.');
+    }
+
+    return raw
+        .whereType<Map<String, dynamic>>()
+        .map((item) => HistoryItem(
+              id: item['id'].toString(),
+              title: item['title']?.toString() ?? '(제목 없음)',
+              number: item['number']?.toString(),
+              tags: item['tags']?.toString(),
+              lastOpenedAt: item['lastOpenedAt']?.toString(),
+            ))
+        .toList();
+  }
+}

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -1,0 +1,22 @@
+name: eunhye_hymn_mobile
+description: Eunhye Hymn mobile app (Flutter MVP)
+publish_to: "none"
+version: 0.1.0+1
+
+environment:
+  sdk: ">=3.4.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^1.2.2
+  shared_preferences: ^2.3.2
+  uuid: ^4.5.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^4.0.0
+
+flutter:
+  uses-material-design: true

--- a/apps/mobile/test/app_config_test.dart
+++ b/apps/mobile/test/app_config_test.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:eunhye_hymn_mobile/src/core/config/app_config.dart';
+
+void main() {
+  test('API base URL always includes /api/v1', () {
+    expect(AppConfig.apiBaseUrl.contains('/api/v1'), isTrue);
+  });
+}

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -1,6 +1,19 @@
 # 안정화 작업 이력
 
 ## 날짜
+- 2026-02-13
+
+## 변경 요약
+1. `apps/mobile` Flutter MVP를 추가했다.
+2. 모바일에서 API 인증 흐름(토큰 저장, 401 자동 refresh 재시도)을 구현했다.
+3. 모바일 핵심 화면(로그인, 찬양 목록/상세, 메모, 히스토리)을 구현했다.
+4. `README.md`, `docs/mobile/README.md`, `docs/current-usable-scope.md`, `CLAUDE.md`를 모바일 현황 기준으로 동기화했다.
+
+## 검증 결과
+- Flutter SDK가 현재 실행 환경에 없어 `flutter pub get`/`flutter test`/`flutter run`은 실행하지 못했다.
+- 코드 정합성은 API 계약 및 파일 단위 자체 검수로 확인했다.
+
+## 날짜
 - 2026-02-06
 
 ## 변경 요약

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -7,7 +7,10 @@
 1. `apps/mobile` Flutter MVP를 추가했다.
 2. 모바일에서 API 인증 흐름(토큰 저장, 401 자동 refresh 재시도)을 구현했다.
 3. 모바일 핵심 화면(로그인, 찬양 목록/상세, 메모, 히스토리)을 구현했다.
-4. `README.md`, `docs/mobile/README.md`, `docs/current-usable-scope.md`, `CLAUDE.md`를 모바일 현황 기준으로 동기화했다.
+4. 리뷰 반영 리팩토링:
+   - `fetchProfile()`는 401일 때만 세션 만료로 처리하고, 5xx/429 등은 오류로 노출하도록 수정했다.
+   - `GET /me/favorites/{hymnId}` 조회 API를 추가해 상세 화면 즐겨찾기 상태를 초기 hydrate하도록 수정했다.
+5. `README.md`, `docs/mobile/README.md`, `docs/current-usable-scope.md`, `CLAUDE.md`를 모바일 현황 기준으로 동기화했다.
 
 ## 검증 결과
 - Flutter SDK가 현재 실행 환경에 없어 `flutter pub get`/`flutter test`/`flutter run`은 실행하지 못했다.

--- a/docs/current-usable-scope.md
+++ b/docs/current-usable-scope.md
@@ -1,18 +1,18 @@
 # 현재 사용 가능 범위 정리
 
-- 작성일: 2026-02-12
+- 작성일: 2026-02-13
 - 기준 브랜치: `develop`
-- 기준 커밋: `9b8ebd0` (Merge pull request #31)
+- 기준 커밋: `6b3d8cc` (Merge pull request #32)
 - 근거 문서: `CLAUDE.md` (마지막 업데이트: 2026-02-13)
-- 근거 PR: #31, #30, #29, #28, #27
+- 근거 PR: #32, #31, #30, #29, #28, #27
 
 ## 1. 요약
 
 현재 시점에서 이 프로젝트는 다음 범위까지 사용 가능하다.
 
-- 로컬 기준: 관리자 웹(Admin) + 백엔드 API의 주요 기능 사용 가능
+- 로컬 기준: 관리자 웹(Admin) + 백엔드 API + 모바일 앱 MVP 사용 가능
 - 배포 기준: AWS 스테이징 자동 배포 파이프라인 구성 완료(인프라/시크릿 준비 필요)
-- 미완료: 모바일 앱(Flutter), 모니터링/알림(CloudWatch/에러 추적)
+- 미완료: 모바일 고도화 항목(소셜 SDK 직접 연동, MIDI 재생 UX, 오프라인 캐시)
 
 ## 2. 지금 바로 써볼 수 있는 범위 (로컬)
 
@@ -47,6 +47,24 @@
 - 멤버 기능: 즐겨찾기, 메모, 히스토리, 이벤트 기록
 
 엔드포인트 기준은 `CLAUDE.md`의 API 섹션(7장)과 현재 컨트롤러/유즈케이스 구현 상태를 따른다.
+
+### 2.3 모바일 앱 (Flutter MVP)
+
+다음 기능을 앱에서 바로 검증할 수 있다.
+
+- 로그인: 소셜 토큰 입력 방식(Google/Kakao), Dev 로그인
+- 찬양: 목록 조회/검색, 상세 조회
+- 개인화: 즐겨찾기 토글, 메모 조회/저장, 최근 열람 히스토리
+- 인증: 토큰 저장, 401 시 자동 refresh 후 재시도
+
+관련 파일:
+
+- `apps/mobile/lib/src/app.dart`
+- `apps/mobile/lib/src/features/auth/login_page.dart`
+- `apps/mobile/lib/src/features/hymn/hymn_list_page.dart`
+- `apps/mobile/lib/src/features/hymn/hymn_detail_page.dart`
+- `apps/mobile/lib/src/features/history/history_page.dart`
+- `apps/mobile/lib/src/core/network/api_client.dart`
 
 ## 3. 조건부로 써볼 수 있는 범위 (스테이징)
 
@@ -100,8 +118,10 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
 
 ## 5. 미완료 범위
 
-- 모니터링/알림: CloudWatch, 에러 추적 미구현
-- 모바일 앱: Flutter 코드 미구현(placeholder)
+- 모바일 고도화:
+  - 소셜 SDK 직접 연동 (현재는 토큰 입력 방식)
+  - MIDI 재생 UX
+  - 오프라인 캐시/동기화
 
 ## 6. 빠른 사용 체크리스트
 
@@ -114,7 +134,11 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
    - `cd apps/admin`
    - `npm install`
    - `npm run dev`
-3. 접속
+3. Mobile 실행
+   - `cd apps/mobile`
+   - `flutter pub get`
+   - `flutter run --dart-define=API_BASE_URL=http://10.0.2.2:8080/api/v1`
+4. 접속
    - Admin: `http://localhost:5173`
    - API Base: `http://localhost:8080/api/v1`
 

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -1,9 +1,69 @@
-# 모바일 문서
+# 모바일 앱 문서
 
-모바일 앱 요구사항, 화면 목록, UX 메모를 정리한다.
+## 1. 현재 상태 (MVP)
 
-## 추천 섹션
-- 화면 인벤토리
-- 네비게이션 맵
-- 오프라인 고려 사항
-- 미디어 재생 UX
+`apps/mobile`에 Flutter MVP가 추가되었다.
+
+구현 기능:
+
+- 로그인
+  - 소셜 로그인 API 토큰 입력 방식 (Google/Kakao)
+  - Dev 로그인 (개발 환경)
+- 찬양
+  - 목록 조회 + 검색
+  - 상세 조회
+  - PNG 에셋 이미지 표시
+- 개인화
+  - 즐겨찾기 토글
+  - 메모 조회/저장
+  - 최근 열람 히스토리 조회
+- 인증
+  - Access/Refresh 토큰 저장
+  - 401 시 `/auth/refresh` 자동 토큰 갱신 후 재시도
+
+## 2. 화면 인벤토리
+
+1. 로그인 화면
+2. 찬양 목록 화면
+3. 찬양 상세 화면
+4. 최근 열람 히스토리 화면
+
+## 3. 네비게이션
+
+- 로그인 성공 후 Home 진입
+- Home 하단 탭:
+  - 찬양 목록
+  - 최근 열람
+- 목록/히스토리에서 상세 화면으로 이동
+
+## 4. API 연동 기준
+
+- Base URL: `/api/v1`
+- 사용 API:
+  - `POST /auth/social`
+  - `POST /auth/dev/login`
+  - `POST /auth/refresh`
+  - `POST /auth/logout`
+  - `GET /me/profile`
+  - `GET /hymns`
+  - `GET /hymns/{id}`
+  - `POST /me/favorites/{hymnId}`
+  - `GET /me/hymns/{hymnId}/note`
+  - `PUT /me/hymns/{hymnId}/note`
+  - `GET /me/history`
+
+## 5. 실행
+
+```bash
+cd apps/mobile
+flutter pub get
+flutter run --dart-define=API_BASE_URL=http://10.0.2.2:8080/api/v1
+```
+
+실기기에서는 `10.0.2.2` 대신 로컬 서버 IP를 사용한다.
+
+## 6. 다음 고도화 항목
+
+- 소셜 SDK 직접 연동 (현재는 토큰 입력 방식)
+- MIDI 재생 UX (앱 내 플레이어)
+- 오프라인 캐시/동기화

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -45,6 +45,7 @@
   - `POST /auth/refresh`
   - `POST /auth/logout`
   - `GET /me/profile`
+  - `GET /me/favorites/{hymnId}`
   - `GET /hymns`
   - `GET /hymns/{id}`
   - `POST /me/favorites/{hymnId}`


### PR DESCRIPTION
## 요약
- `apps/mobile` Flutter MVP 프로젝트 추가
- 인증/토큰 저장/401 자동 refresh 가능한 공통 API 클라이언트 구현
- 로그인(소셜 토큰 + Dev), 찬양 목록/상세, 즐겨찾기, 메모, 최근 열람 히스토리 구현
- `README.md`, `docs/mobile/README.md`, `docs/current-usable-scope.md`, `CLAUDE.md` 문서 동기화

## 주요 파일
- `apps/mobile/lib/src/core/network/api_client.dart`
- `apps/mobile/lib/src/features/auth/login_page.dart`
- `apps/mobile/lib/src/features/hymn/hymn_list_page.dart`
- `apps/mobile/lib/src/features/hymn/hymn_detail_page.dart`
- `apps/mobile/lib/src/features/history/history_page.dart`

## 검증
- 실행 환경에 Flutter SDK가 없어 `flutter pub get` / `flutter test` / `flutter run`은 미실행
- 백엔드 API 계약(실제 controller 기준)과 코드 정합성 자체 검수 완료

## 비고
- 모바일 앱은 소셜 SDK 직접 연동 전 단계(MVP)이며, 현재는 소셜 토큰 입력 방식 로그인