### PR TITLE
perf(events): 관리자 이벤트 조회 인덱스 추가

### DIFF
--- a/apps/api/src/main/resources/db/migration/V7__events_admin_indexes.sql
+++ b/apps/api/src/main/resources/db/migration/V7__events_admin_indexes.sql
@@ -1,0 +1,11 @@
+-- Indexes for admin event list/export query patterns.
+-- Main patterns:
+-- 1) ORDER BY created_at DESC with optional time range filter
+-- 2) event_type + time range filter
+-- 3) hymn_id + time range filter
+-- 4) user_id + time range filter (already had idx_events_user_created)
+
+CREATE INDEX idx_events_created_at_desc ON events(created_at DESC);
+CREATE INDEX idx_events_event_type_created ON events(event_type, created_at DESC);
+CREATE INDEX idx_events_hymn_created ON events(hymn_id, created_at DESC);
+

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,16 @@
 
 ## 2026-02-13
 
+### 이벤트 조회 성능 인덱스(작업중)
+- 관리자 이벤트 조회/CSV 패턴 최적화 인덱스 추가
+  - `idx_events_created_at_desc`
+  - `idx_events_event_type_created`
+  - `idx_events_hymn_created`
+- 마이그레이션 추가
+  - `apps/api/src/main/resources/db/migration/V7__events_admin_indexes.sql`
+- 운영 문서 업데이트
+  - `docs/events.md`에 조회 파라미터, 인덱스, 점검 항목 반영
+
 ### 모바일 기능 3건 머지
 - PR #36 `feat/mobile-social-sdk`
   - Google/Kakao 소셜 SDK 로그인 추가

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,4 +1,4 @@
-﻿# Eunhye Hymn 이벤트 정의
+# Eunhye Hymn 이벤트 정의
 
 ## 1. 목적
 - 모바일/웹 사용자 행동 이벤트를 수집해 감사 로그, 분석, 디버깅에 활용한다.
@@ -51,9 +51,23 @@
 ### 4.2 관리자 감사 로그 조회
 - `GET /api/v1/admin/events`
 - 관리자 권한 필요
-- 필터: `eventType`, `userId`, `hymnId`, `from`, `to`, `limit`
+- 필터: `eventType`, `userId`, `hymnId`, `from`, `to`
+- 페이지네이션: `page`, `size` (`limit` 하위 호환)
 - 집계: `summaryDays` 기준 최근 N일 이벤트 타입별 합계
 
-## 5. 운영 메모
-- 이벤트는 텍스트 기반 `metadataJson`으로 저장한다.
-- 감사 화면에서 문제 시간대/사용자/찬양 단위로 필터링해 원인 추적에 활용한다.
+### 4.3 관리자 감사 로그 CSV
+- `GET /api/v1/admin/events/export`
+- 관리자 권한 필요
+- 필터: `eventType`, `userId`, `hymnId`, `from`, `to`
+- 제한: `limit` (서버 상한 적용)
+
+## 5. 인덱스/성능 메모
+- 관리자 조회 패턴 최적화를 위해 아래 인덱스를 사용한다.
+  - `idx_events_user_created` (`user_id`, `created_at`) - 기존
+  - `idx_events_created_at_desc` (`created_at DESC`)
+  - `idx_events_event_type_created` (`event_type`, `created_at DESC`)
+  - `idx_events_hymn_created` (`hymn_id`, `created_at DESC`)
+- 운영 시 확인 항목
+  - 관리자 이벤트 조회 응답 시간이 증가하면 `EXPLAIN ANALYZE`로 인덱스 사용 여부 확인
+  - 이벤트 테이블 급증 시 CSV `limit` 정책과 백필/아카이빙 정책을 함께 점검
+


### PR DESCRIPTION
## 요약
- 관리자 이벤트 조회/CSV 패턴에 맞춘 DB 인덱스 추가
  - `idx_events_created_at_desc`
  - `idx_events_event_type_created`
  - `idx_events_hymn_created`
- 이벤트 운영 문서(`docs/events.md`)에 조회 파라미터/인덱스/점검 항목 반영
- 변경 이력 업데이트(`docs/changelog-dev.md`)

## 검증
- `./gradlew.bat test --no-daemon --tests *AdminEventApiTest*` 통과

## 영향도
- 스키마 변경(Flyway V7) 포함
- 기능 동작 변경 없음, 조회 성능/운영 가시성 개선 목적