### PR TITLE
security(admin): sessionStorage 기반 토큰 저장으로 하드닝

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -423,7 +423,8 @@ com.eunhyehymn/
 | `src/api/adminUsers.ts` | 사용자 목록/역할·상태 변경 API |
 | `src/api/adminEvents.ts` | 관리자 이벤트 로그/집계 조회 API |
 | `src/api/adminInviteCodes.ts` | 초대코드 목록/생성/비활성화 API |
-| `src/auth/AuthContext.tsx` | AuthProvider + `useAuth()` 훅, JWT 파싱, localStorage 토큰 관리, **`loginWithSocial`** + `setTokensAndUser` 공통 헬퍼 |
+| `src/auth/AuthContext.tsx` | AuthProvider + `useAuth()` 훅, JWT 파싱, sessionStorage 기반 토큰 관리, **`loginWithSocial`** + `setTokensAndUser` 공통 헬퍼 |
+| `src/auth/tokenStore.ts` | Admin 토큰 저장소(sessionStorage), 구 localStorage 토큰 마이그레이션/정리 |
 | `src/auth/ProtectedRoute.tsx` | 미인증 시 `/login` redirect |
 | `src/components/Layout.tsx` | 사이드바(찬양 관리, 에셋 업로드, 사용자 관리, 초대코드 관리, 감사 로그/분석) + 로그아웃 |
 | `src/pages/LoginPage.tsx` | **Google/Kakao 소셜 로그인** + 초대코드 입력 + 접이식 Dev Login |

--- a/apps/admin/src/api/adminEvents.ts
+++ b/apps/admin/src/api/adminEvents.ts
@@ -1,4 +1,5 @@
 import { apiGet } from "./client";
+import { getAccessToken } from "../auth/tokenStore";
 
 export type EventType = "HYMN_OPENED" | "PART_PLAYED" | "NOTE_SAVED" | "FAVORITE_TOGGLED";
 
@@ -84,7 +85,7 @@ export interface ExportAdminEventsCsvResult {
 export async function exportAdminEventsCsv(
   params: ExportAdminEventsCsvParams = {},
 ): Promise<ExportAdminEventsCsvResult> {
-  const token = localStorage.getItem("accessToken");
+  const token = getAccessToken();
   if (!token) {
     throw new Error("인증 토큰이 없습니다. 다시 로그인해 주세요.");
   }

--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -1,3 +1,11 @@
+import {
+  clearTokens,
+  getAccessToken,
+  getRefreshToken,
+  migrateLegacyLocalStorageTokens,
+  setTokens,
+} from "../auth/tokenStore";
+
 const API_BASE = "/api/v1";
 
 type UnauthorizedMode = "redirect" | "throw";
@@ -15,16 +23,14 @@ interface ApiEnvelope<T = unknown> {
   };
 }
 
-function getToken(): string | null {
-  return localStorage.getItem("accessToken");
-}
+migrateLegacyLocalStorageTokens();
 
 function authHeaders(includeAuth: boolean): Record<string, string> {
   if (!includeAuth) {
     return {};
   }
 
-  const token = getToken();
+  const token = getAccessToken();
   if (token) {
     return { Authorization: `Bearer ${token}` };
   }
@@ -33,15 +39,10 @@ function authHeaders(includeAuth: boolean): Record<string, string> {
 
 let refreshPromise: Promise<boolean> | null = null;
 
-function clearTokens(): void {
-  localStorage.removeItem("accessToken");
-  localStorage.removeItem("refreshToken");
-}
-
 async function tryRefreshToken(): Promise<boolean> {
   if (refreshPromise) return refreshPromise;
 
-  const rt = localStorage.getItem("refreshToken");
+  const rt = getRefreshToken();
   if (!rt) return false;
 
   refreshPromise = (async () => {
@@ -61,8 +62,7 @@ async function tryRefreshToken(): Promise<boolean> {
       const tokens = payload.data;
       if (!tokens?.accessToken || !tokens?.refreshToken) return false;
 
-      localStorage.setItem("accessToken", tokens.accessToken);
-      localStorage.setItem("refreshToken", tokens.refreshToken);
+      setTokens(tokens.accessToken, tokens.refreshToken);
       return true;
     } catch {
       return false;
@@ -155,3 +155,4 @@ export async function apiPatch<T>(path: string, body: unknown, options?: ApiRequ
 export async function apiDelete<T>(path: string, options?: ApiRequestOptions): Promise<T> {
   return apiFetch<T>({ method: "DELETE", path, ...options });
 }
+

--- a/apps/admin/src/auth/AuthContext.tsx
+++ b/apps/admin/src/auth/AuthContext.tsx
@@ -12,6 +12,13 @@ import {
   socialLogin as apiSocialLogin,
   type DevLoginRequest,
 } from "../api/auth";
+import {
+  clearTokens,
+  getAccessToken,
+  getRefreshToken,
+  migrateLegacyLocalStorageTokens,
+  setTokens,
+} from "./tokenStore";
 
 interface User {
   userId: string;
@@ -39,7 +46,7 @@ function parseJwtPayload(token: string): Record<string, unknown> | null {
 }
 
 function loadUser(): User | null {
-  const token = localStorage.getItem("accessToken");
+  const token = getAccessToken();
   if (!token) return null;
   const payload = parseJwtPayload(token);
   if (!payload) return null;
@@ -49,12 +56,13 @@ function loadUser(): User | null {
   };
 }
 
+migrateLegacyLocalStorageTokens();
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(loadUser);
 
   const setTokensAndUser = useCallback((accessToken: string, refreshToken: string, fallbackUser?: User) => {
-    localStorage.setItem("accessToken", accessToken);
-    localStorage.setItem("refreshToken", refreshToken);
+    setTokens(accessToken, refreshToken);
     const parsed = parseJwtPayload(accessToken);
     setUser(
       parsed
@@ -75,7 +83,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [setTokensAndUser]);
 
   const logout = useCallback(async () => {
-    const rt = localStorage.getItem("refreshToken");
+    const rt = getRefreshToken();
     if (rt) {
       try {
         await apiLogout(rt);
@@ -83,8 +91,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         // ignore logout errors
       }
     }
-    localStorage.removeItem("accessToken");
-    localStorage.removeItem("refreshToken");
+    clearTokens();
     setUser(null);
   }, []);
 
@@ -109,3 +116,4 @@ export function useAuth(): AuthContextValue {
   }
   return ctx;
 }
+

--- a/apps/admin/src/auth/tokenStore.ts
+++ b/apps/admin/src/auth/tokenStore.ts
@@ -1,0 +1,67 @@
+const ACCESS_TOKEN_KEY = "accessToken";
+const REFRESH_TOKEN_KEY = "refreshToken";
+
+function getSessionStorage(): Storage | null {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function getLocalStorage(): Storage | null {
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function migrateLegacyLocalStorageTokens(): void {
+  const session = getSessionStorage();
+  const local = getLocalStorage();
+  if (!session || !local) {
+    return;
+  }
+
+  const legacyAccess = local.getItem(ACCESS_TOKEN_KEY);
+  const legacyRefresh = local.getItem(REFRESH_TOKEN_KEY);
+
+  if (legacyAccess && !session.getItem(ACCESS_TOKEN_KEY)) {
+    session.setItem(ACCESS_TOKEN_KEY, legacyAccess);
+  }
+  if (legacyRefresh && !session.getItem(REFRESH_TOKEN_KEY)) {
+    session.setItem(REFRESH_TOKEN_KEY, legacyRefresh);
+  }
+
+  // Reduce persistence risk by removing legacy tokens from localStorage.
+  local.removeItem(ACCESS_TOKEN_KEY);
+  local.removeItem(REFRESH_TOKEN_KEY);
+}
+
+export function getAccessToken(): string | null {
+  return getSessionStorage()?.getItem(ACCESS_TOKEN_KEY) ?? null;
+}
+
+export function getRefreshToken(): string | null {
+  return getSessionStorage()?.getItem(REFRESH_TOKEN_KEY) ?? null;
+}
+
+export function setTokens(accessToken: string, refreshToken: string): void {
+  const session = getSessionStorage();
+  if (!session) {
+    return;
+  }
+  session.setItem(ACCESS_TOKEN_KEY, accessToken);
+  session.setItem(REFRESH_TOKEN_KEY, refreshToken);
+}
+
+export function clearTokens(): void {
+  const session = getSessionStorage();
+  if (!session) {
+    return;
+  }
+  session.removeItem(ACCESS_TOKEN_KEY);
+  session.removeItem(REFRESH_TOKEN_KEY);
+}
+

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,15 @@
 
 ## 2026-02-13
 
+### Admin 토큰 저장 하드닝(작업중)
+- Admin 웹 토큰 저장소를 `localStorage`에서 `sessionStorage` 기반으로 전환
+- 구버전 `localStorage` 토큰은 최초 로드시 `sessionStorage`로 마이그레이션 후 삭제
+- 적용 파일:
+  - `apps/admin/src/auth/tokenStore.ts`
+  - `apps/admin/src/auth/AuthContext.tsx`
+  - `apps/admin/src/api/client.ts`
+  - `apps/admin/src/api/adminEvents.ts`
+
 ### 모바일 기능 3건 머지
 - PR #36 `feat/mobile-social-sdk`
   - Google/Kakao 소셜 SDK 로그인 추가


### PR DESCRIPTION
## 요약
- Admin 토큰 저장소를 `localStorage`에서 `sessionStorage`로 전환
- 최초 로딩 시 구버전 `localStorage` 토큰을 `sessionStorage`로 마이그레이션 후 삭제
- 공통 토큰 저장 유틸 추가(`tokenStore`)
- 인증/요청 클라이언트에서 토큰 접근 경로를 `tokenStore`로 통일
- 관련 문서 갱신

## 변경 파일
- `apps/admin/src/auth/tokenStore.ts`
- `apps/admin/src/auth/AuthContext.tsx`
- `apps/admin/src/api/client.ts`
- `apps/admin/src/api/adminEvents.ts`
- `CLAUDE.md`
- `docs/changelog-dev.md`

## 검증
- `npm run build` (in `apps/admin`) 통과

## 보안 관점
- 브라우저 장기 저장(localStorage) 제거로 세션 종료 시 토큰 자동 정리
- XSS 완전 방어는 아니므로, 장기적으로는 refresh token HttpOnly cookie 전환이 필요