### PR TITLE
feat(admin): support custom summary window for event analytics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,7 +258,7 @@ com.eunhyehymn/
 
 | Method | Path | 인증 | 설명 |
 |--------|------|------|------|
-| GET | `/admin/events` | ADMIN | 이벤트 로그 조회 + 최근 N일 이벤트 타입 집계 |
+| GET | `/admin/events` | ADMIN | 이벤트 로그 조회 + 최근 N일 이벤트 타입 집계 (`summaryDays` 1~90) |
 | GET | `/admin/events/export` | ADMIN | 이벤트 로그 CSV 내보내기 |
 
 ### 7.8 사용자 개인 (`MeController`)
@@ -438,7 +438,7 @@ com.eunhyehymn/
 | `src/pages/AdminAssetUploadPage.tsx` | 에셋 업로드 3단계 UI (Tailwind 스타일, hymnId/onConfirmed props 지원) |
 | `src/pages/UserListPage.tsx` | 사용자 목록 테이블 + 역할/상태 변경 + 검색/필터 |
 | `src/pages/InviteCodePage.tsx` | 초대코드 목록 + 생성/비활성화 + **만료일 설정 및 표시** |
-| `src/pages/AdminEventPage.tsx` | 감사 로그 필터/페이지네이션 조회 + 최근 N일 집계 + CSV 내보내기 |
+| `src/pages/AdminEventPage.tsx` | 감사 로그 필터/페이지네이션 조회 + 집계 기간(1~90일) 커스텀 + CSV 내보내기 |
 | `src/App.tsx` | BrowserRouter 라우팅 설정 |
 
 ### 라우팅 구조
@@ -662,7 +662,7 @@ develop push → GitHub Actions
 - 에셋 업로드 3단계 (presign/upload/confirm) + 삭제
 - 사용자 관리 (역할/상태 변경, 검색/필터)
 - 초대코드 관리 (생성/비활성화/만료일 설정)
-- 감사 로그/분석 화면 (`GET /admin/events`) - 필터/페이지네이션 조회 + 최근 N일 집계 + CSV 내보내기
+- 감사 로그/분석 화면 (`GET /admin/events`) - 필터/페이지네이션 조회 + 집계 기간(1~90일) 커스텀 + CSV 내보내기
 - 소셜 로그인 UI (Google/Kakao) + 초대코드 입력 플로우
 - Access Token 자동 갱신 (401 → refresh → 재시도, mutex 패턴)
 - 인증 컨텍스트 (`loginWithSocial`, `setTokensAndUser`), 공통 API 클라이언트, 사이드바 레이아웃
@@ -741,7 +741,7 @@ develop push → GitHub Actions
 - 배포 후 스모크 테스트 항목과 점검 결과를 `docs/staging-rehearsal-log.md`에 주기적으로 갱신
 
 **3. 기능 백로그**
-- 감사 로그 고도화(집계 기간 커스텀, 대용량 비동기 export)
+- 감사 로그 고도화(대용량 비동기 export)
 
 **4. 모바일 배포 패키징**
 - 현재 저장소 기준 실행은 `flutter run -d chrome` 중심

--- a/apps/admin/src/pages/AdminEventPage.tsx
+++ b/apps/admin/src/pages/AdminEventPage.tsx
@@ -15,7 +15,9 @@ const EVENT_TYPE_OPTIONS: Array<{ label: string; value: "all" | EventType }> = [
   { label: "즐겨찾기", value: "FAVORITE_TOGGLED" },
 ];
 
-const SUMMARY_DAY_OPTIONS = [1, 7, 30];
+const SUMMARY_DAY_PRESETS = [1, 7, 30, 60, 90];
+const MIN_SUMMARY_DAYS = 1;
+const MAX_SUMMARY_DAYS = 90;
 const SIZE_OPTIONS = [20, 50, 100, 200];
 
 function toIsoUtc(localDateTime: string): string | undefined {
@@ -44,6 +46,10 @@ function triggerDownload(blob: Blob, filename: string): void {
   URL.revokeObjectURL(url);
 }
 
+function clampSummaryDays(days: number): number {
+  return Math.min(Math.max(days, MIN_SUMMARY_DAYS), MAX_SUMMARY_DAYS);
+}
+
 export default function AdminEventPage() {
   const [eventType, setEventType] = useState<"all" | EventType>("all");
   const [userId, setUserId] = useState("");
@@ -67,6 +73,7 @@ export default function AdminEventPage() {
   const [loading, setLoading] = useState(true);
   const [exporting, setExporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isSummaryWindowFromDateFilter = Boolean(fromLocal || toLocal);
 
   const maxSummaryCount = useMemo(() => {
     if (!summary || summary.byType.length === 0) {
@@ -184,16 +191,43 @@ export default function AdminEventPage() {
                 <option key={option} value={option}>{`${option}건`}</option>
               ))}
             </select>
-            <select
+            <input
+              type="number"
+              min={MIN_SUMMARY_DAYS}
+              max={MAX_SUMMARY_DAYS}
               value={summaryDays}
-              onChange={(e) => setSummaryDays(Number(e.target.value))}
+              onChange={(e) => {
+                const parsed = Number.parseInt(e.target.value, 10);
+                if (Number.isNaN(parsed)) {
+                  setSummaryDays(MIN_SUMMARY_DAYS);
+                  return;
+                }
+                setSummaryDays(clampSummaryDays(parsed));
+              }}
+              onBlur={() => setSummaryDays((prev) => clampSummaryDays(prev))}
               className="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-            >
-              {SUMMARY_DAY_OPTIONS.map((days) => (
-                <option key={days} value={days}>{`최근 ${days}일`}</option>
-              ))}
-            </select>
+              title="집계 기간(일)"
+              placeholder="집계 기간(일)"
+            />
           </div>
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <span className="text-xs text-gray-500">집계 기간 프리셋</span>
+          {SUMMARY_DAY_PRESETS.map((days) => (
+            <button
+              key={days}
+              type="button"
+              onClick={() => setSummaryDays(days)}
+              className={`px-2 py-1 text-xs rounded border ${
+                summaryDays === days
+                  ? "bg-indigo-600 text-white border-indigo-600"
+                  : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+              }`}
+            >
+              {`${days}일`}
+            </button>
+          ))}
+          <span className="text-xs text-gray-500">허용 범위: 1~90일</span>
         </div>
         <div className="mt-3 flex justify-end gap-2">
           <button
@@ -219,7 +253,9 @@ export default function AdminEventPage() {
       {summary && (
         <div className="bg-white rounded-lg shadow p-4 mb-4">
           <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
-            <h2 className="text-lg font-semibold">최근 {summaryDays}일 이벤트 집계</h2>
+            <h2 className="text-lg font-semibold">
+              {isSummaryWindowFromDateFilter ? "지정 기간 이벤트 집계" : `최근 ${summaryDays}일 이벤트 집계`}
+            </h2>
             <div className="text-sm text-gray-500">
               {formatDateTime(summary.fromInclusive)} ~ {formatDateTime(summary.toExclusive)}
             </div>

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminEventApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminEventApiTest.java
@@ -187,6 +187,35 @@ class AdminEventApiTest {
     }
 
     @Test
+    void summarySupportsCustomSummaryDaysWindow() throws Exception {
+        Instant now = Instant.now();
+        saveEvent(UUID.randomUUID(), userAId, EventType.HYMN_OPENED, hymnAId, PartType.ALL, now.minus(40, ChronoUnit.DAYS));
+        saveEvent(UUID.randomUUID(), userAId, EventType.NOTE_SAVED, hymnAId, null, now.minus(20, ChronoUnit.DAYS));
+
+        String within30Days = mockMvc.perform(get("/admin/events")
+                .header("Authorization", "Bearer " + adminToken)
+                .param("summaryDays", "30"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        String within45Days = mockMvc.perform(get("/admin/events")
+                .header("Authorization", "Bearer " + adminToken)
+                .param("summaryDays", "45"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        long total30 = objectMapper.readTree(within30Days).get("data").get("summary").get("total").asLong();
+        long total45 = objectMapper.readTree(within45Days).get("data").get("summary").get("total").asLong();
+
+        assertThat(total30).isEqualTo(1L);
+        assertThat(total45).isEqualTo(2L);
+    }
+
+    @Test
     void adminCanNavigateWithPagination() throws Exception {
         Instant now = Instant.now();
         saveEvent(UUID.randomUUID(), userAId, EventType.HYMN_OPENED, hymnAId, PartType.ALL, now.minus(3, ChronoUnit.MINUTES));

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -249,3 +249,32 @@
 - `powershell -NoProfile -File .\\scripts\\staging-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn`
 - `aws sts get-caller-identity` (현재 환경: credential 미설정 확인)
 - `rg -n "22010284332|22010387328|22010470389|Conditional Go|preflight" docs/current-usable-scope.md docs/deployment-readiness-audit.md docs/changelog-dev.md CLAUDE.md`
+
+## 9. 이번 사이클 기록 (2026-02-14, 6차)
+
+### 목표
+- 기능 백로그 일부 완료: 관리자 감사 로그 집계 기간 커스텀(1~90일)
+
+### 범위
+- 포함: Admin UI 입력 확장, API 통합 테스트 추가, 문서/백로그 동기화
+- 제외: 대용량 비동기 export 구현
+
+### 수행 작업
+1. Admin UI 개선
+- `apps/admin/src/pages/AdminEventPage.tsx`
+- 집계 기간 입력을 숫자 입력(1~90)으로 전환하고 프리셋 버튼(1/7/30/60/90) 추가
+- 날짜 필터 존재 시 집계 제목을 "지정 기간 이벤트 집계"로 표기
+
+2. API 검증 보강
+- `apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminEventApiTest.java`
+- `summaryDays=45` 집계 반영 통합 테스트 추가
+
+3. 문서 동기화
+- `docs/events.md`: `summaryDays` 커스텀 범위 명시
+- `docs/current-usable-scope.md`, `CLAUDE.md`: 기능/백로그 상태 갱신
+- `docs/changelog-dev.md` 업데이트
+
+### 검증
+- `./gradlew.bat test --tests "com.eunhyehymn.presentation.controllers.AdminEventApiTest" --no-daemon --stacktrace` (`apps/api`)
+- `npm ci` + `npx tsc --noEmit` + `npm run build` (`apps/admin`)
+- `rg -n "summaryDays|1~90|대용량 비동기 export" docs/events.md docs/current-usable-scope.md CLAUDE.md docs/changelog-dev.md`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,18 @@
 
 ## 2026-02-14
 
+### 감사 로그 집계 기간 커스텀(6차)
+- 관리자 이벤트 화면 개선
+  - `apps/admin/src/pages/AdminEventPage.tsx`
+  - 집계 기간 입력을 고정 select(1/7/30)에서 숫자 입력(1~90일) + 프리셋(1/7/30/60/90)으로 확장
+  - `from/to` 필터 사용 시 집계 제목을 "지정 기간 이벤트 집계"로 표시
+- API 검증 강화
+  - `apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminEventApiTest.java`
+  - `summaryDays=45` 같은 비프리셋 값이 실제 집계에 반영되는 통합 테스트 추가
+- 문서 동기화
+  - `docs/events.md`, `docs/current-usable-scope.md`, `CLAUDE.md`
+  - 백로그 항목에서 "집계 기간 커스텀" 완료 반영
+
 ### 스테이징 준비도 동기화 + preflight 하드닝(5차)
 - `scripts/staging-preflight.ps1` 개선
   - `aws sts get-caller-identity` 실패 시 즉시 예외 종료 대신 원인(자격증명/프로필/응답) 표준 출력

--- a/docs/current-usable-scope.md
+++ b/docs/current-usable-scope.md
@@ -27,7 +27,7 @@
 - 에셋 관리: Presign -> 업로드 -> Confirm 3단계, 에셋 삭제
 - 사용자 관리: 사용자 목록, 역할/상태 변경
 - 초대코드 관리: 생성/비활성화/만료일 설정 및 표시
-- 감사 로그/분석: 이벤트 로그 필터/페이지네이션 조회, 이벤트 타입별 집계(최근 N일), CSV 내보내기
+- 감사 로그/분석: 이벤트 로그 필터/페이지네이션 조회, 이벤트 타입별 집계(최근 N일, `summaryDays` 1~90 커스텀), CSV 내보내기
 - 인증: Google/Kakao 소셜 로그인 UI, Dev 로그인
 - 토큰: 401 발생 시 Access Token 자동 갱신 후 재시도
 
@@ -50,7 +50,7 @@
 - 찬양: 공개 조회 + 관리자 CRUD + 삭제(cascade)
 - 에셋: 관리자 Presign/Confirm/Delete (AssetType: `PNG`, `MIDI`)
 - 사용자/초대코드 관리자 기능
-- 관리자 감사 로그: `GET /admin/events` 조회/필터/페이지네이션 + 최근 N일 이벤트 타입 집계
+- 관리자 감사 로그: `GET /admin/events` 조회/필터/페이지네이션 + 최근 N일 이벤트 타입 집계(`summaryDays` 1~90)
 - 관리자 감사 로그 내보내기: `GET /admin/events/export` CSV 다운로드
 - 멤버 기능: 즐겨찾기, 메모, 히스토리, 이벤트 기록
 
@@ -138,7 +138,7 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
   - `docs/runbook.md` + `docs/staging-smoke-checklist.md` 기준 Admin/Mobile 수동 스모크 실행
   - 리허설/스모크 결과를 `docs/changelog-dev.md`에 주기 반영
 - 운영 기능 백로그
-  - 감사 로그 고도화(집계 기간 커스텀, 대용량 비동기 export)
+  - 감사 로그 고도화(대용량 비동기 export)
 
 ## 6. 빠른 사용 체크리스트
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -54,6 +54,8 @@
 - 필터: `eventType`, `userId`, `hymnId`, `from`, `to`
 - 페이지네이션: `page`, `size` (`limit` 하위 호환)
 - 집계: `summaryDays` 기준 최근 N일 이벤트 타입별 합계
+  - 허용 범위: `1~90` (기본값 7)
+  - 관리자 UI는 숫자 입력 + 프리셋(`1/7/30/60/90`)을 지원
 
 ### 4.3 관리자 감사 로그 CSV
 - `GET /api/v1/admin/events/export`


### PR DESCRIPTION
﻿## Summary
- enhance Admin event analytics UI to support custom summary window input (`1~90` days) with quick presets (`1/7/30/60/90`)
- add summary title behavior so date-filtered queries show `지정 기간 이벤트 집계` instead of fixed `최근 N일`
- add API integration coverage for non-preset `summaryDays` values (`45`) in `AdminEventApiTest`
- sync docs and backlog status:
  - `docs/events.md`
  - `docs/current-usable-scope.md`
  - `CLAUDE.md`
  - `docs/changelog-dev.md`
  - `docs/WORK_CYCLE.md`

## Why
The remaining backlog item included "집계 기간 커스텀" for admin event analytics. Backend already accepted `summaryDays` up to 90, but UI was restricted to fixed options. This PR removes that gap and records the completion in project docs.

## Verification
- `./gradlew.bat test --tests "com.eunhyehymn.presentation.controllers.AdminEventApiTest" --no-daemon --stacktrace` (`apps/api`)
- `npm ci` (`apps/admin`)
- `npx tsc --noEmit` (`apps/admin`)
- `npm run build` (`apps/admin`)
- `rg -n "summaryDays|1~90|대용량 비동기 export" apps/admin/src/pages/AdminEventPage.tsx apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminEventApiTest.java docs/events.md docs/current-usable-scope.md CLAUDE.md docs/changelog-dev.md docs/WORK_CYCLE.md`

## Risk / Follow-up
- custom window UX is now complete; the remaining analytics backlog is large-scale async export.
- manual runtime smoke for Admin/Mobile remains a separate operational task.
