### PR TITLE
chore(staging): harden preflight identity checks and sync readiness docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -717,6 +717,8 @@ develop push → GitHub Actions
   - `22010284332` (develop)
   - `22010387328` (rollback rehearsal)
   - `22010470389` (develop restore)
+- preflight 스크립트 실패 원인 가시성 보강
+  - `scripts/staging-preflight.ps1` (`aws sts get-caller-identity` 실패 원인 상세 출력)
 
 ### 미완료 (우선순위순)
 
@@ -724,6 +726,7 @@ develop push → GitHub Actions
 - Terraform 실제 적용 및 AWS 리소스 활성화
 - GitHub Actions Secrets/권한 상태 주기 점검 및 preflight 통과 환경 유지
 - EC2 접근 권한/배포 계정 권한 점검 및 운영 체크리스트 정기 실행
+- Admin/Mobile 런타임 수동 스모크 정례 실행
 - 단계별 온보딩: `docs/admin/aws-free-tier-onboarding.md`
 - 보조 스크립트:
   - `scripts/staging-preflight.ps1`

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -221,3 +221,31 @@
 - `gh run view 22010284332 --json conclusion,jobs,url`
 - `gh run view 22010387328 --json conclusion,jobs,url`
 - `gh run view 22010470389 --json conclusion,jobs,url`
+
+## 8. 이번 사이클 기록 (2026-02-14, 5차)
+
+### 목표
+- 다음 우선순위 작업 수행: preflight 실행성 개선 + 준비도 문서 상태 최신화
+
+### 범위
+- 포함: preflight 스크립트 오류 처리 보강, 상태 문서 동기화
+- 제외: 애플리케이션 기능 개발
+
+### 수행 작업
+1. 환경 보정
+- 로컬 `aws`/`terraform` CLI 설치
+- preflight 무스킵 실행 시도
+
+2. preflight 하드닝
+- `scripts/staging-preflight.ps1`에서 `aws sts get-caller-identity` 실패 처리 개선
+- 자격증명/프로필 문제를 표 형태로 명시해 즉시 원인 파악 가능하게 수정
+
+3. 문서 동기화
+- `docs/current-usable-scope.md`: 기준 커밋/근거 PR/스테이징 실행 상태 최신화
+- `docs/deployment-readiness-audit.md`: 2026-02-14 리허설/롤백/복구 결과 반영
+- `docs/changelog-dev.md`, `CLAUDE.md` 업데이트
+
+### 검증
+- `powershell -NoProfile -File .\\scripts\\staging-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn`
+- `aws sts get-caller-identity` (현재 환경: credential 미설정 확인)
+- `rg -n "22010284332|22010387328|22010470389|Conditional Go|preflight" docs/current-usable-scope.md docs/deployment-readiness-audit.md docs/changelog-dev.md CLAUDE.md`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,14 @@
 
 ## 2026-02-14
 
+### 스테이징 준비도 동기화 + preflight 하드닝(5차)
+- `scripts/staging-preflight.ps1` 개선
+  - `aws sts get-caller-identity` 실패 시 즉시 예외 종료 대신 원인(자격증명/프로필/응답) 표준 출력
+  - 자격증명 미설정 환경에서도 preflight 결과를 표 형태로 확인 가능
+- 상태 문서 최신화
+  - `docs/current-usable-scope.md`: 기준 커밋/근거 PR/실리허설 결과/남은 과제 동기화
+  - `docs/deployment-readiness-audit.md`: 2026-02-14 리허설/롤백/복구 실행 결과 반영
+
 ### 스테이징 실가동 리허설 실행(4차)
 - 요청된 사이클 1~3 실제 수행
   - 1) `develop` 리허설 배포 성공: run `22010284332`

--- a/docs/current-usable-scope.md
+++ b/docs/current-usable-scope.md
@@ -2,9 +2,9 @@
 
 - 작성일: 2026-02-14
 - 기준 브랜치: `develop` (통합/배포 기준)
-- 기준 커밋: `7757090` (2026-02-14 로컬 확인 시점 `develop` HEAD)
+- 기준 커밋: `630edd4` (2026-02-14 03:51 UTC 기준 `develop` HEAD)
 - 근거 문서: `README.md`, `CLAUDE.md`, `docs/WORK_CYCLE.md`
-- 근거 PR: #43, #42, #41, #40, #38, #37, #36, #31
+- 근거 PR: #49, #48, #47, #46, #45, #43, #42, #41, #40, #38, #37, #36, #31
 
 ## 1. 요약
 
@@ -13,7 +13,8 @@
 - 로컬 기능: 관리자 웹(Admin) + 백엔드 API + 모바일 앱(MVP + 모바일 고도화 3건) 사용 가능
 - 배포 기능: AWS 스테이징 자동 배포 파이프라인 코드 구성 완료
 - CI 기능: API/Admin/Mobile 검증 워크플로우 구성 완료
-- 현재 우선 과제: 스테이징 실배포 전환(Terraform 적용, Secrets 설정, EC2 권한/접근 확인)
+- 스테이징 리허설/롤백/복구 자동 실행 증빙 확보(run `22010284332`, `22010387328`, `22010470389`)
+- 현재 우선 과제: 운영 PC 기준 preflight 무스킵 통과 환경 유지 + Admin/Mobile 수동 스모크 정례화
 - 모바일 배포 상태: 현재 저장소 기준 웹 실행(`-d chrome`) 중심이며, 앱스토어 배포(Android/iOS)는 별도 준비가 필요
 
 ## 2. 지금 바로 검증 가능한 범위 (로컬)
@@ -93,14 +94,15 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
 - `apps/admin/nginx.conf`
 - `apps/api/Dockerfile`
 
-실제 동작을 위해 아래 선행 조건이 필요하다.
+실행 상태(2026-02-14 기준):
 
-- [ ] AWS 리소스 생성(Terraform)
-- [ ] GitHub Secrets 설정(`AWS_*`, `ECR_REGISTRY`, `EC2_HOST`, `EC2_SSH_KEY`, `DEPLOY_ENV_FILE`, 선택: `ENABLE_AWSLOGS`)
-- [ ] EC2 접근 가능 상태 및 배포 계정 권한 확인
-- [ ] 배포 서버 `.env` 준비 (`infra/aws/docker-compose.prod.yml`의 `env_file: .env` 요구)
-- [ ] 첫 `develop` 배포 후 `GET /api/v1/ping` + 관리자 로그인 + 핵심 API 스모크 테스트
-- [ ] `docs/staging-smoke-checklist.md` 기준 점검 결과 기록 및 `docs/runbook.md`와 동기화
+- [x] AWS 리소스 생성(Terraform)
+- [x] GitHub Secrets 설정(`AWS_*`, `ECR_REGISTRY`, `EC2_HOST`, `EC2_SSH_KEY`, `DEPLOY_ENV_FILE`, 선택: `ENABLE_AWSLOGS`)
+- [x] EC2 접근 가능 상태 및 배포 계정 권한 확인
+- [x] 배포 서버 `.env` 준비 (`DEPLOY_ENV_FILE` 기반)
+- [x] `develop` 배포 후 헬스체크 통과 (`deploy` verify 단계 성공)
+- [x] `docs/staging-smoke-checklist.md` 및 `docs/staging-rehearsal-log.md`에 결과 기록
+- [ ] Admin/Mobile 런타임 수동 스모크(실기기/실계정) 주기 실행
 
 실행 상태 확인:
 - 사전 점검: `scripts/staging-preflight.ps1`
@@ -130,12 +132,11 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
 ## 5. 미완료 범위 (우선순위)
 
 - 스테이징 실가동 전환
-  - Terraform apply 및 리소스 활성화
-  - GitHub Secrets 구성
-  - 배포/롤백/장애 대응 실동작 검증
+  - 운영 PC 기준 `staging-preflight.ps1` 무스킵 통과 상태 유지 (`aws` 자격증명 + `infra/aws/terraform.tfvars`)
+  - 배포/롤백/장애 대응 리허설의 정기 반복 및 증빙 누적
 - 운영 문서/절차 실행 검증
-  - `docs/runbook.md` + `docs/staging-smoke-checklist.md` 기준 리허설 1회 수행
-  - 리허설 결과를 `docs/changelog-dev.md`에 기록
+  - `docs/runbook.md` + `docs/staging-smoke-checklist.md` 기준 Admin/Mobile 수동 스모크 실행
+  - 리허설/스모크 결과를 `docs/changelog-dev.md`에 주기 반영
 - 운영 기능 백로그
   - 감사 로그 고도화(집계 기간 커스텀, 대용량 비동기 export)
 
@@ -184,4 +185,12 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
 ### 7.2 2026-02-14 문서 동기화
 - 스테이징 스모크 체크리스트 문서 추가: `docs/staging-smoke-checklist.md`
 - 운영 런북과 스모크 테스트 절차 동기화: `docs/runbook.md`
+
+### 7.3 2026-02-14 실리허설/롤백 검증 로그
+- `scripts/staging-rehearsal.ps1 -Ref develop -SkipPreflight`
+  - run: `22010284332` (success)
+- rollback rehearsal (`tmp/staging-rollback-6fef282`)
+  - run: `22010387328` (success)
+- develop restore rehearsal
+  - run: `22010470389` (success)
 

--- a/docs/deployment-readiness-audit.md
+++ b/docs/deployment-readiness-audit.md
@@ -8,7 +8,7 @@
 
 - 로컬 개발/검증: **가능**
 - 스테이징 자동배포 파이프라인: **코드 구성 완료 (조건부 가능)**
-- 스테이징 실가동: **미완료** (인프라 생성/시크릿/접근 검증 필요)
+- 스테이징 실가동: **조건부 가능** (배포/롤백/복구 리허설 성공, 수동 스모크 정례화 필요)
 - 프로덕션 배포: **준비 전**
 - 모바일 스토어 배포(Android/iOS): **준비 전**
 
@@ -108,10 +108,29 @@
   - 사전 점검 스크립트 추가: `scripts/staging-preflight.ps1`
   - Secrets 동기화 스크립트 추가: `scripts/staging-sync-secrets.ps1`
 
+### 4.2 2026-02-14 진행 업데이트 (기록)
+
+- 완료:
+  - 스테이징 리허설 실행 성공 (`workflow_dispatch`)
+    - `22010284332` (`develop`)
+  - 롤백 리허설 실행 성공 (임시 브랜치 기준)
+    - `22010387328` (`tmp/staging-rollback-6fef282`)
+  - 최신 develop 재배포(복구) 성공
+    - `22010470389` (`develop`)
+  - 리허설 증빙 문서화 완료
+    - `docs/staging-rehearsal-log.md`
+    - `docs/staging-smoke-checklist.md`
+- 보강:
+  - `scripts/staging-rehearsal.ps1`에 SHA ref 가드 추가
+    - `workflow_dispatch` branch/tag 제약을 명확히 안내
+- 잔여:
+  - 운영 PC 기준 preflight 무스킵 통과 상태 유지 (`aws` 자격증명 + `terraform.tfvars`)
+  - Admin/Mobile 런타임 수동 스모크 정기 수행
+
 ## 5. 현재 판단 (Go/No-Go)
 
 - 로컬 데모/개발: **Go**
-- 스테이징 실운영 검증: **Conditional Go** (체크리스트 완료 후)
+- 스테이징 실운영 검증: **Conditional Go** (배포/롤백 자동 리허설은 통과, Admin/Mobile 수동 스모크 정례화 필요)
 - 프로덕션 공개 배포: **No-Go**
 - 모바일 앱스토어 배포: **No-Go**
 

--- a/scripts/staging-preflight.ps1
+++ b/scripts/staging-preflight.ps1
@@ -93,14 +93,30 @@ if (-not (Test-CommandExists "aws") -or -not (Test-CommandExists "terraform") -o
 }
 
 $identityCommand = Build-AwsCommand "sts get-caller-identity"
-$identityJson = & $env:ComSpec /d /c $identityCommand 2>$null
-if ($LASTEXITCODE -ne 0) {
-  Add-Check "aws sts get-caller-identity" $false "failed"
+$identityResult = Run-CommandCapture $identityCommand
+if ($identityResult.ExitCode -ne 0) {
+  $identityDetail = "failed"
+  if ($identityResult.Output -match "Unable to locate credentials|NoCredentialProviders") {
+    $identityDetail = "credentials missing (run aws configure or aws configure sso)"
+  } elseif ($identityResult.Output -match "The config profile .* could not be found") {
+    $identityDetail = "aws profile not found"
+  } elseif (-not [string]::IsNullOrWhiteSpace($identityResult.Output)) {
+    $identityDetail = "failed: " + $identityResult.Output.Split("`n")[0]
+  }
+
+  Add-Check "aws sts get-caller-identity" $false $identityDetail
   $checks | Format-Table -AutoSize
   exit 1
 }
 
-$identity = $identityJson | ConvertFrom-Json
+try {
+  $identity = $identityResult.Output | ConvertFrom-Json
+} catch {
+  Add-Check "aws sts get-caller-identity" $false "failed: invalid json response"
+  $checks | Format-Table -AutoSize
+  exit 1
+}
+
 Add-Check "aws identity" $true ("arn=" + $identity.Arn)
 
 gh auth status 1>$null 2>$null

--- a/scripts/staging-preflight.ps1
+++ b/scripts/staging-preflight.ps1
@@ -97,7 +97,7 @@ $identityResult = Run-CommandCapture $identityCommand
 if ($identityResult.ExitCode -ne 0) {
   $identityDetail = "failed"
   if ($identityResult.Output -match "Unable to locate credentials|NoCredentialProviders") {
-    $identityDetail = "credentials missing (run aws configure or aws configure sso)"
+    $identityDetail = "credentials missing (run aws configure / aws configure sso / aws login)"
   } elseif ($identityResult.Output -match "The config profile .* could not be found") {
     $identityDetail = "aws profile not found"
   } elseif (-not [string]::IsNullOrWhiteSpace($identityResult.Output)) {


### PR DESCRIPTION
﻿## Summary
- harden `scripts/staging-preflight.ps1` identity check path:
  - replace direct `cmd` invocation with captured execution
  - return actionable reasons for STS failure (missing credentials/profile/invalid response)
  - keep tabular preflight output even when identity check fails
- sync readiness state documents to current `develop` evidence:
  - `docs/current-usable-scope.md`
  - `docs/deployment-readiness-audit.md`
  - `docs/changelog-dev.md`
  - `docs/WORK_CYCLE.md`
  - `CLAUDE.md`

## Why
The next priority was preflight non-skip verification and readiness-state alignment. After installing missing CLIs, preflight surfaced a poor failure mode (hard exception on missing AWS credentials). This PR fixes that and updates docs to match the completed rehearsal/rollback evidence from 2026-02-14.

## Verification
- `aws --version`
- `terraform version`
- `powershell -NoProfile -File .\scripts\staging-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn`
  - expected in current local env: credential-related fail with clear detail (no hard stack trace)
- `aws sts get-caller-identity`
  - expected in current local env: `Unable to locate credentials`
- PowerShell parser check for `scripts/staging-preflight.ps1` (no parse errors)
- `rg -n "22010284332|22010387328|22010470389|Conditional Go|preflight" docs/current-usable-scope.md docs/deployment-readiness-audit.md docs/changelog-dev.md docs/WORK_CYCLE.md CLAUDE.md`
- `rg -n "^(<<<<<<<|>>>>>>>|=======)$" scripts/staging-preflight.ps1 docs/current-usable-scope.md docs/deployment-readiness-audit.md docs/changelog-dev.md docs/WORK_CYCLE.md CLAUDE.md` (no matches)

## Risk / Follow-up
- preflight will still fail until AWS credentials/profile are configured (intended); now the reason is explicit.
- full non-skip pass additionally requires `infra/aws/terraform.tfvars` on the execution machine.
