### PR TITLE
feat(staging): automate rehearsal run and evidence logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -525,6 +525,7 @@ com.eunhyehymn/
 | `ENABLE_AWSLOGS` | CloudWatch 로그 전송 활성화 여부 (`true` 시 활성화, 미설정 시 기본 `false`) |
 
 - **수동 검증 실행**: `workflow_dispatch`로 브랜치 기준 배포 검증 가능 (`enable_awslogs` 입력)
+- **리허설 자동 실행**: `scripts/staging-rehearsal.ps1`로 preflight + workflow_dispatch + run 대기 + 로그 기록 자동화
 
 ---
 
@@ -710,6 +711,8 @@ develop push → GitHub Actions
 - 스테이징 실가동 체크리스트/런북 동기화
   - `docs/staging-smoke-checklist.md`
   - `docs/runbook.md`
+- 스테이징 리허설 실행 로그 문서 추가
+  - `docs/staging-rehearsal-log.md`
 
 ### 미완료 (우선순위순)
 
@@ -721,13 +724,14 @@ develop push → GitHub Actions
 - 보조 스크립트:
   - `scripts/staging-preflight.ps1`
   - `scripts/staging-sync-secrets.ps1`
+  - `scripts/staging-rehearsal.ps1`
 - IAM 정책 샘플:
   - `infra/aws/terraform-deployer-iam-policy.json`
 - 진행 상태는 preflight 결과(`scripts/staging-preflight.ps1`)와 `gh secret list` 기준으로 최신화한다.
 
 **2. 운영 문서/절차 고도화**
 - `docs/runbook.md` + `docs/staging-smoke-checklist.md` 기준으로 롤백/장애 대응 리허설 수행 후 결과 반영
-- 배포 후 스모크 테스트 항목과 점검 결과를 주기적으로 갱신
+- 배포 후 스모크 테스트 항목과 점검 결과를 `docs/staging-rehearsal-log.md`에 주기적으로 갱신
 
 **3. 기능 백로그**
 - 감사 로그 고도화(집계 기간 커스텀, 대용량 비동기 export)

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -153,3 +153,32 @@
 ### 검증
 - `bash -n infra/aws/deploy.sh`
 - `rg -n "<<<<<<<|>>>>>>>" .github/workflows/deploy-staging.yml infra/aws/deploy.sh infra/aws/README.md docs/runbook.md`
+
+## 6. 이번 사이클 기록 (2026-02-14, 3차)
+
+### 목표
+- 스테이징 리허설 실행/기록 자동화로 Go/No-Go 근거 수집 시간을 단축
+
+### 범위
+- 포함: 리허설 자동 실행 스크립트 추가, 운영 문서/로그 템플릿 동기화
+- 제외: AWS 리소스 실제 생성/변경
+
+### 수행 작업
+1. 리허설 자동화 스크립트 추가
+- `scripts/staging-rehearsal.ps1`
+- preflight 실행, `deploy-staging.yml` workflow_dispatch 트리거, run 완료 대기, 결과 로그 자동 기록
+
+2. 리허설 로그 문서 추가
+- `docs/staging-rehearsal-log.md`
+- UTC 시간/브랜치/run URL/결과를 표 형식으로 누적 기록
+
+3. 운영 문서 동기화
+- `docs/runbook.md`: 자동 리허설 경로 및 로그 기록 위치 반영
+- `docs/staging-smoke-checklist.md`: 실행 전 자동 리허설 로그 확인 항목 반영
+- `infra/aws/README.md`: 스크립트 사용법 추가
+- `docs/changelog-dev.md`, `CLAUDE.md` 업데이트
+
+### 검증
+- `powershell -NoProfile -File .\\scripts\\staging-rehearsal.ps1 -DryRun -SkipPreflight` (의존성/파라미터 경로 확인용)
+- `rg -n "staging-rehearsal|staging-rehearsal-log" docs/runbook.md docs/staging-smoke-checklist.md infra/aws/README.md CLAUDE.md`
+- `rg -n "^(<<<<<<<|>>>>>>>|=======)$" scripts/staging-rehearsal.ps1 docs/staging-rehearsal-log.md docs/runbook.md docs/staging-smoke-checklist.md infra/aws/README.md docs/changelog-dev.md docs/WORK_CYCLE.md CLAUDE.md`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,17 @@
 
 ## 2026-02-14
 
+### 스테이징 리허설 자동화(3차)
+- 리허설 실행 스크립트 추가
+  - `scripts/staging-rehearsal.ps1`
+  - preflight 실행 → `deploy-staging.yml` `workflow_dispatch` 트리거 → run 완료 대기 → 결과 로그 기록 자동화
+- 리허설 이력 문서 추가
+  - `docs/staging-rehearsal-log.md`
+- 운영 문서 동기화
+  - `docs/runbook.md`, `docs/staging-smoke-checklist.md`, `infra/aws/README.md`
+  - 리허설 자동 실행 경로/증빙 문서 반영
+  - `CLAUDE.md`, `docs/WORK_CYCLE.md` 업데이트
+
 ### 스테이징 배포 안정화(2차)
 - `deploy-staging.yml` 개선
   - `workflow_dispatch` 트리거 추가 (`enable_awslogs` 입력)

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -12,6 +12,7 @@
 
 ## 3. 참조 문서
 - `docs/staging-smoke-checklist.md`
+- `docs/staging-rehearsal-log.md`
 - `docs/deployment-readiness-audit.md`
 - `infra/aws/README.md`
 - `docs/SECRETS_MANAGEMENT.md`
@@ -23,6 +24,9 @@
 - [ ] 롤백 기준 버전(이전 이미지 태그) 확인
 - [ ] 사전 점검 스크립트 통과
   - `.\scripts\staging-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn [-AwsProfile <profile>]`
+- [ ] 배포 리허설 자동 실행(권장)
+  - `.\scripts\staging-rehearsal.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref develop [-AwsProfile <profile>]`
+  - 로컬 확인만 필요하면 `-DryRun` 사용
 - [ ] GitHub Actions 필수 Secrets 등록 확인
   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `ECR_REGISTRY`, `EC2_HOST`, `EC2_SSH_KEY`, `DEPLOY_ENV_FILE`
 - [ ] GitHub Actions 배포 워크플로 최신 성공 이력 확인
@@ -33,6 +37,7 @@
 2. GitHub Actions 배포 워크플로 실행
    - 운영 반영: `develop` push 트리거
    - 리허설/선검증: `Deploy Staging` workflow_dispatch (`enable_awslogs=false` 권장)
+   - 자동화 경로: `.\scripts\staging-rehearsal.ps1` 실행 시 preflight + workflow_dispatch + run 완료 대기 + 로그 기록을 일괄 수행
 3. EC2에서 컨테이너 상태 확인
    - `docker ps`
    - `docker logs <api_container> --tail 200`
@@ -40,7 +45,7 @@
    - `curl http://<EC2_HOST>/api/v1/ping`
 5. `docs/staging-smoke-checklist.md` 전 항목 수행
 6. 결과 기록
-   - 성공: 배포 시각, 커밋, 수행자, 체크 결과를 문서/티켓에 기록
+   - 성공: 배포 시각, 커밋, 수행자, 체크 결과를 문서/티켓에 기록 (`docs/staging-rehearsal-log.md` 포함)
    - 실패: 즉시 롤백 후 장애 대응 절차로 전환
 
 ## 6. 롤백 절차

--- a/docs/staging-rehearsal-log.md
+++ b/docs/staging-rehearsal-log.md
@@ -1,0 +1,6 @@
+# Staging Rehearsal Log
+
+스테이징 리허설 실행 기록 문서다. `scripts/staging-rehearsal.ps1`가 자동으로 행을 추가한다.
+
+| UTC Time | Repo | Ref | Preflight | Workflow Run | Result | Notes |
+|----------|------|-----|-----------|--------------|--------|-------|

--- a/docs/staging-smoke-checklist.md
+++ b/docs/staging-smoke-checklist.md
@@ -8,9 +8,13 @@
 
 - [ ] GitHub Actions 배포 워크플로가 정상 완료되었는지 확인
 - [ ] 점검 대상 커밋 SHA/배포 시각/담당자 확정
+- [ ] 자동 리허설 로그(`docs/staging-rehearsal-log.md`) 최신 행 확인
 - [ ] 관리자 계정 및 모바일 테스트 계정 준비
 - [ ] 모바일 테스트 기기(최소 1대) + 웹(Chrome) 준비
 - [ ] 로그 확인 경로 준비 (EC2 docker logs, CloudWatch)
+
+권장 실행:
+- `.\scripts\staging-rehearsal.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref develop [-AwsProfile <profile>]`
 
 ## 2. API 기본 점검
 

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -140,6 +140,19 @@ Terraform 적용 후 아래 스크립트로 필수 Secrets를 한 번에 동기�
 .\scripts\staging-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn [-AwsProfile eunhye-staging]
 ```
 
+리허설 자동 실행(권장):
+
+```powershell
+.\scripts\staging-rehearsal.ps1 `
+  -Repo V4N1LLA/Eunhye_Hymn `
+  -Ref develop `
+  [-AwsProfile eunhye-staging]
+```
+
+이 스크립트는 `staging-preflight.ps1` 실행 후 `deploy-staging.yml`을 `workflow_dispatch`로 트리거하고 run 완료까지 대기한 다음 `docs/staging-rehearsal-log.md`에 결과를 기록한다.
+
+로컬 문법/파라미터 검증만 필요하면 `-DryRun` 옵션을 사용한다.
+
 ### 수동 실행 (권장 점검 루트)
 
 `deploy-staging.yml`은 `workflow_dispatch`를 지원합니다.

--- a/scripts/staging-rehearsal.ps1
+++ b/scripts/staging-rehearsal.ps1
@@ -1,0 +1,169 @@
+param(
+  [string]$Repo = "V4N1LLA/Eunhye_Hymn",
+  [string]$Ref = "develop",
+  [string]$Workflow = "deploy-staging.yml",
+  [string]$AwsProfile = "",
+  [switch]$SkipPreflight,
+  [switch]$SkipTerraformPlan,
+  [switch]$EnableAwsLogs,
+  [switch]$DryRun,
+  [int]$RunDetectRetries = 24,
+  [int]$RunDetectIntervalSeconds = 5,
+  [int]$WatchIntervalSeconds = 10,
+  [string]$LogFile = "docs/staging-rehearsal-log.md"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Test-CommandExists {
+  param([string]$Name)
+  return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Invoke-CommandStrict {
+  param(
+    [string]$Name,
+    [scriptblock]$Command
+  )
+  & $Command
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Name failed with exit code $LASTEXITCODE"
+  }
+}
+
+function Ensure-LogFile {
+  param([string]$Path)
+  if (Test-Path $Path) {
+    return
+  }
+
+  @"
+# Staging Rehearsal Log
+
+스테이징 리허설 실행 기록 문서다. `scripts/staging-rehearsal.ps1`가 자동으로 행을 추가한다.
+
+| UTC Time | Repo | Ref | Preflight | Workflow Run | Result | Notes |
+|----------|------|-----|-----------|--------------|--------|-------|
+"@ | Set-Content -Path $Path -Encoding utf8
+}
+
+function Append-LogRow {
+  param(
+    [string]$Path,
+    [string]$RepoName,
+    [string]$BranchRef,
+    [string]$PreflightStatus,
+    [string]$RunUrl,
+    [string]$Result,
+    [string]$Notes
+  )
+
+  Ensure-LogFile -Path $Path
+  $utc = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+  Add-Content -Path $Path -Value "| $utc | $RepoName | $BranchRef | $PreflightStatus | $RunUrl | $Result | $Notes |" -Encoding utf8
+}
+
+if (-not (Test-CommandExists "gh")) {
+  throw "gh CLI is required."
+}
+
+$preflightStatus = "SKIPPED"
+$notes = "enable_awslogs=$($EnableAwsLogs.IsPresent.ToString().ToLower())"
+
+if (-not $SkipPreflight) {
+  $preflightScript = Join-Path $PSScriptRoot "staging-preflight.ps1"
+  if (-not (Test-Path $preflightScript)) {
+    throw "preflight script not found: $preflightScript"
+  }
+
+  $preflightArgs = @(
+    "-File", $preflightScript,
+    "-Repo", $Repo
+  )
+  if (-not [string]::IsNullOrWhiteSpace($AwsProfile)) {
+    $preflightArgs += @("-AwsProfile", $AwsProfile)
+  }
+  if ($SkipTerraformPlan) {
+    $preflightArgs += "-SkipTerraformPlan"
+  }
+
+  & powershell.exe @preflightArgs
+  if ($LASTEXITCODE -ne 0) {
+    $preflightStatus = "FAILED"
+    Append-LogRow -Path $LogFile -RepoName $Repo -BranchRef $Ref -PreflightStatus $preflightStatus -RunUrl "-" -Result "ABORTED" -Notes "preflight failed"
+    throw "staging preflight failed; rehearsal aborted."
+  }
+  $preflightStatus = "PASS"
+}
+
+$triggeredAfter = (Get-Date).ToUniversalTime()
+$enableValue = if ($EnableAwsLogs) { "true" } else { "false" }
+
+if ($DryRun) {
+  Write-Host "[DryRun] Repo: $Repo"
+  Write-Host "[DryRun] Ref: $Ref"
+  Write-Host "[DryRun] Workflow: $Workflow"
+  Write-Host "[DryRun] enable_awslogs=$enableValue"
+  Write-Host "[DryRun] Preflight: $preflightStatus"
+  Write-Host "[DryRun] LogFile: $LogFile"
+  exit 0
+}
+
+Invoke-CommandStrict -Name "gh workflow run" -Command {
+  gh workflow run $Workflow --repo $Repo --ref $Ref -f "enable_awslogs=$enableValue"
+}
+
+$runId = $null
+$runUrl = $null
+for ($i = 0; $i -lt $RunDetectRetries; $i++) {
+  $runJson = gh run list --repo $Repo --workflow $Workflow --branch $Ref --event workflow_dispatch --limit 5 --json databaseId,createdAt,url,status
+  if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($runJson)) {
+    $runs = $runJson | ConvertFrom-Json
+    $candidate = $runs |
+      Where-Object { ([DateTime]$_.createdAt).ToUniversalTime() -ge $triggeredAfter.AddSeconds(-5) } |
+      Sort-Object { [DateTime]$_.createdAt } -Descending |
+      Select-Object -First 1
+
+    if ($null -ne $candidate) {
+      $runId = "$($candidate.databaseId)"
+      $runUrl = "$($candidate.url)"
+      break
+    }
+  }
+  Start-Sleep -Seconds $RunDetectIntervalSeconds
+}
+
+if ([string]::IsNullOrWhiteSpace($runId)) {
+  Append-LogRow -Path $LogFile -RepoName $Repo -BranchRef $Ref -PreflightStatus $preflightStatus -RunUrl "-" -Result "FAILED" -Notes "could not detect workflow run id"
+  throw "failed to detect workflow run id after trigger."
+}
+
+gh run watch $runId --repo $Repo --interval $WatchIntervalSeconds --exit-status
+$watchExitCode = $LASTEXITCODE
+
+$runView = gh run view $runId --repo $Repo --json conclusion,status,url,headSha,workflowName,createdAt,updatedAt
+if ($LASTEXITCODE -ne 0) {
+  $result = if ($watchExitCode -eq 0) { "SUCCESS" } else { "FAILED" }
+  Append-LogRow -Path $LogFile -RepoName $Repo -BranchRef $Ref -PreflightStatus $preflightStatus -RunUrl $runUrl -Result $result -Notes "$notes, run_id=$runId"
+  if ($watchExitCode -ne 0) {
+    throw "workflow run failed (run id: $runId)."
+  }
+  Write-Host "Rehearsal completed: $runUrl"
+  exit 0
+}
+
+$runInfo = $runView | ConvertFrom-Json
+$conclusion = if ([string]::IsNullOrWhiteSpace($runInfo.conclusion)) { "unknown" } else { $runInfo.conclusion }
+$result = if ($watchExitCode -eq 0) { "SUCCESS" } else { "FAILED" }
+$summary = "$notes, run_id=$runId, conclusion=$conclusion, head_sha=$($runInfo.headSha)"
+
+Append-LogRow -Path $LogFile -RepoName $Repo -BranchRef $Ref -PreflightStatus $preflightStatus -RunUrl $runInfo.url -Result $result -Notes $summary
+
+if ($watchExitCode -ne 0) {
+  throw "workflow run failed (run id: $runId, conclusion: $conclusion)."
+}
+
+Write-Host "Rehearsal completed successfully."
+Write-Host "Run: $($runInfo.url)"
+Write-Host "Recorded at: $LogFile"
+exit 0


### PR DESCRIPTION
﻿## Summary
- add `scripts/staging-rehearsal.ps1` to automate staging rehearsal flow:
  - run `scripts/staging-preflight.ps1` (optional skip)
  - trigger `deploy-staging.yml` via `workflow_dispatch`
  - wait for workflow completion and determine result
  - append evidence row into `docs/staging-rehearsal-log.md`
- add reusable rehearsal evidence log doc: `docs/staging-rehearsal-log.md`
- sync operational docs and project context for the new rehearsal path:
  - `docs/runbook.md`
  - `docs/staging-smoke-checklist.md`
  - `infra/aws/README.md`
  - `docs/changelog-dev.md`
  - `docs/WORK_CYCLE.md`
  - `CLAUDE.md`

## Why
The highest-priority unfinished area is staging go-live verification. We had preflight/secret-sync scripts but no single command to execute and record a rehearsal run. This PR reduces manual steps and keeps a consistent Go/No-Go evidence trail.

## Verification
- `powershell -NoProfile -File .\scripts\staging-rehearsal.ps1 -DryRun -SkipPreflight`
- PowerShell parser check for `scripts/staging-rehearsal.ps1` (no parse errors)
- `rg -n "staging-rehearsal|staging-rehearsal-log" docs/runbook.md docs/staging-smoke-checklist.md infra/aws/README.md CLAUDE.md docs/changelog-dev.md docs/WORK_CYCLE.md`
- `rg -n "^(<<<<<<<|>>>>>>>|=======)$" scripts/staging-rehearsal.ps1 docs/staging-rehearsal-log.md docs/runbook.md docs/staging-smoke-checklist.md infra/aws/README.md docs/changelog-dev.md docs/WORK_CYCLE.md CLAUDE.md` (no matches)
- secret-pattern spot check: no credential/key literals added in changed files

## Risk / Follow-up
- `scripts/staging-rehearsal.ps1` is Windows PowerShell oriented (`powershell.exe` call). If cross-platform use is required, we can add a `pwsh` compatible fallback path.
- Full end-to-end verification requires real AWS/GitHub environment (intentional); local validation used `-DryRun`.
