### PR TITLE
fix(staging): harden deploy flow with awslogs fallback

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -4,6 +4,16 @@ on:
   push:
     branches:
       - develop
+  workflow_dispatch:
+    inputs:
+      enable_awslogs:
+        description: "Enable CloudWatch awslogs overlay during deploy"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 env:
   AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -144,7 +154,7 @@ jobs:
       - name: Run deploy script
         env:
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
-          ENABLE_AWSLOGS: ${{ secrets.ENABLE_AWSLOGS }}
+          ENABLE_AWSLOGS: ${{ github.event_name == 'workflow_dispatch' && inputs.enable_awslogs || secrets.ENABLE_AWSLOGS }}
         run: |
           ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
             ec2-user@${{ secrets.EC2_HOST }} \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -508,9 +508,9 @@ com.eunhyehymn/
 - **실행**: `flutter pub get` → `flutter analyze` → `flutter test`
 
 ### Deploy Staging (`deploy-staging.yml`)
-- **트리거**: develop push
-- **Jobs**: `test-api` → `check-admin` → `build-and-push` → `deploy`
-- **단계**: API 테스트 → Admin 타입체크+빌드 → Docker 이미지 빌드 & ECR push (api:latest + admin:latest) → EC2 SSH 배포 (compose + awslogs 오버레이 + deploy.sh) → 헬스체크
+- **트리거**: develop push + `workflow_dispatch`
+- **Jobs**: `preflight-secrets` → `test-api` → `check-admin` → `build-and-push` → `deploy`
+- **단계**: Secrets 유효성 검사 → API 테스트 → Admin 타입체크+빌드 → Docker 이미지 빌드 & ECR push (api:latest + admin:latest) → EC2 SSH 배포 (compose + 선택적 awslogs 오버레이 + deploy.sh) → 헬스체크
 - **필수 Secrets**:
 
 | Secret | 설명 |
@@ -523,6 +523,8 @@ com.eunhyehymn/
 | `EC2_SSH_KEY` | EC2 SSH 프라이빗 키 (PEM) |
 | `DEPLOY_ENV_FILE` | `.env` 파일 전체 내용 (DB, JWT, S3 등) |
 | `ENABLE_AWSLOGS` | CloudWatch 로그 전송 활성화 여부 (`true` 시 활성화, 미설정 시 기본 `false`) |
+
+- **수동 검증 실행**: `workflow_dispatch`로 브랜치 기준 배포 검증 가능 (`enable_awslogs` 입력)
 
 ---
 
@@ -590,6 +592,7 @@ develop push → GitHub Actions
 - `api`는 `.env` 파일에서 DB_URL, JWT_SECRET 등 환경변수 로드
 - `nginx`는 `nginx.conf`에서 `/api/v1` → `http://api:8080` 프록시
 - 기본 로깅 드라이버는 `json-file`; `ENABLE_AWSLOGS=true`일 때 `docker-compose.prod.awslogs.yml` 오버레이로 CloudWatch 로그 전송 활성화
+- `deploy.sh`는 awslogs 드라이버 미지원/재기동 실패 시 기본 로깅으로 자동 fallback 후 재시도
 
 ### 15.6 Nginx 설정 (`apps/admin/nginx.conf`)
 

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -126,3 +126,30 @@
 - 범위 제외: 신규 기능 개발
 - 완료 기준: `docs/runbook.md` + `docs/staging-smoke-checklist.md` 기준으로 Go/No-Go 판단 근거 확보
 - 검증 명령: `rg -n "No-Go|필수 체크리스트|스모크|롤백" docs/runbook.md docs/staging-smoke-checklist.md docs/current-usable-scope.md docs/deployment-readiness-audit.md`
+
+## 5. 이번 사이클 기록 (2026-02-14, 2차)
+
+### 목표
+- 스테이징 배포 실패 원인(awslogs 옵션) 차단 + 브랜치 단위 배포 검증 경로 확보
+
+### 범위
+- 포함: deploy workflow/스크립트 안정화, 운영 문서 동기화
+- 제외: AWS 리소스 실제 생성/변경
+
+### 수행 작업
+1. 배포 워크플로 개선
+- `workflow_dispatch` 추가 (`enable_awslogs` 입력)
+- 필수 시크릿 검증 `preflight-secrets` 선행
+
+2. 배포 스크립트 안정화
+- `infra/aws/deploy.sh`에 awslogs 드라이버 감지
+- awslogs 실패 시 기본 로깅으로 자동 fallback 재시도
+
+3. 운영 문서 동기화
+- `infra/aws/README.md`: 수동 검증 실행 경로 추가
+- `docs/runbook.md`: 운영 반영/리허설 경로 분리 명시
+- `docs/changelog-dev.md`, `CLAUDE.md` 업데이트
+
+### 검증
+- `bash -n infra/aws/deploy.sh`
+- `rg -n "<<<<<<<|>>>>>>>" .github/workflows/deploy-staging.yml infra/aws/deploy.sh infra/aws/README.md docs/runbook.md`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,18 @@
 
 ## 2026-02-14
 
+### 스테이징 배포 안정화(2차)
+- `deploy-staging.yml` 개선
+  - `workflow_dispatch` 트리거 추가 (`enable_awslogs` 입력)
+  - `preflight-secrets` job을 선행해 필수 Secrets 누락 시 조기 실패
+- `deploy.sh` 안정화
+  - awslogs 드라이버 미지원 시 자동 fallback
+  - awslogs 모드 재기동 실패 시 기본 logging(`json-file`)으로 자동 재시도
+- 운영 문서 보강
+  - `infra/aws/README.md`에 수동 검증 실행(workflow_dispatch) 루트 추가
+  - `docs/runbook.md` 배포 절차에 운영 반영/리허설 실행 경로 분리 명시
+  - `CLAUDE.md` CI/CD 섹션 최신화
+
 ### 스테이징 실가동 준비 문서 사이클
 - 스테이징 스모크 테스트 기준 문서 추가
   - `docs/staging-smoke-checklist.md`

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -31,6 +31,8 @@
 ## 5. 배포 절차
 1. `develop`에 변경 머지
 2. GitHub Actions 배포 워크플로 실행
+   - 운영 반영: `develop` push 트리거
+   - 리허설/선검증: `Deploy Staging` workflow_dispatch (`enable_awslogs=false` 권장)
 3. EC2에서 컨테이너 상태 확인
    - `docker ps`
    - `docker logs <api_container> --tail 200`

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -140,6 +140,17 @@ Terraform 적용 후 아래 스크립트로 필수 Secrets를 한 번에 동기�
 .\scripts\staging-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn [-AwsProfile eunhye-staging]
 ```
 
+### 수동 실행 (권장 점검 루트)
+
+`deploy-staging.yml`은 `workflow_dispatch`를 지원합니다.
+
+- 브랜치 검증 시:
+  - GitHub Actions > `Deploy Staging` > `Run workflow`
+  - `Use workflow from`: 검증 브랜치 선택
+  - `enable_awslogs`: 기본 `false`로 실행
+- 운영 반영 시:
+  - `develop` 머지 후 push 트리거 자동 실행
+
 ### DEPLOY_ENV_FILE 내용
 
 `infra/aws/.env.example`을 참고하여 작성:
@@ -195,6 +206,8 @@ ssh -i eunhye-staging.pem ec2-user@${EC2_IP} \
 ```
 
 `ENABLE_AWSLOGS`는 기본값 `false`입니다. 기존 스테이징 인스턴스에서 Terraform(IAM/Log Group) 적용 전에 `true`로 배포하면 컨테이너 시작이 실패할 수 있으므로, 인프라 적용 이후에만 활성화하세요.
+
+참고: `deploy.sh`는 `ENABLE_AWSLOGS=true`라도 호스트가 awslogs 드라이버를 지원하지 않거나 awslogs 모드 재기동에 실패하면 기본 logging(`json-file`)으로 자동 fallback 후 재시도합니다.
 
 ## 검증
 

--- a/infra/aws/deploy.sh
+++ b/infra/aws/deploy.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 APP_DIR="/home/ec2-user/app"
 COMPOSE_FILE="${APP_DIR}/docker-compose.prod.yml"
 COMPOSE_AWSLOGS_FILE="${APP_DIR}/docker-compose.prod.awslogs.yml"
+COMPOSE_ARGS_BASE=(-f "${COMPOSE_FILE}")
 
 # Check required env
 if [ -z "${ECR_REGISTRY:-}" ]; then
@@ -17,12 +18,36 @@ if [ -z "${AWS_REGION:-}" ]; then
 fi
 
 ENABLE_AWSLOGS="${ENABLE_AWSLOGS:-false}"
-COMPOSE_ARGS=(-f "${COMPOSE_FILE}")
-if [ "${ENABLE_AWSLOGS}" = "true" ]; then
+
+to_lower() {
+  echo "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+is_true() {
+  case "$(to_lower "$1")" in
+    true|1|yes|y|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+has_awslogs_driver() {
+  docker info --format '{{range .Plugins.Log}}{{println .}}{{end}}' 2>/dev/null | grep -qx 'awslogs'
+}
+
+USE_AWSLOGS=false
+COMPOSE_ARGS=("${COMPOSE_ARGS_BASE[@]}")
+if is_true "${ENABLE_AWSLOGS}"; then
   if [ -f "${COMPOSE_AWSLOGS_FILE}" ]; then
-    COMPOSE_ARGS+=(-f "${COMPOSE_AWSLOGS_FILE}")
+    if has_awslogs_driver; then
+      USE_AWSLOGS=true
+      COMPOSE_ARGS+=(-f "${COMPOSE_AWSLOGS_FILE}")
+    else
+      echo "WARNING: awslogs driver is not available on this host; falling back to default json-file logging."
+      ENABLE_AWSLOGS=false
+    fi
   else
     echo "WARNING: ${COMPOSE_AWSLOGS_FILE} not found; falling back to default json-file logging."
+    ENABLE_AWSLOGS=false
   fi
 fi
 
@@ -31,7 +56,7 @@ export ECR_REGISTRY AWS_REGION ENABLE_AWSLOGS
 echo "=== Eunhye Hymn Deploy ==="
 echo "ECR Registry: ${ECR_REGISTRY}"
 echo "AWS Region:   ${AWS_REGION}"
-echo "AWS Logs:     ${ENABLE_AWSLOGS}"
+echo "AWS Logs:     ${ENABLE_AWSLOGS} (effective=${USE_AWSLOGS})"
 
 # ── 1. ECR Login ─────────────────────────────────────────────
 echo "[1/4] Logging in to ECR..."
@@ -44,7 +69,23 @@ docker compose "${COMPOSE_ARGS[@]}" pull
 
 # ── 3. Restart containers ───────────────────────────────────
 echo "[3/4] Restarting containers..."
+set +e
 docker compose "${COMPOSE_ARGS[@]}" up -d --remove-orphans
+UP_EXIT=$?
+set -e
+
+if [ "${UP_EXIT}" -ne 0 ]; then
+  if [ "${USE_AWSLOGS}" = "true" ]; then
+    echo "WARNING: compose up failed with awslogs enabled. Retrying with default logging."
+    ENABLE_AWSLOGS=false
+    export ENABLE_AWSLOGS
+    COMPOSE_ARGS=("${COMPOSE_ARGS_BASE[@]}")
+    docker compose "${COMPOSE_ARGS[@]}" up -d --remove-orphans
+  else
+    echo "ERROR: compose up failed."
+    exit "${UP_EXIT}"
+  fi
+fi
 
 # ── 4. Cleanup old images ───────────────────────────────────
 echo "[4/4] Cleaning up unused images..."


### PR DESCRIPTION
﻿## Summary
- add `workflow_dispatch` trigger to `deploy-staging.yml` with `enable_awslogs` input for branch-level deployment verification
- harden `infra/aws/deploy.sh` to detect awslogs driver support and automatically fall back to default logging when overlay startup fails
- sync staging operation docs (`infra/aws/README.md`, `docs/runbook.md`) and cycle/change tracking docs (`docs/changelog-dev.md`, `docs/WORK_CYCLE.md`, `CLAUDE.md`)

## Why
Recent staging runs failed when awslogs overlay was unavailable on target hosts. This PR keeps CloudWatch logging optional while making deployment resilient and testable via manual dispatch.

## Verification
- `bash -n infra/aws/deploy.sh`
- `rg -n "^(<<<<<<<|>>>>>>>|=======)$" .github/workflows/deploy-staging.yml infra/aws/deploy.sh infra/aws/README.md docs/runbook.md CLAUDE.md docs/changelog-dev.md docs/WORK_CYCLE.md`
- `gh workflow run deploy-staging.yml --ref feat/staging-activation-cycle -f enable_awslogs=false`
- `gh run watch 22008355661 --exit-status` (success)

## Risk / Follow-up
- when `enable_awslogs=true`, target EC2 must have docker awslogs capability and CloudWatch IAM permissions
- preflight/secret sync scripts should remain the primary gate before enabling logs in operations
