### PR TITLE
feat: 관리자 감사 로그 비동기 대용량 CSV export 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
 ```
 Eunhye_Hymn/
 ├── apps/
-│   ├── api/              # Spring Boot 백엔드 (Java 17, Gradle) ← MVP 완료 (26 UseCase)
+│   ├── api/              # Spring Boot 백엔드 (Java 17, Gradle) ← MVP 완료 (27 UseCase)
 │   │   └── Dockerfile    # Multi-stage (JDK build → JRE run + curl for healthcheck)
 │   ├── admin/            # React + Vite + TypeScript 관리자 웹  ← 8페이지 완료
 │   │   ├── Dockerfile    # Multi-stage (Node build → Nginx serve)
@@ -157,7 +157,7 @@ com.eunhyehymn/
 │   └── repository/     # Repository 인터페이스
 ├── application/
 │   ├── ports/          # 외부 서비스 인터페이스 (SocialTokenVerifier)
-│   └── usecases/       # 비즈니스 로직 Use Cases (26개)
+│   └── usecases/       # 비즈니스 로직 Use Cases (27개)
 ├── presentation/
 │   ├── controllers/    # REST 컨트롤러 (11개)
 │   └── dto/            # Request/Response DTOs
@@ -260,6 +260,9 @@ com.eunhyehymn/
 |--------|------|------|------|
 | GET | `/admin/events` | ADMIN | 이벤트 로그 조회 + 최근 N일 이벤트 타입 집계 (`summaryDays` 1~90) |
 | GET | `/admin/events/export` | ADMIN | 이벤트 로그 CSV 내보내기 |
+| POST | `/admin/events/export-jobs` | ADMIN | 비동기 대용량 CSV 작업 생성 (202 Accepted) |
+| GET | `/admin/events/export-jobs/{jobId}` | ADMIN | 비동기 CSV 작업 상태 조회 |
+| GET | `/admin/events/export-jobs/{jobId}/download` | ADMIN | 완료된 비동기 CSV 다운로드 |
 
 ### 7.8 사용자 개인 (`MeController`)
 
@@ -287,7 +290,7 @@ com.eunhyehymn/
 
 ---
 
-## 8. Use Cases (26개)
+## 8. Use Cases (27개)
 
 | Use Case | 메서드 | 핵심 로직 |
 |----------|--------|-----------|
@@ -313,6 +316,7 @@ com.eunhyehymn/
 | `AdminListUsersUseCase` | `listAll()` | 전체 사용자 목록 조회 |
 | `AdminUpdateUserUseCase` | `update(userId, role, status)` | 사용자 역할/상태 변경 |
 | `AdminListEventsUseCase` | `execute(query)` | 관리자 이벤트 로그 조회 + 이벤트 타입 집계 |
+| `AdminEventExportJobUseCase` | `create/get/process/getDownload` | 관리자 비동기 대용량 CSV 작업 생성/상태/처리/다운로드 |
 | `AdminCreateInviteCodeUseCase` | `create(code, createdBy, ...)` | 초대코드 생성 (중복 검사) |
 | `AdminListInviteCodesUseCase` | `listAll()` | 전체 초대코드 목록 |
 | `AdminRevokeInviteCodeUseCase` | `revoke(code)` | 초대코드 비활성화 (enabled=false) |
@@ -333,6 +337,7 @@ com.eunhyehymn/
 | `V5__asset_type_png_midi.sql` | assets.type PDF → PNG, AUDIO → MIDI 변환 |
 | `V6__invite_codes.sql` | invite_codes 테이블 생성 (code PK, created_by FK, max_uses, used_count, enabled, expires_at) |
 | `V7__events_admin_indexes.sql` | 관리자 이벤트 조회/CSV 최적화 인덱스 3개 추가 |
+| `V8__event_export_jobs.sql` | 비동기 대용량 CSV 작업 테이블(event_export_jobs) 추가 |
 
 ### 주요 인덱스
 - `idx_refresh_tokens_user_id` ON refresh_tokens(user_id)
@@ -399,7 +404,7 @@ com.eunhyehymn/
 | `FlywayRepositoryIntegrationTest` | DB 마이그레이션 통합 |
 | `GetHistoryUseCaseTest` | 히스토리 Use Case 단위 |
 | `AdminUserApiTest` | 사용자 관리 API (목록, 역할/상태 변경, 권한 검사) |
-| `AdminEventApiTest` | 관리자 이벤트 API (로그 조회, 집계, 페이지네이션, CSV export, 검증) |
+| `AdminEventApiTest` | 관리자 이벤트 API (로그 조회, 집계, 페이지네이션, 동기/비동기 CSV export, 접근 제어 검증) |
 | `AdminInviteCodeApiTest` | 초대코드 관리 API (생성, 목록, 비활성화, 검증) |
 
 - **테스트 DB**: H2 인메모리 (test 프로필)
@@ -647,14 +652,14 @@ develop push → GitHub Actions
 
 ### 완료
 
-**백엔드 API (26 UseCase, 11 Controller)**
+**백엔드 API (27 UseCase, 11 Controller)**
 - 찬양 CRUD + 삭제 (cascade: 에셋/메모/상태/이벤트)
 - S3 에셋 관리 (presign/confirm/삭제)
 - JWT 인증 + 소셜 로그인 (Google/Kakao) + 토큰 회전
 - DB 기반 초대코드 관리 (CRUD + 검증 + 원자적 사용 횟수 증가)
 - 사용자 관리 (역할/상태 변경)
 - 멤버 기능 (즐겨찾기, 메모, 히스토리, 이벤트 기록)
-- DB 스키마 Flyway 마이그레이션 (V1~V7)
+- DB 스키마 Flyway 마이그레이션 (V1~V8)
 - 테스트 12개 파일 전체 통과 (SocialLoginApiTest 포함)
 
 **Admin 프론트엔드 (8페이지)**
@@ -662,7 +667,7 @@ develop push → GitHub Actions
 - 에셋 업로드 3단계 (presign/upload/confirm) + 삭제
 - 사용자 관리 (역할/상태 변경, 검색/필터)
 - 초대코드 관리 (생성/비활성화/만료일 설정)
-- 감사 로그/분석 화면 (`GET /admin/events`) - 필터/페이지네이션 조회 + 집계 기간(1~90일) 커스텀 + CSV 내보내기
+- 감사 로그/분석 화면 (`GET /admin/events`) - 필터/페이지네이션 조회 + 집계 기간(1~90일) 커스텀 + 동기 CSV 내보내기 + 비동기 대용량 CSV 작업/다운로드
 - 소셜 로그인 UI (Google/Kakao) + 초대코드 입력 플로우
 - Access Token 자동 갱신 (401 → refresh → 재시도, mutex 패턴)
 - 인증 컨텍스트 (`loginWithSocial`, `setTokensAndUser`), 공통 API 클라이언트, 사이드바 레이아웃
@@ -741,7 +746,7 @@ develop push → GitHub Actions
 - 배포 후 스모크 테스트 항목과 점검 결과를 `docs/staging-rehearsal-log.md`에 주기적으로 갱신
 
 **3. 기능 백로그**
-- 감사 로그 고도화(대용량 비동기 export)
+- 비동기 export 결과 보관 정책(만료/정리) 및 운영 지표(실패율/처리시간) 정례화
 
 **4. 모바일 배포 패키징**
 - 현재 저장소 기준 실행은 `flutter run -d chrome` 중심

--- a/apps/admin/src/api/adminEvents.ts
+++ b/apps/admin/src/api/adminEvents.ts
@@ -1,4 +1,4 @@
-import { apiFetchRaw, apiGet } from "./client";
+import { apiFetchRaw, apiGet, apiPost } from "./client";
 
 export type EventType = "HYMN_OPENED" | "PART_PLAYED" | "NOTE_SAVED" | "FAVORITE_TOGGLED";
 
@@ -81,6 +81,32 @@ export interface ExportAdminEventsCsvResult {
   filename: string;
 }
 
+export type EventExportJobStatus = "QUEUED" | "RUNNING" | "COMPLETED" | "FAILED";
+
+export interface AdminEventExportJob {
+  id: string;
+  status: EventExportJobStatus;
+  exportLimit: number;
+  rowCount: number | null;
+  fileName: string | null;
+  errorMessage: string | null;
+  createdAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  statusUrl: string;
+  downloadUrl: string;
+  downloadable: boolean;
+}
+
+export interface CreateAdminEventExportJobParams {
+  eventType?: EventType;
+  userId?: string;
+  hymnId?: string;
+  from?: string;
+  to?: string;
+  limit?: number;
+}
+
 export async function exportAdminEventsCsv(
   params: ExportAdminEventsCsvParams = {},
 ): Promise<ExportAdminEventsCsvResult> {
@@ -107,6 +133,44 @@ export async function exportAdminEventsCsv(
   const disposition = response.headers.get("Content-Disposition") ?? "";
   const match = disposition.match(/filename=\"?([^\";]+)\"?/i);
   const filename = match?.[1] ?? "admin-events.csv";
+
+  return { blob, filename };
+}
+
+export function createAdminEventExportJob(
+  params: CreateAdminEventExportJobParams = {},
+): Promise<AdminEventExportJob> {
+  const query = new URLSearchParams();
+  if (params.eventType) query.set("eventType", params.eventType);
+  if (params.userId) query.set("userId", params.userId);
+  if (params.hymnId) query.set("hymnId", params.hymnId);
+  if (params.from) query.set("from", params.from);
+  if (params.to) query.set("to", params.to);
+  if (params.limit != null) query.set("limit", String(params.limit));
+
+  const suffix = query.toString();
+  const path = suffix ? `/admin/events/export-jobs?${suffix}` : "/admin/events/export-jobs";
+  return apiPost<AdminEventExportJob>(path);
+}
+
+export function getAdminEventExportJob(jobId: string): Promise<AdminEventExportJob> {
+  return apiGet<AdminEventExportJob>(`/admin/events/export-jobs/${jobId}`);
+}
+
+export async function downloadAdminEventExportJobCsv(jobId: string): Promise<ExportAdminEventsCsvResult> {
+  const response = await apiFetchRaw({ method: "GET", path: `/admin/events/export-jobs/${jobId}/download` });
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as
+      | { error?: { message?: string } }
+      | null;
+    throw new Error(payload?.error?.message ?? "비동기 CSV 다운로드에 실패했습니다.");
+  }
+
+  const blob = await response.blob();
+  const disposition = response.headers.get("Content-Disposition") ?? "";
+  const match = disposition.match(/filename=\"?([^\";]+)\"?/i);
+  const filename = match?.[1] ?? "admin-events-async.csv";
 
   return { blob, filename };
 }

--- a/apps/admin/src/pages/AdminEventPage.tsx
+++ b/apps/admin/src/pages/AdminEventPage.tsx
@@ -1,6 +1,10 @@
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import {
+  createAdminEventExportJob,
+  downloadAdminEventExportJobCsv,
   exportAdminEventsCsv,
+  getAdminEventExportJob,
+  type AdminEventExportJob,
   listAdminEvents,
   type AdminEventItem,
   type AdminEventSummary,
@@ -19,6 +23,8 @@ const SUMMARY_DAY_PRESETS = [1, 7, 30, 60, 90];
 const MIN_SUMMARY_DAYS = 1;
 const MAX_SUMMARY_DAYS = 90;
 const SIZE_OPTIONS = [20, 50, 100, 200];
+const ASYNC_EXPORT_LIMIT = 50_000;
+const ASYNC_EXPORT_POLL_INTERVAL_MS = 2_000;
 
 function toIsoUtc(localDateTime: string): string | undefined {
   if (!localDateTime) {
@@ -50,6 +56,19 @@ function clampSummaryDays(days: number): number {
   return Math.min(Math.max(days, MIN_SUMMARY_DAYS), MAX_SUMMARY_DAYS);
 }
 
+function formatAsyncJobStatus(status: AdminEventExportJob["status"]): string {
+  if (status === "QUEUED") {
+    return "대기 중";
+  }
+  if (status === "RUNNING") {
+    return "처리 중";
+  }
+  if (status === "COMPLETED") {
+    return "완료";
+  }
+  return "실패";
+}
+
 export default function AdminEventPage() {
   const [eventType, setEventType] = useState<"all" | EventType>("all");
   const [userId, setUserId] = useState("");
@@ -72,6 +91,9 @@ export default function AdminEventPage() {
   });
   const [loading, setLoading] = useState(true);
   const [exporting, setExporting] = useState(false);
+  const [creatingAsyncJob, setCreatingAsyncJob] = useState(false);
+  const [downloadingAsyncJob, setDownloadingAsyncJob] = useState(false);
+  const [asyncJob, setAsyncJob] = useState<AdminEventExportJob | null>(null);
   const [error, setError] = useState<string | null>(null);
   const isSummaryWindowFromDateFilter = Boolean(fromLocal || toLocal);
 
@@ -111,6 +133,39 @@ export default function AdminEventPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page]);
 
+  useEffect(() => {
+    if (!asyncJob || (asyncJob.status !== "QUEUED" && asyncJob.status !== "RUNNING")) {
+      return;
+    }
+
+    let cancelled = false;
+    const pollStatus = async () => {
+      if (cancelled) {
+        return;
+      }
+      try {
+        const latest = await getAdminEventExportJob(asyncJob.id);
+        if (!cancelled) {
+          setAsyncJob(latest);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "비동기 내보내기 상태를 확인하지 못했습니다.");
+        }
+      }
+    };
+
+    void pollStatus();
+    const timer = window.setInterval(() => {
+      void pollStatus();
+    }, ASYNC_EXPORT_POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [asyncJob?.id, asyncJob?.status]);
+
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setPage(1);
@@ -134,6 +189,45 @@ export default function AdminEventPage() {
       setError(err instanceof Error ? err.message : "CSV 내보내기에 실패했습니다.");
     } finally {
       setExporting(false);
+    }
+  };
+
+  const handleCreateAsyncExportJob = async () => {
+    setCreatingAsyncJob(true);
+    setError(null);
+    try {
+      const job = await createAdminEventExportJob({
+        eventType: eventType === "all" ? undefined : eventType,
+        userId: userId.trim() || undefined,
+        hymnId: hymnId.trim() || undefined,
+        from: toIsoUtc(fromLocal),
+        to: toIsoUtc(toLocal),
+        limit: ASYNC_EXPORT_LIMIT,
+      });
+      setAsyncJob(job);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "비동기 내보내기 요청에 실패했습니다.");
+    } finally {
+      setCreatingAsyncJob(false);
+    }
+  };
+
+  const handleDownloadAsyncExport = async () => {
+    if (!asyncJob || !asyncJob.downloadable) {
+      return;
+    }
+
+    setDownloadingAsyncJob(true);
+    setError(null);
+    try {
+      const result = await downloadAdminEventExportJobCsv(asyncJob.id);
+      triggerDownload(result.blob, result.filename);
+      const refreshed = await getAdminEventExportJob(asyncJob.id);
+      setAsyncJob(refreshed);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "비동기 CSV 다운로드에 실패했습니다.");
+    } finally {
+      setDownloadingAsyncJob(false);
     }
   };
 
@@ -232,6 +326,15 @@ export default function AdminEventPage() {
         <div className="mt-3 flex justify-end gap-2">
           <button
             type="button"
+            onClick={handleCreateAsyncExportJob}
+            className="border border-emerald-600 text-emerald-700 px-4 py-2 rounded hover:bg-emerald-50 disabled:opacity-60"
+            disabled={loading || creatingAsyncJob}
+            title={`필터 조건 기준 최대 ${ASYNC_EXPORT_LIMIT.toLocaleString("ko-KR")}건 비동기 내보내기`}
+          >
+            {creatingAsyncJob ? "요청 중..." : "비동기 CSV 요청"}
+          </button>
+          <button
+            type="button"
             onClick={handleExportCsv}
             className="border border-indigo-600 text-indigo-700 px-4 py-2 rounded hover:bg-indigo-50 disabled:opacity-60"
             disabled={loading || exporting}
@@ -249,6 +352,48 @@ export default function AdminEventPage() {
       </form>
 
       {error && <p className="text-red-600 mb-4">{error}</p>}
+
+      {asyncJob && (
+        <div className="bg-white rounded-lg shadow p-4 mb-4 border border-emerald-100">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <p className="text-sm text-gray-500">비동기 내보내기 작업</p>
+              <p className="text-xs text-gray-500 break-all">jobId: {asyncJob.id}</p>
+            </div>
+            <span
+              className={`px-2 py-1 text-xs rounded-full font-medium ${
+                asyncJob.status === "COMPLETED"
+                  ? "bg-emerald-100 text-emerald-700"
+                  : asyncJob.status === "FAILED"
+                    ? "bg-red-100 text-red-700"
+                    : "bg-amber-100 text-amber-700"
+              }`}
+            >
+              {formatAsyncJobStatus(asyncJob.status)}
+            </span>
+          </div>
+          <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-2 text-sm text-gray-600">
+            <div>요청 상한: {asyncJob.exportLimit.toLocaleString("ko-KR")}건</div>
+            <div>완료 건수: {(asyncJob.rowCount ?? 0).toLocaleString("ko-KR")}건</div>
+            <div>요청 시각: {formatDateTime(asyncJob.createdAt)}</div>
+            <div>완료 시각: {asyncJob.completedAt ? formatDateTime(asyncJob.completedAt) : "-"}</div>
+          </div>
+          {asyncJob.errorMessage && <p className="mt-2 text-sm text-red-600">{asyncJob.errorMessage}</p>}
+          <div className="mt-3 flex flex-wrap items-center justify-end gap-2">
+            {(asyncJob.status === "QUEUED" || asyncJob.status === "RUNNING") && (
+              <span className="text-xs text-gray-500">2초 간격으로 상태를 자동 갱신합니다.</span>
+            )}
+            <button
+              type="button"
+              onClick={handleDownloadAsyncExport}
+              disabled={!asyncJob.downloadable || downloadingAsyncJob}
+              className="border border-emerald-600 text-emerald-700 px-3 py-1.5 rounded hover:bg-emerald-50 disabled:opacity-50"
+            >
+              {downloadingAsyncJob ? "다운로드 중..." : "비동기 CSV 다운로드"}
+            </button>
+          </div>
+        </div>
+      )}
 
       {summary && (
         <div className="bg-white rounded-lg shadow p-4 mb-4">

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminEventExportJobUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminEventExportJobUseCase.java
@@ -1,0 +1,235 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.common.error.ApiException;
+import com.eunhyehymn.domain.model.Event;
+import com.eunhyehymn.domain.model.EventExportJob;
+import com.eunhyehymn.domain.model.EventExportJobStatus;
+import com.eunhyehymn.domain.model.EventType;
+import com.eunhyehymn.domain.repository.EventExportJobRepository;
+import com.eunhyehymn.domain.repository.EventRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+
+public class AdminEventExportJobUseCase {
+    private static final int DEFAULT_EXPORT_LIMIT = 20_000;
+    private static final int MAX_EXPORT_LIMIT = 100_000;
+    private static final int CSV_FETCH_BATCH_SIZE = 1_000;
+    private static final int MAX_ERROR_MESSAGE_LENGTH = 500;
+    private static final String CSV_HEADER = "id,userId,eventType,hymnId,part,metadataJson,createdAt\n";
+
+    private final EventRepository eventRepository;
+    private final EventExportJobRepository eventExportJobRepository;
+
+    public AdminEventExportJobUseCase(
+        EventRepository eventRepository,
+        EventExportJobRepository eventExportJobRepository
+    ) {
+        this.eventRepository = eventRepository;
+        this.eventExportJobRepository = eventExportJobRepository;
+    }
+
+    public EventExportJob create(CreateCommand command) {
+        int exportLimit = normalizeExportLimit(command.limit());
+        EventExportJob job = new EventExportJob(
+            UUID.randomUUID(),
+            command.requestedBy(),
+            command.eventType(),
+            command.userId(),
+            command.hymnId(),
+            command.fromInclusive(),
+            command.toExclusive(),
+            exportLimit,
+            EventExportJobStatus.QUEUED,
+            null,
+            null,
+            null,
+            null,
+            Instant.now(),
+            null,
+            null
+        );
+        return eventExportJobRepository.save(job);
+    }
+
+    public EventExportJob get(UUID jobId, UUID requestedBy) {
+        EventExportJob job = eventExportJobRepository.findById(jobId)
+            .orElseThrow(() -> new ApiException(
+                HttpStatus.NOT_FOUND,
+                "export_job_not_found",
+                "Export job not found",
+                null
+            ));
+
+        if (!job.requestedBy().equals(requestedBy)) {
+            throw new ApiException(HttpStatus.NOT_FOUND, "export_job_not_found", "Export job not found", null);
+        }
+        return job;
+    }
+
+    public EventExportJob process(UUID jobId) {
+        EventExportJob queuedJob = eventExportJobRepository.findById(jobId)
+            .orElseThrow(() -> new ApiException(
+                HttpStatus.NOT_FOUND,
+                "export_job_not_found",
+                "Export job not found",
+                null
+            ));
+
+        if (queuedJob.status() != EventExportJobStatus.QUEUED) {
+            return queuedJob;
+        }
+
+        EventExportJob runningJob = eventExportJobRepository.save(queuedJob.markRunning(Instant.now()));
+
+        try {
+            CsvBuildResult csvBuildResult = buildCsv(runningJob);
+            String filename = buildFileName(runningJob.id());
+            return eventExportJobRepository.save(runningJob.markCompleted(
+                csvBuildResult.rowCount(),
+                filename,
+                csvBuildResult.csvContent(),
+                Instant.now()
+            ));
+        } catch (Exception ex) {
+            String errorMessage = toErrorMessage(ex);
+            return eventExportJobRepository.save(runningJob.markFailed(errorMessage, Instant.now()));
+        }
+    }
+
+    public DownloadResult getDownload(UUID jobId, UUID requestedBy) {
+        EventExportJob job = get(jobId, requestedBy);
+        if (job.status() == EventExportJobStatus.FAILED) {
+            throw new ApiException(
+                HttpStatus.CONFLICT,
+                "export_job_failed",
+                job.errorMessage() == null ? "Export job failed" : job.errorMessage(),
+                null
+            );
+        }
+        if (job.status() != EventExportJobStatus.COMPLETED) {
+            throw new ApiException(
+                HttpStatus.CONFLICT,
+                "export_job_not_ready",
+                "Export job is not completed yet",
+                null
+            );
+        }
+        if (job.fileName() == null || job.csvContent() == null) {
+            throw new ApiException(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "export_job_corrupted",
+                "Export job result is missing",
+                null
+            );
+        }
+
+        return new DownloadResult(
+            job.fileName(),
+            job.csvContent()
+        );
+    }
+
+    private CsvBuildResult buildCsv(EventExportJob job) {
+        StringBuilder sb = new StringBuilder(CSV_HEADER);
+        int currentPage = 1;
+        long rowCount = 0;
+
+        while (rowCount < job.exportLimit()) {
+            List<Event> batch = eventRepository.findRecent(
+                job.fromInclusive(),
+                job.toExclusive(),
+                job.eventType(),
+                job.userId(),
+                job.hymnId(),
+                currentPage,
+                CSV_FETCH_BATCH_SIZE
+            );
+
+            if (batch.isEmpty()) {
+                break;
+            }
+
+            for (Event event : batch) {
+                if (rowCount >= job.exportLimit()) {
+                    break;
+                }
+                appendCsvRow(sb, event);
+                rowCount += 1;
+            }
+
+            if (batch.size() < CSV_FETCH_BATCH_SIZE) {
+                break;
+            }
+
+            currentPage += 1;
+        }
+
+        return new CsvBuildResult(sb.toString(), rowCount);
+    }
+
+    private void appendCsvRow(StringBuilder sb, Event event) {
+        sb.append(csv(event.id()));
+        sb.append(',').append(csv(event.userId()));
+        sb.append(',').append(csv(event.eventType().name()));
+        sb.append(',').append(csv(event.hymnId()));
+        sb.append(',').append(csv(event.part() == null ? null : event.part().name()));
+        sb.append(',').append(csv(event.metadataJson()));
+        sb.append(',').append(csv(event.createdAt()));
+        sb.append('\n');
+    }
+
+    private String csv(Object value) {
+        if (value == null) {
+            return "";
+        }
+        String raw = value.toString().replace("\"", "\"\"");
+        return "\"" + raw + "\"";
+    }
+
+    private int normalizeExportLimit(Integer limit) {
+        if (limit == null) {
+            return DEFAULT_EXPORT_LIMIT;
+        }
+        if (limit < 1) {
+            return 1;
+        }
+        return Math.min(limit, MAX_EXPORT_LIMIT);
+    }
+
+    private String buildFileName(UUID jobId) {
+        return "admin-events-async-" + jobId + "-" + Instant.now().toString().replace(":", "-") + ".csv";
+    }
+
+    private String toErrorMessage(Exception ex) {
+        String raw = ex.getMessage();
+        if (raw == null || raw.isBlank()) {
+            return "Export job failed unexpectedly";
+        }
+        if (raw.length() <= MAX_ERROR_MESSAGE_LENGTH) {
+            return raw;
+        }
+        return raw.substring(0, MAX_ERROR_MESSAGE_LENGTH);
+    }
+
+    public record CreateCommand(
+        UUID requestedBy,
+        EventType eventType,
+        UUID userId,
+        UUID hymnId,
+        Instant fromInclusive,
+        Instant toExclusive,
+        Integer limit
+    ) {
+    }
+
+    public record DownloadResult(
+        String fileName,
+        String csvContent
+    ) {
+    }
+
+    private record CsvBuildResult(String csvContent, long rowCount) {
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/AsyncConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/AsyncConfig.java
@@ -1,0 +1,20 @@
+package com.eunhyehymn.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class AsyncConfig {
+    @Bean(name = "eventExportTaskExecutor")
+    TaskExecutor eventExportTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("event-export-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/UseCaseConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/UseCaseConfig.java
@@ -1,6 +1,7 @@
 package com.eunhyehymn.common.config;
 
 import com.eunhyehymn.application.usecases.AdminCreateHymnUseCase;
+import com.eunhyehymn.application.usecases.AdminEventExportJobUseCase;
 import com.eunhyehymn.application.usecases.AdminListEventsUseCase;
 import com.eunhyehymn.application.usecases.AdminDeleteHymnUseCase;
 import com.eunhyehymn.application.usecases.AdminListHymnsUseCase;
@@ -16,6 +17,7 @@ import com.eunhyehymn.application.usecases.RecordEventsUseCase;
 import com.eunhyehymn.application.usecases.SaveHymnNoteUseCase;
 import com.eunhyehymn.application.usecases.ToggleFavoriteUseCase;
 import com.eunhyehymn.domain.repository.AssetRepository;
+import com.eunhyehymn.domain.repository.EventExportJobRepository;
 import com.eunhyehymn.domain.repository.EventRepository;
 import com.eunhyehymn.domain.repository.HymnNoteRepository;
 import com.eunhyehymn.domain.repository.HymnRepository;
@@ -94,6 +96,14 @@ public class UseCaseConfig {
     @Bean
     AdminListEventsUseCase adminListEventsUseCase(EventRepository eventRepository) {
         return new AdminListEventsUseCase(eventRepository);
+    }
+
+    @Bean
+    AdminEventExportJobUseCase adminEventExportJobUseCase(
+        EventRepository eventRepository,
+        EventExportJobRepository eventExportJobRepository
+    ) {
+        return new AdminEventExportJobUseCase(eventRepository, eventExportJobRepository);
     }
 
     @Bean

--- a/apps/api/src/main/java/com/eunhyehymn/domain/model/EventExportJob.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/model/EventExportJob.java
@@ -1,0 +1,86 @@
+package com.eunhyehymn.domain.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record EventExportJob(
+    UUID id,
+    UUID requestedBy,
+    EventType eventType,
+    UUID userId,
+    UUID hymnId,
+    Instant fromInclusive,
+    Instant toExclusive,
+    int exportLimit,
+    EventExportJobStatus status,
+    Long rowCount,
+    String fileName,
+    String csvContent,
+    String errorMessage,
+    Instant createdAt,
+    Instant startedAt,
+    Instant completedAt
+) {
+    public EventExportJob markRunning(Instant startedAt) {
+        return new EventExportJob(
+            id,
+            requestedBy,
+            eventType,
+            userId,
+            hymnId,
+            fromInclusive,
+            toExclusive,
+            exportLimit,
+            EventExportJobStatus.RUNNING,
+            null,
+            null,
+            null,
+            null,
+            createdAt,
+            startedAt,
+            null
+        );
+    }
+
+    public EventExportJob markCompleted(long rowCount, String fileName, String csvContent, Instant completedAt) {
+        return new EventExportJob(
+            id,
+            requestedBy,
+            eventType,
+            userId,
+            hymnId,
+            fromInclusive,
+            toExclusive,
+            exportLimit,
+            EventExportJobStatus.COMPLETED,
+            rowCount,
+            fileName,
+            csvContent,
+            null,
+            createdAt,
+            startedAt,
+            completedAt
+        );
+    }
+
+    public EventExportJob markFailed(String errorMessage, Instant completedAt) {
+        return new EventExportJob(
+            id,
+            requestedBy,
+            eventType,
+            userId,
+            hymnId,
+            fromInclusive,
+            toExclusive,
+            exportLimit,
+            EventExportJobStatus.FAILED,
+            null,
+            null,
+            null,
+            errorMessage,
+            createdAt,
+            startedAt,
+            completedAt
+        );
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/domain/model/EventExportJobStatus.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/model/EventExportJobStatus.java
@@ -1,0 +1,8 @@
+package com.eunhyehymn.domain.model;
+
+public enum EventExportJobStatus {
+    QUEUED,
+    RUNNING,
+    COMPLETED,
+    FAILED
+}

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/EventExportJobRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/EventExportJobRepository.java
@@ -1,0 +1,11 @@
+package com.eunhyehymn.domain.repository;
+
+import com.eunhyehymn.domain.model.EventExportJob;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface EventExportJobRepository {
+    EventExportJob save(EventExportJob job);
+
+    Optional<EventExportJob> findById(UUID id);
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobEntity.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobEntity.java
@@ -1,0 +1,170 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import com.eunhyehymn.domain.model.EventExportJobStatus;
+import com.eunhyehymn.domain.model.EventType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "event_export_jobs")
+public class EventExportJobEntity {
+    @Id
+    @Column(nullable = false)
+    private UUID id;
+
+    @Column(name = "requested_by", nullable = false)
+    private UUID requestedBy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type")
+    private EventType eventType;
+
+    @Column(name = "user_id")
+    private UUID userId;
+
+    @Column(name = "hymn_id")
+    private UUID hymnId;
+
+    @Column(name = "from_inclusive")
+    private Instant fromInclusive;
+
+    @Column(name = "to_exclusive")
+    private Instant toExclusive;
+
+    @Column(name = "export_limit", nullable = false)
+    private int exportLimit;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EventExportJobStatus status;
+
+    @Column(name = "row_count")
+    private Long rowCount;
+
+    @Column(name = "file_name")
+    private String fileName;
+
+    @Column(name = "csv_content", columnDefinition = "text")
+    private String csvContent;
+
+    @Column(name = "error_message", columnDefinition = "text")
+    private String errorMessage;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "started_at")
+    private Instant startedAt;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    protected EventExportJobEntity() {
+    }
+
+    public EventExportJobEntity(
+        UUID id,
+        UUID requestedBy,
+        EventType eventType,
+        UUID userId,
+        UUID hymnId,
+        Instant fromInclusive,
+        Instant toExclusive,
+        int exportLimit,
+        EventExportJobStatus status,
+        Long rowCount,
+        String fileName,
+        String csvContent,
+        String errorMessage,
+        Instant createdAt,
+        Instant startedAt,
+        Instant completedAt
+    ) {
+        this.id = id;
+        this.requestedBy = requestedBy;
+        this.eventType = eventType;
+        this.userId = userId;
+        this.hymnId = hymnId;
+        this.fromInclusive = fromInclusive;
+        this.toExclusive = toExclusive;
+        this.exportLimit = exportLimit;
+        this.status = status;
+        this.rowCount = rowCount;
+        this.fileName = fileName;
+        this.csvContent = csvContent;
+        this.errorMessage = errorMessage;
+        this.createdAt = createdAt;
+        this.startedAt = startedAt;
+        this.completedAt = completedAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public UUID getRequestedBy() {
+        return requestedBy;
+    }
+
+    public EventType getEventType() {
+        return eventType;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public UUID getHymnId() {
+        return hymnId;
+    }
+
+    public Instant getFromInclusive() {
+        return fromInclusive;
+    }
+
+    public Instant getToExclusive() {
+        return toExclusive;
+    }
+
+    public int getExportLimit() {
+        return exportLimit;
+    }
+
+    public EventExportJobStatus getStatus() {
+        return status;
+    }
+
+    public Long getRowCount() {
+        return rowCount;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public String getCsvContent() {
+        return csvContent;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getStartedAt() {
+        return startedAt;
+    }
+
+    public Instant getCompletedAt() {
+        return completedAt;
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobJpaRepository.java
@@ -1,0 +1,7 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventExportJobJpaRepository extends JpaRepository<EventExportJobEntity, UUID> {
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobRepositoryAdapter.java
@@ -1,0 +1,28 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import com.eunhyehymn.domain.model.EventExportJob;
+import com.eunhyehymn.domain.repository.EventExportJobRepository;
+import com.eunhyehymn.infrastructure.persistence.mapper.EventExportJobMapper;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class EventExportJobRepositoryAdapter implements EventExportJobRepository {
+    private final EventExportJobJpaRepository jpaRepository;
+
+    public EventExportJobRepositoryAdapter(EventExportJobJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public EventExportJob save(EventExportJob job) {
+        EventExportJobEntity saved = jpaRepository.save(EventExportJobMapper.toEntity(job));
+        return EventExportJobMapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<EventExportJob> findById(UUID id) {
+        return jpaRepository.findById(id).map(EventExportJobMapper::toDomain);
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/mapper/EventExportJobMapper.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/mapper/EventExportJobMapper.java
@@ -1,0 +1,51 @@
+package com.eunhyehymn.infrastructure.persistence.mapper;
+
+import com.eunhyehymn.domain.model.EventExportJob;
+import com.eunhyehymn.infrastructure.persistence.EventExportJobEntity;
+
+public final class EventExportJobMapper {
+    private EventExportJobMapper() {
+    }
+
+    public static EventExportJob toDomain(EventExportJobEntity entity) {
+        return new EventExportJob(
+            entity.getId(),
+            entity.getRequestedBy(),
+            entity.getEventType(),
+            entity.getUserId(),
+            entity.getHymnId(),
+            entity.getFromInclusive(),
+            entity.getToExclusive(),
+            entity.getExportLimit(),
+            entity.getStatus(),
+            entity.getRowCount(),
+            entity.getFileName(),
+            entity.getCsvContent(),
+            entity.getErrorMessage(),
+            entity.getCreatedAt(),
+            entity.getStartedAt(),
+            entity.getCompletedAt()
+        );
+    }
+
+    public static EventExportJobEntity toEntity(EventExportJob job) {
+        return new EventExportJobEntity(
+            job.id(),
+            job.requestedBy(),
+            job.eventType(),
+            job.userId(),
+            job.hymnId(),
+            job.fromInclusive(),
+            job.toExclusive(),
+            job.exportLimit(),
+            job.status(),
+            job.rowCount(),
+            job.fileName(),
+            job.csvContent(),
+            job.errorMessage(),
+            job.createdAt(),
+            job.startedAt(),
+            job.completedAt()
+        );
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminEventController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminEventController.java
@@ -1,22 +1,31 @@
 package com.eunhyehymn.presentation.controllers;
 
+import com.eunhyehymn.application.usecases.AdminEventExportJobUseCase;
 import com.eunhyehymn.application.usecases.AdminListEventsUseCase;
 import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.common.response.ApiResponse;
 import com.eunhyehymn.domain.model.Event;
+import com.eunhyehymn.domain.model.EventExportJob;
+import com.eunhyehymn.domain.model.EventExportJobStatus;
 import com.eunhyehymn.domain.model.EventType;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,9 +35,17 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class AdminEventController {
     private final AdminListEventsUseCase adminListEventsUseCase;
+    private final AdminEventExportJobUseCase adminEventExportJobUseCase;
+    private final TaskExecutor eventExportTaskExecutor;
 
-    public AdminEventController(AdminListEventsUseCase adminListEventsUseCase) {
+    public AdminEventController(
+        AdminListEventsUseCase adminListEventsUseCase,
+        AdminEventExportJobUseCase adminEventExportJobUseCase,
+        @Qualifier("eventExportTaskExecutor") TaskExecutor eventExportTaskExecutor
+    ) {
         this.adminListEventsUseCase = adminListEventsUseCase;
+        this.adminEventExportJobUseCase = adminEventExportJobUseCase;
+        this.eventExportTaskExecutor = eventExportTaskExecutor;
     }
 
     @GetMapping
@@ -80,6 +97,61 @@ public class AdminEventController {
         return ApiResponse.success(new EventListResponse(items, summary, pagination));
     }
 
+    @PostMapping("/export-jobs")
+    public ResponseEntity<ApiResponse<EventExportJobResponse>> createExportJob(
+        @RequestParam(required = false) String eventType,
+        @RequestParam(required = false) String userId,
+        @RequestParam(required = false) String hymnId,
+        @RequestParam(required = false) String from,
+        @RequestParam(required = false) String to,
+        @RequestParam(required = false) Integer limit,
+        Authentication authentication
+    ) {
+        QueryContext context = resolveQueryContext(eventType, userId, hymnId, from, to, null, null, null, null);
+        UUID requestedBy = UUID.fromString(authentication.getName());
+
+        EventExportJob job = adminEventExportJobUseCase.create(new AdminEventExportJobUseCase.CreateCommand(
+            requestedBy,
+            context.eventType(),
+            context.userId(),
+            context.hymnId(),
+            context.fromInclusive(),
+            context.toExclusive(),
+            limit
+        ));
+
+        eventExportTaskExecutor.execute(() -> adminEventExportJobUseCase.process(job.id()));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(URI.create("/admin/events/export-jobs/" + job.id()));
+        return new ResponseEntity<>(ApiResponse.success(toExportJobResponse(job)), headers, HttpStatus.ACCEPTED);
+    }
+
+    @GetMapping("/export-jobs/{jobId}")
+    public ApiResponse<EventExportJobResponse> getExportJob(
+        @PathVariable UUID jobId,
+        Authentication authentication
+    ) {
+        EventExportJob job = adminEventExportJobUseCase.get(jobId, UUID.fromString(authentication.getName()));
+        return ApiResponse.success(toExportJobResponse(job));
+    }
+
+    @GetMapping("/export-jobs/{jobId}/download")
+    public ResponseEntity<String> downloadExportJob(
+        @PathVariable UUID jobId,
+        Authentication authentication
+    ) {
+        AdminEventExportJobUseCase.DownloadResult result = adminEventExportJobUseCase.getDownload(
+            jobId,
+            UUID.fromString(authentication.getName())
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(new MediaType("text", "csv", StandardCharsets.UTF_8));
+        headers.setContentDisposition(ContentDisposition.attachment().filename(result.fileName()).build());
+        return new ResponseEntity<>(result.csvContent(), headers, HttpStatus.OK);
+    }
+
     @GetMapping("/export")
     public ResponseEntity<String> exportCsv(
         @RequestParam(required = false) String eventType,
@@ -109,6 +181,25 @@ public class AdminEventController {
         headers.setContentDisposition(ContentDisposition.attachment().filename(filename).build());
 
         return new ResponseEntity<>(csv, headers, HttpStatus.OK);
+    }
+
+    private EventExportJobResponse toExportJobResponse(EventExportJob job) {
+        String statusUrl = "/admin/events/export-jobs/" + job.id();
+        String downloadUrl = statusUrl + "/download";
+        return new EventExportJobResponse(
+            job.id(),
+            job.status().name(),
+            job.exportLimit(),
+            job.rowCount(),
+            job.fileName(),
+            job.errorMessage(),
+            job.createdAt(),
+            job.startedAt(),
+            job.completedAt(),
+            statusUrl,
+            downloadUrl,
+            job.status() == EventExportJobStatus.COMPLETED
+        );
     }
 
     private QueryContext resolveQueryContext(
@@ -260,6 +351,22 @@ public class AdminEventController {
         long totalPages,
         boolean hasPrevious,
         boolean hasNext
+    ) {
+    }
+
+    public record EventExportJobResponse(
+        UUID id,
+        String status,
+        int exportLimit,
+        Long rowCount,
+        String fileName,
+        String errorMessage,
+        Instant createdAt,
+        Instant startedAt,
+        Instant completedAt,
+        String statusUrl,
+        String downloadUrl,
+        boolean downloadable
     ) {
     }
 

--- a/apps/api/src/main/resources/db/migration/V8__event_export_jobs.sql
+++ b/apps/api/src/main/resources/db/migration/V8__event_export_jobs.sql
@@ -1,0 +1,21 @@
+CREATE TABLE event_export_jobs (
+    id UUID PRIMARY KEY,
+    requested_by UUID NOT NULL REFERENCES users(id),
+    event_type VARCHAR(100),
+    user_id UUID,
+    hymn_id UUID,
+    from_inclusive TIMESTAMP,
+    to_exclusive TIMESTAMP,
+    export_limit INTEGER NOT NULL,
+    status VARCHAR(50) NOT NULL,
+    row_count BIGINT,
+    file_name VARCHAR(255),
+    csv_content TEXT,
+    error_message TEXT,
+    created_at TIMESTAMP NOT NULL,
+    started_at TIMESTAMP,
+    completed_at TIMESTAMP
+);
+
+CREATE INDEX idx_event_export_jobs_requested_by_created
+    ON event_export_jobs(requested_by, created_at DESC);

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminEventApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminEventApiTest.java
@@ -2,6 +2,7 @@ package com.eunhyehymn.presentation.controllers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -13,6 +14,7 @@ import com.eunhyehymn.domain.model.UserStatus;
 import com.eunhyehymn.infrastructure.persistence.AssetJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.AuthIdentityJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.EventEntity;
+import com.eunhyehymn.infrastructure.persistence.EventExportJobJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.EventJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.HymnEntity;
 import com.eunhyehymn.infrastructure.persistence.HymnJpaRepository;
@@ -30,6 +32,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,6 +54,7 @@ class AdminEventApiTest {
     @Autowired private HymnNoteJpaRepository hymnNoteJpaRepository;
     @Autowired private UserHymnStateJpaRepository userHymnStateJpaRepository;
     @Autowired private EventJpaRepository eventJpaRepository;
+    @Autowired private EventExportJobJpaRepository eventExportJobJpaRepository;
     @Autowired private AuthIdentityJpaRepository authIdentityJpaRepository;
     @Autowired private RefreshTokenJpaRepository refreshTokenJpaRepository;
     @Autowired private InviteCodeJpaRepository inviteCodeJpaRepository;
@@ -66,6 +70,7 @@ class AdminEventApiTest {
     @BeforeEach
     void setUp() {
         inviteCodeJpaRepository.deleteAll();
+        eventExportJobJpaRepository.deleteAll();
         eventJpaRepository.deleteAll();
         userHymnStateJpaRepository.deleteAll();
         hymnNoteJpaRepository.deleteAll();
@@ -259,6 +264,73 @@ class AdminEventApiTest {
     }
 
     @Test
+    void adminCanCreateAndDownloadAsyncExportJob() throws Exception {
+        Instant now = Instant.now();
+        saveEvent(UUID.randomUUID(), userAId, EventType.HYMN_OPENED, hymnAId, PartType.ALL, now.minus(2, ChronoUnit.MINUTES));
+        saveEvent(UUID.randomUUID(), userAId, EventType.NOTE_SAVED, hymnAId, null, now.minus(1, ChronoUnit.MINUTES));
+
+        String createResponse = mockMvc.perform(post("/admin/events/export-jobs")
+                .header("Authorization", "Bearer " + adminToken)
+                .param("eventType", "HYMN_OPENED")
+                .param("limit", "5000"))
+            .andExpect(status().isAccepted())
+            .andExpect(jsonPath("$.data.id").exists())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        UUID jobId = UUID.fromString(objectMapper.readTree(createResponse).get("data").get("id").asText());
+        JsonNode finalState = waitForJobCompletion(jobId, adminToken);
+
+        assertThat(finalState).isNotNull();
+        assertThat(finalState.get("status").asText()).isEqualTo("COMPLETED");
+        assertThat(finalState.get("rowCount").asLong()).isEqualTo(1L);
+        assertThat(finalState.get("downloadable").asBoolean()).isTrue();
+
+        String csv = mockMvc.perform(get("/admin/events/export-jobs/{jobId}/download", jobId)
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isOk())
+            .andExpect(header().string("Content-Type", org.hamcrest.Matchers.containsString("text/csv")))
+            .andExpect(header().string("Content-Disposition", org.hamcrest.Matchers.containsString("attachment;")))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertThat(csv).contains("id,userId,eventType,hymnId,part,metadataJson,createdAt");
+        assertThat(csv).contains("HYMN_OPENED");
+        assertThat(csv).doesNotContain("NOTE_SAVED");
+    }
+
+    @Test
+    void asyncExportJobIsVisibleOnlyToRequester() throws Exception {
+        UUID secondAdminId = UUID.randomUUID();
+        userJpaRepository.save(new UserEntity(
+            secondAdminId,
+            "Admin 2",
+            Role.ADMIN,
+            UserStatus.ACTIVE,
+            Instant.now(),
+            Instant.now()
+        ));
+        String secondAdminToken = jwtService.issueAccessToken(secondAdminId.toString(), Role.ADMIN.name());
+
+        String createResponse = mockMvc.perform(post("/admin/events/export-jobs")
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isAccepted())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+        UUID jobId = UUID.fromString(objectMapper.readTree(createResponse).get("data").get("id").asText());
+
+        mockMvc.perform(get("/admin/events/export-jobs/{jobId}", jobId)
+                .header("Authorization", "Bearer " + secondAdminToken))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error.code").value("export_job_not_found"));
+
+        waitForJobCompletion(jobId, adminToken);
+    }
+
+    @Test
     void invalidUserIdReturnsBadRequest() throws Exception {
         mockMvc.perform(get("/admin/events")
                 .header("Authorization", "Bearer " + adminToken)
@@ -277,6 +349,26 @@ class AdminEventApiTest {
                 .param("to", now.minus(1, ChronoUnit.HOURS).toString()))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.error.code").value("invalid_range"));
+    }
+
+    private JsonNode waitForJobCompletion(UUID jobId, String token) throws Exception {
+        JsonNode latest = null;
+        for (int attempt = 0; attempt < 40; attempt += 1) {
+            String response = mockMvc.perform(get("/admin/events/export-jobs/{jobId}", jobId)
+                    .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+            latest = objectMapper.readTree(response).get("data");
+            String status = latest.get("status").asText();
+            if ("COMPLETED".equals(status) || "FAILED".equals(status)) {
+                return latest;
+            }
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+        return latest;
     }
 
     private void saveEvent(

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -278,3 +278,42 @@
 - `./gradlew.bat test --tests "com.eunhyehymn.presentation.controllers.AdminEventApiTest" --no-daemon --stacktrace` (`apps/api`)
 - `npm ci` + `npx tsc --noEmit` + `npm run build` (`apps/admin`)
 - `rg -n "summaryDays|1~90|대용량 비동기 export" docs/events.md docs/current-usable-scope.md CLAUDE.md docs/changelog-dev.md`
+
+## 10. 이번 사이클 기록 (2026-02-14, 7차)
+
+### 목표
+- 기능 백로그 완료: 관리자 감사 로그 대용량 비동기 export 구현
+
+### 범위
+- 포함: 비동기 export API/DB/UI 구현, 통합 테스트, 문서 동기화
+- 제외: 비동기 export 결과 만료/자동 정리 배치
+
+### 수행 작업
+1. 백엔드 비동기 export job 도입
+- `apps/api/src/main/resources/db/migration/V8__event_export_jobs.sql`
+- `EventExportJob`/`EventExportJobStatus` 도메인 모델 및 저장소 추가
+- `AdminEventExportJobUseCase`로 작업 생성/처리/다운로드 검증 구현
+- `AdminEventController`에 아래 엔드포인트 추가
+  - `POST /admin/events/export-jobs`
+  - `GET /admin/events/export-jobs/{jobId}`
+  - `GET /admin/events/export-jobs/{jobId}/download`
+
+2. 관리자 UI 연동
+- `apps/admin/src/api/adminEvents.ts`
+  - 비동기 작업 생성/조회/다운로드 API 추가
+- `apps/admin/src/pages/AdminEventPage.tsx`
+  - "비동기 CSV 요청" 버튼 추가
+  - 작업 상태(QUEUED/RUNNING/COMPLETED/FAILED) 카드 + 완료 다운로드 버튼 추가
+
+3. 테스트 및 안정화
+- `AdminEventApiTest`에 비동기 export 통합 테스트 추가
+- 테스트 간 백그라운드 레이스를 방지하도록 요청자 격리 테스트 종료 전에 작업 완료 대기 처리
+
+4. 문서 동기화
+- `docs/events.md`, `docs/api-contract.md`, `docs/usecases/admin-list-events.md`
+- `docs/current-usable-scope.md`, `docs/changelog-dev.md`, `CLAUDE.md`
+
+### 검증
+- `./gradlew.bat test --tests "com.eunhyehymn.presentation.controllers.AdminEventApiTest" --no-daemon --stacktrace` (`apps/api`)
+- `./gradlew.bat test --no-daemon --stacktrace` (`apps/api`)
+- `npm ci` + `npx tsc --noEmit` + `npm run build` (`apps/admin`)

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -167,6 +167,9 @@ Base URL: `/api/v1`
 ### 4.3 감사 로그/분석
 - `GET /admin/events`
 - `GET /admin/events/export` (CSV 다운로드)
+- `POST /admin/events/export-jobs` (비동기 대용량 CSV 작업 생성, 202 Accepted)
+- `GET /admin/events/export-jobs/{jobId}` (작업 상태 조회)
+- `GET /admin/events/export-jobs/{jobId}/download` (완료 작업 다운로드)
 - 지원 쿼리:
   - `eventType`: `HYMN_OPENED` | `PART_PLAYED` | `NOTE_SAVED` | `FAVORITE_TOGGLED`
   - `userId`, `hymnId`: UUID
@@ -214,6 +217,24 @@ Base URL: `/api/v1`
 - `GET /admin/events/export` 응답:
   - `Content-Type: text/csv`
   - `Content-Disposition: attachment; filename="admin-events-*.csv"`
+
+- `POST /admin/events/export-jobs` 응답 `data` 예시:
+```json
+{
+  "id": "job-uuid",
+  "status": "QUEUED",
+  "exportLimit": 50000,
+  "rowCount": null,
+  "fileName": null,
+  "errorMessage": null,
+  "createdAt": "2026-02-14T05:00:00Z",
+  "startedAt": null,
+  "completedAt": null,
+  "statusUrl": "/admin/events/export-jobs/job-uuid",
+  "downloadUrl": "/admin/events/export-jobs/job-uuid/download",
+  "downloadable": false
+}
+```
 
 ## 5. 사용자 개인 영역
 

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,22 @@
 
 ## 2026-02-14
 
+### 감사 로그 대용량 비동기 export(7차)
+- 백엔드 비동기 export job 추가
+  - `POST /api/v1/admin/events/export-jobs`: 작업 생성(202 Accepted)
+  - `GET /api/v1/admin/events/export-jobs/{jobId}`: 상태 조회
+  - `GET /api/v1/admin/events/export-jobs/{jobId}/download`: 완료 작업 다운로드
+  - 신규 테이블: `event_export_jobs` (`V8__event_export_jobs.sql`)
+  - 신규 도메인/유스케이스: `EventExportJob`, `EventExportJobStatus`, `AdminEventExportJobUseCase`
+- 관리자 UI 반영
+  - `apps/admin/src/pages/AdminEventPage.tsx`
+  - 비동기 CSV 요청 버튼, 작업 상태 카드, 완료 후 다운로드 버튼 추가
+  - 최대 50,000건 요청 프리셋(백엔드 상한 100,000) 적용
+- API 테스트 보강
+  - `AdminEventApiTest`에 비동기 export 생성/완료/다운로드 및 요청자 격리 검증 추가
+- 문서 동기화
+  - `docs/events.md`, `docs/api-contract.md`, `docs/usecases/admin-list-events.md`, `docs/current-usable-scope.md`, `CLAUDE.md`, `docs/WORK_CYCLE.md`
+
 ### 감사 로그 집계 기간 커스텀(6차)
 - 관리자 이벤트 화면 개선
   - `apps/admin/src/pages/AdminEventPage.tsx`

--- a/docs/current-usable-scope.md
+++ b/docs/current-usable-scope.md
@@ -27,7 +27,7 @@
 - 에셋 관리: Presign -> 업로드 -> Confirm 3단계, 에셋 삭제
 - 사용자 관리: 사용자 목록, 역할/상태 변경
 - 초대코드 관리: 생성/비활성화/만료일 설정 및 표시
-- 감사 로그/분석: 이벤트 로그 필터/페이지네이션 조회, 이벤트 타입별 집계(최근 N일, `summaryDays` 1~90 커스텀), CSV 내보내기
+- 감사 로그/분석: 이벤트 로그 필터/페이지네이션 조회, 이벤트 타입별 집계(최근 N일, `summaryDays` 1~90 커스텀), 동기 CSV 내보내기 + 비동기 대용량 CSV 작업(요청/상태/다운로드)
 - 인증: Google/Kakao 소셜 로그인 UI, Dev 로그인
 - 토큰: 401 발생 시 Access Token 자동 갱신 후 재시도
 
@@ -51,7 +51,7 @@
 - 에셋: 관리자 Presign/Confirm/Delete (AssetType: `PNG`, `MIDI`)
 - 사용자/초대코드 관리자 기능
 - 관리자 감사 로그: `GET /admin/events` 조회/필터/페이지네이션 + 최근 N일 이벤트 타입 집계(`summaryDays` 1~90)
-- 관리자 감사 로그 내보내기: `GET /admin/events/export` CSV 다운로드
+- 관리자 감사 로그 내보내기: `GET /admin/events/export`(동기 CSV), `POST /admin/events/export-jobs` + `GET /admin/events/export-jobs/{jobId}` + `GET /admin/events/export-jobs/{jobId}/download`(비동기 대용량 CSV)
 - 멤버 기능: 즐겨찾기, 메모, 히스토리, 이벤트 기록
 
 엔드포인트 기준은 `CLAUDE.md` 7장과 현재 컨트롤러/유즈케이스 구현 상태를 따른다.
@@ -138,7 +138,7 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
   - `docs/runbook.md` + `docs/staging-smoke-checklist.md` 기준 Admin/Mobile 수동 스모크 실행
   - 리허설/스모크 결과를 `docs/changelog-dev.md`에 주기 반영
 - 운영 기능 백로그
-  - 감사 로그 고도화(대용량 비동기 export)
+  - 비동기 export 결과 보관 정책(만료/정리) 및 운영 모니터링 지표 정례화
 
 ## 6. 빠른 사용 체크리스트
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -63,6 +63,18 @@
 - 필터: `eventType`, `userId`, `hymnId`, `from`, `to`
 - 제한: `limit` (서버 상한 적용)
 
+### 4.4 관리자 감사 로그 비동기 CSV (대용량)
+- `POST /api/v1/admin/events/export-jobs`
+  - 비동기 내보내기 작업 생성(202 Accepted)
+  - 필터: `eventType`, `userId`, `hymnId`, `from`, `to`
+  - `limit`: 기본 20,000 / 최대 100,000
+- `GET /api/v1/admin/events/export-jobs/{jobId}`
+  - 작업 상태 조회
+  - 상태: `QUEUED`, `RUNNING`, `COMPLETED`, `FAILED`
+- `GET /api/v1/admin/events/export-jobs/{jobId}/download`
+  - 완료(`COMPLETED`) 작업 CSV 다운로드
+  - 미완료/실패 작업은 `409` 반환
+
 ## 5. 인덱스/성능 메모
 - 관리자 조회 패턴 최적화를 위해 아래 인덱스를 사용한다.
   - `idx_events_user_created` (`user_id`, `created_at`) - 기존
@@ -72,4 +84,5 @@
 - 운영 시 확인 항목
   - 관리자 이벤트 조회 응답 시간이 증가하면 `EXPLAIN ANALYZE`로 인덱스 사용 여부 확인
   - 이벤트 테이블 급증 시 CSV `limit` 정책과 백필/아카이빙 정책을 함께 점검
+  - 대용량 비동기 export는 `event_export_jobs` 테이블 크기/완료율/실패율을 함께 모니터링
 

--- a/docs/usecases/admin-list-events.md
+++ b/docs/usecases/admin-list-events.md
@@ -14,6 +14,9 @@
 ## API
 - `GET /api/v1/admin/events`
 - `GET /api/v1/admin/events/export` (CSV 다운로드)
+- `POST /api/v1/admin/events/export-jobs` (비동기 대용량 CSV 작업 생성)
+- `GET /api/v1/admin/events/export-jobs/{jobId}` (작업 상태 조회)
+- `GET /api/v1/admin/events/export-jobs/{jobId}/download` (완료 작업 CSV 다운로드)
 
 ## 주요 파라미터
 - `eventType`: `HYMN_OPENED`, `PART_PLAYED`, `NOTE_SAVED`, `FAVORITE_TOGGLED`
@@ -22,6 +25,7 @@
 - `page`, `size`: 페이지네이션 (기본 1/50, 최대 size 200)
 - `limit`: 하위 호환 조회 개수 파라미터
 - `summaryDays`: 집계 일수(기본 7, 최대 90)
+- `export-jobs limit`: 기본 20,000, 최대 100,000
 
 ## 응답 예시
 ```json


### PR DESCRIPTION
## 요약
- 관리자 감사 로그 대용량 비동기 CSV export를 추가했습니다.
- 기존 동기 `GET /admin/events/export`는 호환 유지하고, 신규 비동기 job API를 추가했습니다.
- Admin 이벤트 페이지에서 비동기 요청/상태 조회/다운로드를 사용할 수 있도록 UI를 확장했습니다.

## 주요 변경
1. 백엔드 (API)
- Flyway 마이그레이션 추가: `V8__event_export_jobs.sql`
- 신규 도메인/저장소/매퍼/어댑터 추가
  - `EventExportJob`, `EventExportJobStatus`, `EventExportJobRepository`
  - `EventExportJobEntity`, `EventExportJobJpaRepository`, `EventExportJobMapper`, `EventExportJobRepositoryAdapter`
- 신규 유스케이스: `AdminEventExportJobUseCase`
  - 작업 생성(`QUEUED`) / 백그라운드 처리(`RUNNING`) / 완료(`COMPLETED`) / 실패(`FAILED`)
  - limit 기본 20,000 / 최대 100,000
- 컨트롤러 확장: `AdminEventController`
  - `POST /admin/events/export-jobs`
  - `GET /admin/events/export-jobs/{jobId}`
  - `GET /admin/events/export-jobs/{jobId}/download`
- 백그라운드 실행기 추가: `AsyncConfig` (`eventExportTaskExecutor`)

2. 관리자 웹 (Admin)
- API 클라이언트 확장: `apps/admin/src/api/adminEvents.ts`
  - 비동기 export job 생성/조회/다운로드 함수 추가
- 화면 확장: `apps/admin/src/pages/AdminEventPage.tsx`
  - "비동기 CSV 요청" 버튼 추가
  - 작업 상태 카드(대기/처리/완료/실패) 및 2초 폴링 추가
  - 완료 시 "비동기 CSV 다운로드" 가능

3. 테스트
- `AdminEventApiTest` 보강
  - 비동기 export 생성/완료/다운로드 통합 테스트
  - 요청자 격리(다른 관리자 접근 시 404) 테스트

4. 문서 동기화
- `docs/events.md`
- `docs/api-contract.md`
- `docs/usecases/admin-list-events.md`
- `docs/current-usable-scope.md`
- `docs/changelog-dev.md`
- `docs/WORK_CYCLE.md`
- `CLAUDE.md`

## 검증
- `cd apps/api && ./gradlew.bat test --tests "com.eunhyehymn.presentation.controllers.AdminEventApiTest" --no-daemon --stacktrace`
- `cd apps/api && ./gradlew.bat test --no-daemon --stacktrace`
- `cd apps/admin && npm ci`
- `cd apps/admin && npx tsc --noEmit`
- `cd apps/admin && npm run build`

## 리스크/후속
- 현재 비동기 결과(CSV)는 DB(`event_export_jobs.csv_content`)에 저장됩니다.
- 후속으로 결과 만료/정리 정책(배치)과 운영 모니터링 지표(실패율/처리시간) 정례화가 필요합니다.