### PR TITLE
feat: 비동기 export 결과 정리 배치 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
 ```
 Eunhye_Hymn/
 ├── apps/
-│   ├── api/              # Spring Boot 백엔드 (Java 17, Gradle) ← MVP 완료 (27 UseCase)
+│   ├── api/              # Spring Boot 백엔드 (Java 17, Gradle) ← MVP 완료 (28 UseCase)
 │   │   └── Dockerfile    # Multi-stage (JDK build → JRE run + curl for healthcheck)
 │   ├── admin/            # React + Vite + TypeScript 관리자 웹  ← 8페이지 완료
 │   │   ├── Dockerfile    # Multi-stage (Node build → Nginx serve)
@@ -133,6 +133,9 @@ cd apps/mobile
 | `S3_ENDPOINT` | S3 엔드포인트 오버라이드 | - | (빈 문자열) |
 | `S3_PUBLIC_BASE_URL` | 에셋 공개 URL 베이스 | - | (빈 문자열) |
 | `S3_PRESIGN_EXPIRES_MINUTES` | presigned URL 만료 | - | `15` |
+| `EVENT_EXPORT_JOB_RETENTION_DAYS` | 비동기 export 결과 보관 일수 | - | `7` |
+| `EVENT_EXPORT_JOB_CLEANUP_CRON` | 비동기 export 정리 스케줄(cron) | - | `0 15 3 * * *` |
+| `EVENT_EXPORT_JOB_CLEANUP_ZONE` | 비동기 export 정리 스케줄 타임존 | - | `UTC` |
 
 ---
 
@@ -157,12 +160,12 @@ com.eunhyehymn/
 │   └── repository/     # Repository 인터페이스
 ├── application/
 │   ├── ports/          # 외부 서비스 인터페이스 (SocialTokenVerifier)
-│   └── usecases/       # 비즈니스 로직 Use Cases (27개)
+│   └── usecases/       # 비즈니스 로직 Use Cases (28개)
 ├── presentation/
 │   ├── controllers/    # REST 컨트롤러 (11개)
 │   └── dto/            # Request/Response DTOs
 ├── infrastructure/
-│   ├── persistence/    # JPA Repository Adapters (9개)
+│   ├── persistence/    # JPA Repository Adapters (10개)
 │   ├── security/       # JWT, Social Login, Security Config
 │   └── storage/        # S3 Storage Service
 └── common/
@@ -290,7 +293,7 @@ com.eunhyehymn/
 
 ---
 
-## 8. Use Cases (27개)
+## 8. Use Cases (28개)
 
 | Use Case | 메서드 | 핵심 로직 |
 |----------|--------|-----------|
@@ -317,6 +320,7 @@ com.eunhyehymn/
 | `AdminUpdateUserUseCase` | `update(userId, role, status)` | 사용자 역할/상태 변경 |
 | `AdminListEventsUseCase` | `execute(query)` | 관리자 이벤트 로그 조회 + 이벤트 타입 집계 |
 | `AdminEventExportJobUseCase` | `create/get/process/getDownload` | 관리자 비동기 대용량 CSV 작업 생성/상태/처리/다운로드 |
+| `CleanupEventExportJobsUseCase` | `cleanup(now)` | 완료/실패 비동기 export 작업 보관기한 정리 |
 | `AdminCreateInviteCodeUseCase` | `create(code, createdBy, ...)` | 초대코드 생성 (중복 검사) |
 | `AdminListInviteCodesUseCase` | `listAll()` | 전체 초대코드 목록 |
 | `AdminRevokeInviteCodeUseCase` | `revoke(code)` | 초대코드 비활성화 (enabled=false) |
@@ -403,6 +407,8 @@ com.eunhyehymn/
 | `SocialLoginApiTest` | 소셜 로그인 API (Google/Kakao, 초대코드 검증, 기존 사용자) |
 | `FlywayRepositoryIntegrationTest` | DB 마이그레이션 통합 |
 | `GetHistoryUseCaseTest` | 히스토리 Use Case 단위 |
+| `CleanupEventExportJobsUseCaseTest` | 비동기 export 정리 Use Case 단위 |
+| `CleanupEventExportJobsUseCaseIntegrationTest` | 비동기 export 정리 정책 통합 |
 | `AdminUserApiTest` | 사용자 관리 API (목록, 역할/상태 변경, 권한 검사) |
 | `AdminEventApiTest` | 관리자 이벤트 API (로그 조회, 집계, 페이지네이션, 동기/비동기 CSV export, 접근 제어 검증) |
 | `AdminInviteCodeApiTest` | 초대코드 관리 API (생성, 목록, 비활성화, 검증) |
@@ -652,15 +658,16 @@ develop push → GitHub Actions
 
 ### 완료
 
-**백엔드 API (27 UseCase, 11 Controller)**
+**백엔드 API (28 UseCase, 11 Controller)**
 - 찬양 CRUD + 삭제 (cascade: 에셋/메모/상태/이벤트)
 - S3 에셋 관리 (presign/confirm/삭제)
 - JWT 인증 + 소셜 로그인 (Google/Kakao) + 토큰 회전
 - DB 기반 초대코드 관리 (CRUD + 검증 + 원자적 사용 횟수 증가)
 - 사용자 관리 (역할/상태 변경)
 - 멤버 기능 (즐겨찾기, 메모, 히스토리, 이벤트 기록)
+- 비동기 export 결과 정리 배치 (완료/실패 작업 기본 7일 보관 후 정리)
 - DB 스키마 Flyway 마이그레이션 (V1~V8)
-- 테스트 12개 파일 전체 통과 (SocialLoginApiTest 포함)
+- 테스트 14개 파일 전체 통과 (SocialLoginApiTest 포함)
 
 **Admin 프론트엔드 (8페이지)**
 - 찬양 목록/생성/수정/삭제 + 검색/필터 + 활성화 토글
@@ -746,7 +753,7 @@ develop push → GitHub Actions
 - 배포 후 스모크 테스트 항목과 점검 결과를 `docs/staging-rehearsal-log.md`에 주기적으로 갱신
 
 **3. 기능 백로그**
-- 비동기 export 결과 보관 정책(만료/정리) 및 운영 지표(실패율/처리시간) 정례화
+- 비동기 export 운영 지표(실패율/처리시간/정리량) 정례화
 
 **4. 모바일 배포 패키징**
 - 현재 저장소 기준 실행은 `flutter run -d chrome` 중심

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/CleanupEventExportJobsUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/CleanupEventExportJobsUseCase.java
@@ -1,0 +1,40 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.domain.repository.EventExportJobRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+public class CleanupEventExportJobsUseCase {
+    private static final int MIN_RETENTION_DAYS = 1;
+
+    private final EventExportJobRepository eventExportJobRepository;
+    private final int retentionDays;
+
+    public CleanupEventExportJobsUseCase(
+        EventExportJobRepository eventExportJobRepository,
+        int retentionDays
+    ) {
+        this.eventExportJobRepository = eventExportJobRepository;
+        this.retentionDays = normalizeRetentionDays(retentionDays);
+    }
+
+    public Result cleanup(Instant now) {
+        Instant completedBeforeExclusive = now.minus(retentionDays, ChronoUnit.DAYS);
+        long deleted = eventExportJobRepository.deleteCompletedOrFailedBefore(completedBeforeExclusive);
+        return new Result(retentionDays, completedBeforeExclusive, deleted);
+    }
+
+    private int normalizeRetentionDays(int value) {
+        if (value < MIN_RETENTION_DAYS) {
+            return MIN_RETENTION_DAYS;
+        }
+        return value;
+    }
+
+    public record Result(
+        int retentionDays,
+        Instant completedBeforeExclusive,
+        long deletedCount
+    ) {
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/SchedulingConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.eunhyehymn.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/UseCaseConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/UseCaseConfig.java
@@ -8,6 +8,7 @@ import com.eunhyehymn.application.usecases.AdminListHymnsUseCase;
 import com.eunhyehymn.application.usecases.AdminListUsersUseCase;
 import com.eunhyehymn.application.usecases.AdminUpdateHymnUseCase;
 import com.eunhyehymn.application.usecases.AdminUpdateUserUseCase;
+import com.eunhyehymn.application.usecases.CleanupEventExportJobsUseCase;
 import com.eunhyehymn.application.usecases.GetFavoriteUseCase;
 import com.eunhyehymn.application.usecases.GetHistoryUseCase;
 import com.eunhyehymn.application.usecases.GetHymnDetailUseCase;
@@ -23,6 +24,7 @@ import com.eunhyehymn.domain.repository.HymnNoteRepository;
 import com.eunhyehymn.domain.repository.HymnRepository;
 import com.eunhyehymn.domain.repository.UserHymnStateRepository;
 import com.eunhyehymn.domain.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -104,6 +106,14 @@ public class UseCaseConfig {
         EventExportJobRepository eventExportJobRepository
     ) {
         return new AdminEventExportJobUseCase(eventRepository, eventExportJobRepository);
+    }
+
+    @Bean
+    CleanupEventExportJobsUseCase cleanupEventExportJobsUseCase(
+        EventExportJobRepository eventExportJobRepository,
+        @Value("${events.export.jobs.retention-days:7}") int retentionDays
+    ) {
+        return new CleanupEventExportJobsUseCase(eventExportJobRepository, retentionDays);
     }
 
     @Bean

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/EventExportJobRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/EventExportJobRepository.java
@@ -1,6 +1,7 @@
 package com.eunhyehymn.domain.repository;
 
 import com.eunhyehymn.domain.model.EventExportJob;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -8,4 +9,6 @@ public interface EventExportJobRepository {
     EventExportJob save(EventExportJob job);
 
     Optional<EventExportJob> findById(UUID id);
+
+    long deleteCompletedOrFailedBefore(Instant completedBeforeExclusive);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobJpaRepository.java
@@ -1,7 +1,13 @@
 package com.eunhyehymn.infrastructure.persistence;
 
+import com.eunhyehymn.domain.model.EventExportJobStatus;
+import java.time.Instant;
+import java.util.Collection;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface EventExportJobJpaRepository extends JpaRepository<EventExportJobEntity, UUID> {
+    @Transactional
+    long deleteByStatusInAndCompletedAtBefore(Collection<EventExportJobStatus> statuses, Instant completedBeforeExclusive);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobRepositoryAdapter.java
@@ -1,8 +1,11 @@
 package com.eunhyehymn.infrastructure.persistence;
 
 import com.eunhyehymn.domain.model.EventExportJob;
+import com.eunhyehymn.domain.model.EventExportJobStatus;
 import com.eunhyehymn.domain.repository.EventExportJobRepository;
 import com.eunhyehymn.infrastructure.persistence.mapper.EventExportJobMapper;
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Repository;
@@ -24,5 +27,13 @@ public class EventExportJobRepositoryAdapter implements EventExportJobRepository
     @Override
     public Optional<EventExportJob> findById(UUID id) {
         return jpaRepository.findById(id).map(EventExportJobMapper::toDomain);
+    }
+
+    @Override
+    public long deleteCompletedOrFailedBefore(Instant completedBeforeExclusive) {
+        return jpaRepository.deleteByStatusInAndCompletedAtBefore(
+            List.of(EventExportJobStatus.COMPLETED, EventExportJobStatus.FAILED),
+            completedBeforeExclusive
+        );
     }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/scheduling/EventExportJobCleanupScheduler.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/scheduling/EventExportJobCleanupScheduler.java
@@ -1,0 +1,33 @@
+package com.eunhyehymn.infrastructure.scheduling;
+
+import com.eunhyehymn.application.usecases.CleanupEventExportJobsUseCase;
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventExportJobCleanupScheduler {
+    private static final Logger logger = LoggerFactory.getLogger(EventExportJobCleanupScheduler.class);
+
+    private final CleanupEventExportJobsUseCase cleanupEventExportJobsUseCase;
+
+    public EventExportJobCleanupScheduler(CleanupEventExportJobsUseCase cleanupEventExportJobsUseCase) {
+        this.cleanupEventExportJobsUseCase = cleanupEventExportJobsUseCase;
+    }
+
+    @Scheduled(
+        cron = "${events.export.jobs.cleanup-cron:0 15 3 * * *}",
+        zone = "${events.export.jobs.cleanup-zone:UTC}"
+    )
+    public void cleanupFinishedJobs() {
+        CleanupEventExportJobsUseCase.Result result = cleanupEventExportJobsUseCase.cleanup(Instant.now());
+        logger.info(
+            "event-export cleanup completed: deleted={}, retentionDays={}, completedBeforeExclusive={}",
+            result.deletedCount(),
+            result.retentionDays(),
+            result.completedBeforeExclusive()
+        );
+    }
+}

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -45,3 +45,10 @@ storage:
     endpoint: ${S3_ENDPOINT:}
     public-base-url: ${S3_PUBLIC_BASE_URL:}
     presign-expires-minutes: ${S3_PRESIGN_EXPIRES_MINUTES:15}
+
+events:
+  export:
+    jobs:
+      retention-days: ${EVENT_EXPORT_JOB_RETENTION_DAYS:7}
+      cleanup-cron: ${EVENT_EXPORT_JOB_CLEANUP_CRON:0 15 3 * * *}
+      cleanup-zone: ${EVENT_EXPORT_JOB_CLEANUP_ZONE:UTC}

--- a/apps/api/src/test/java/com/eunhyehymn/application/usecases/CleanupEventExportJobsUseCaseIntegrationTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/application/usecases/CleanupEventExportJobsUseCaseIntegrationTest.java
@@ -1,0 +1,92 @@
+package com.eunhyehymn.application.usecases;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.eunhyehymn.domain.model.EventExportJobStatus;
+import com.eunhyehymn.domain.model.EventType;
+import com.eunhyehymn.domain.model.Role;
+import com.eunhyehymn.domain.model.UserStatus;
+import com.eunhyehymn.infrastructure.persistence.EventExportJobEntity;
+import com.eunhyehymn.infrastructure.persistence.EventExportJobJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.UserEntity;
+import com.eunhyehymn.infrastructure.persistence.UserJpaRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CleanupEventExportJobsUseCaseIntegrationTest {
+    @Autowired private CleanupEventExportJobsUseCase cleanupEventExportJobsUseCase;
+    @Autowired private EventExportJobJpaRepository eventExportJobJpaRepository;
+    @Autowired private UserJpaRepository userJpaRepository;
+
+    private UUID requestedBy;
+
+    @BeforeEach
+    void setUp() {
+        eventExportJobJpaRepository.deleteAll();
+        requestedBy = UUID.randomUUID();
+        userJpaRepository.save(new UserEntity(
+            requestedBy,
+            "Cleanup Tester",
+            Role.ADMIN,
+            UserStatus.ACTIVE,
+            Instant.now(),
+            Instant.now()
+        ));
+    }
+
+    @AfterEach
+    void tearDown() {
+        eventExportJobJpaRepository.deleteAll();
+        userJpaRepository.deleteById(requestedBy);
+    }
+
+    @Test
+    void cleanupDeletesOnlyCompletedOrFailedJobsOutsideRetentionWindow() {
+        Instant now = Instant.now();
+
+        UUID oldCompletedId = saveJob(EventExportJobStatus.COMPLETED, now.minus(10, ChronoUnit.DAYS));
+        UUID oldFailedId = saveJob(EventExportJobStatus.FAILED, now.minus(8, ChronoUnit.DAYS));
+        UUID recentCompletedId = saveJob(EventExportJobStatus.COMPLETED, now.minus(2, ChronoUnit.DAYS));
+        UUID runningOldId = saveJob(EventExportJobStatus.RUNNING, null);
+
+        CleanupEventExportJobsUseCase.Result result = cleanupEventExportJobsUseCase.cleanup(now);
+
+        assertThat(result.deletedCount()).isEqualTo(2);
+        assertThat(eventExportJobJpaRepository.findById(oldCompletedId)).isEmpty();
+        assertThat(eventExportJobJpaRepository.findById(oldFailedId)).isEmpty();
+        assertThat(eventExportJobJpaRepository.findById(recentCompletedId)).isPresent();
+        assertThat(eventExportJobJpaRepository.findById(runningOldId)).isPresent();
+    }
+
+    private UUID saveJob(EventExportJobStatus status, Instant completedAt) {
+        UUID id = UUID.randomUUID();
+        eventExportJobJpaRepository.save(new EventExportJobEntity(
+            id,
+            requestedBy,
+            EventType.HYMN_OPENED,
+            null,
+            null,
+            null,
+            null,
+            10_000,
+            status,
+            status == EventExportJobStatus.COMPLETED ? 5L : null,
+            status == EventExportJobStatus.COMPLETED ? "sample.csv" : null,
+            status == EventExportJobStatus.COMPLETED ? "id,userId\n" : null,
+            status == EventExportJobStatus.FAILED ? "sample error" : null,
+            completedAt == null ? Instant.now() : completedAt.minus(1, ChronoUnit.HOURS),
+            completedAt == null ? null : completedAt.minus(30, ChronoUnit.MINUTES),
+            completedAt
+        ));
+        return id;
+    }
+}

--- a/apps/api/src/test/java/com/eunhyehymn/application/usecases/CleanupEventExportJobsUseCaseTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/application/usecases/CleanupEventExportJobsUseCaseTest.java
@@ -1,0 +1,60 @@
+package com.eunhyehymn.application.usecases;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.eunhyehymn.domain.model.EventExportJob;
+import com.eunhyehymn.domain.repository.EventExportJobRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class CleanupEventExportJobsUseCaseTest {
+    @Test
+    void cleanupUsesConfiguredRetentionDays() {
+        InMemoryEventExportJobRepository repository = new InMemoryEventExportJobRepository();
+        repository.deletedCount = 3;
+        CleanupEventExportJobsUseCase useCase = new CleanupEventExportJobsUseCase(repository, 7);
+
+        Instant now = Instant.parse("2026-02-14T00:00:00Z");
+        CleanupEventExportJobsUseCase.Result result = useCase.cleanup(now);
+
+        assertThat(repository.lastCompletedBeforeExclusive).isEqualTo(now.minus(7, ChronoUnit.DAYS));
+        assertThat(result.deletedCount()).isEqualTo(3);
+        assertThat(result.retentionDays()).isEqualTo(7);
+    }
+
+    @Test
+    void retentionDaysLowerThanOneIsNormalized() {
+        InMemoryEventExportJobRepository repository = new InMemoryEventExportJobRepository();
+        CleanupEventExportJobsUseCase useCase = new CleanupEventExportJobsUseCase(repository, 0);
+
+        Instant now = Instant.parse("2026-02-14T00:00:00Z");
+        CleanupEventExportJobsUseCase.Result result = useCase.cleanup(now);
+
+        assertThat(result.retentionDays()).isEqualTo(1);
+        assertThat(repository.lastCompletedBeforeExclusive).isEqualTo(now.minus(1, ChronoUnit.DAYS));
+    }
+
+    private static final class InMemoryEventExportJobRepository implements EventExportJobRepository {
+        private Instant lastCompletedBeforeExclusive;
+        private long deletedCount;
+
+        @Override
+        public EventExportJob save(EventExportJob job) {
+            throw new UnsupportedOperationException("not used in this test");
+        }
+
+        @Override
+        public Optional<EventExportJob> findById(UUID id) {
+            return Optional.empty();
+        }
+
+        @Override
+        public long deleteCompletedOrFailedBefore(Instant completedBeforeExclusive) {
+            this.lastCompletedBeforeExclusive = completedBeforeExclusive;
+            return deletedCount;
+        }
+    }
+}

--- a/apps/api/src/test/resources/application-test.yml
+++ b/apps/api/src/test/resources/application-test.yml
@@ -12,9 +12,17 @@ spring:
       ddl-auto: validate
   flyway:
     enabled: true
+  task:
+    scheduling:
+      enabled: false
 
 security:
   jwt:
     secret: test-secret
     access-token-ttl-seconds: 3600
     refresh-token-ttl-seconds: 1209600
+
+events:
+  export:
+    jobs:
+      retention-days: 7

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -317,3 +317,45 @@
 - `./gradlew.bat test --tests "com.eunhyehymn.presentation.controllers.AdminEventApiTest" --no-daemon --stacktrace` (`apps/api`)
 - `./gradlew.bat test --no-daemon --stacktrace` (`apps/api`)
 - `npm ci` + `npx tsc --noEmit` + `npm run build` (`apps/admin`)
+
+## 11. 이번 사이클 기록 (2026-02-14, 8차)
+
+### 목표
+- 기능 백로그 완료: 비동기 export 결과 보관 정책(만료/정리) 배치 도입
+
+### 범위
+- 포함: 백엔드 정리 유스케이스/스케줄러, 테스트 보강, 문서 동기화
+- 제외: 운영 대시보드/알람 지표 자동 수집
+
+### 수행 작업
+1. 백엔드 정리 정책 구현
+- `CleanupEventExportJobsUseCase` 추가
+  - 완료/실패 상태 작업을 보관 일수 기준으로 삭제
+  - 기본 보관 일수 `7`일(최소 `1`일)
+- 저장소 삭제 메서드 추가
+  - `EventExportJobRepository.deleteCompletedOrFailedBefore(...)`
+  - `EventExportJobJpaRepository.deleteByStatusInAndCompletedAtBefore(...)`
+- 스케줄러 추가
+  - `EventExportJobCleanupScheduler`
+  - 기본 실행: 매일 03:15 UTC (`events.export.jobs.cleanup-cron`)
+
+2. 설정 추가
+- `application.yml`
+  - `events.export.jobs.retention-days`
+  - `events.export.jobs.cleanup-cron`
+  - `events.export.jobs.cleanup-zone`
+- `application-test.yml`
+  - 테스트 환경에서 스케줄러 비활성화 (`spring.task.scheduling.enabled=false`)
+
+3. 테스트 보강
+- 단위 테스트: `CleanupEventExportJobsUseCaseTest`
+- 통합 테스트: `CleanupEventExportJobsUseCaseIntegrationTest`
+- 전체 API 테스트 시 격리 이슈를 막기 위해 integration test에 `tearDown` 정리 추가
+
+4. 문서 동기화
+- `docs/events.md`, `docs/current-usable-scope.md`, `docs/changelog-dev.md`, `CLAUDE.md`
+
+### 검증
+- `./gradlew.bat test --tests "com.eunhyehymn.application.usecases.CleanupEventExportJobsUseCaseTest" --tests "com.eunhyehymn.application.usecases.CleanupEventExportJobsUseCaseIntegrationTest" --no-daemon --stacktrace` (`apps/api`)
+- `./gradlew.bat test --no-daemon --stacktrace` (`apps/api`)
+- `npx tsc --noEmit` + `npm run build` (`apps/admin`)

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,22 @@
 
 ## 2026-02-14
 
+### 비동기 export 결과 정리 배치(8차)
+- 백엔드 정리 정책 추가
+  - `CleanupEventExportJobsUseCase` 추가 (완료/실패 작업 보관 기한 기준 삭제)
+  - `EventExportJobCleanupScheduler` 추가 (기본 매일 03:15 UTC 실행)
+  - 저장소 삭제 메서드 추가: 완료/실패 + `completed_at` 기준 일괄 삭제
+- 설정 추가
+  - `EVENT_EXPORT_JOB_RETENTION_DAYS` (기본 7)
+  - `EVENT_EXPORT_JOB_CLEANUP_CRON` (기본 `0 15 3 * * *`)
+  - `EVENT_EXPORT_JOB_CLEANUP_ZONE` (기본 `UTC`)
+- 테스트 보강
+  - `CleanupEventExportJobsUseCaseTest` (정리 기준 계산/정규화 단위 테스트)
+  - `CleanupEventExportJobsUseCaseIntegrationTest` (완료/실패만 삭제되는 통합 테스트)
+  - 테스트 격리를 위한 cleanup integration test `tearDown` 추가
+- 문서 동기화
+  - `docs/events.md`, `docs/current-usable-scope.md`, `docs/WORK_CYCLE.md`, `CLAUDE.md`
+
 ### 감사 로그 대용량 비동기 export(7차)
 - 백엔드 비동기 export job 추가
   - `POST /api/v1/admin/events/export-jobs`: 작업 생성(202 Accepted)

--- a/docs/current-usable-scope.md
+++ b/docs/current-usable-scope.md
@@ -2,9 +2,9 @@
 
 - 작성일: 2026-02-14
 - 기준 브랜치: `develop` (통합/배포 기준)
-- 기준 커밋: `630edd4` (2026-02-14 03:51 UTC 기준 `develop` HEAD)
+- 기준 커밋: `389c752` (2026-02-14 05:11 UTC 기준 `develop` HEAD)
 - 근거 문서: `README.md`, `CLAUDE.md`, `docs/WORK_CYCLE.md`
-- 근거 PR: #49, #48, #47, #46, #45, #43, #42, #41, #40, #38, #37, #36, #31
+- 근거 PR: #52, #49, #48, #47, #46, #45, #43, #42, #41, #40, #38, #37, #36, #31
 
 ## 1. 요약
 
@@ -27,7 +27,7 @@
 - 에셋 관리: Presign -> 업로드 -> Confirm 3단계, 에셋 삭제
 - 사용자 관리: 사용자 목록, 역할/상태 변경
 - 초대코드 관리: 생성/비활성화/만료일 설정 및 표시
-- 감사 로그/분석: 이벤트 로그 필터/페이지네이션 조회, 이벤트 타입별 집계(최근 N일, `summaryDays` 1~90 커스텀), 동기 CSV 내보내기 + 비동기 대용량 CSV 작업(요청/상태/다운로드)
+- 감사 로그/분석: 이벤트 로그 필터/페이지네이션 조회, 이벤트 타입별 집계(최근 N일, `summaryDays` 1~90 커스텀), 동기 CSV 내보내기 + 비동기 대용량 CSV 작업(요청/상태/다운로드) + 완료/실패 작업 자동 정리
 - 인증: Google/Kakao 소셜 로그인 UI, Dev 로그인
 - 토큰: 401 발생 시 Access Token 자동 갱신 후 재시도
 
@@ -51,7 +51,7 @@
 - 에셋: 관리자 Presign/Confirm/Delete (AssetType: `PNG`, `MIDI`)
 - 사용자/초대코드 관리자 기능
 - 관리자 감사 로그: `GET /admin/events` 조회/필터/페이지네이션 + 최근 N일 이벤트 타입 집계(`summaryDays` 1~90)
-- 관리자 감사 로그 내보내기: `GET /admin/events/export`(동기 CSV), `POST /admin/events/export-jobs` + `GET /admin/events/export-jobs/{jobId}` + `GET /admin/events/export-jobs/{jobId}/download`(비동기 대용량 CSV)
+- 관리자 감사 로그 내보내기: `GET /admin/events/export`(동기 CSV), `POST /admin/events/export-jobs` + `GET /admin/events/export-jobs/{jobId}` + `GET /admin/events/export-jobs/{jobId}/download`(비동기 대용량 CSV), 스케줄러 기반 결과 정리(기본 7일 보관)
 - 멤버 기능: 즐겨찾기, 메모, 히스토리, 이벤트 기록
 
 엔드포인트 기준은 `CLAUDE.md` 7장과 현재 컨트롤러/유즈케이스 구현 상태를 따른다.
@@ -138,7 +138,7 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
   - `docs/runbook.md` + `docs/staging-smoke-checklist.md` 기준 Admin/Mobile 수동 스모크 실행
   - 리허설/스모크 결과를 `docs/changelog-dev.md`에 주기 반영
 - 운영 기능 백로그
-  - 비동기 export 결과 보관 정책(만료/정리) 및 운영 모니터링 지표 정례화
+  - 비동기 export 운영 모니터링 지표(실패율/처리시간/정리량) 정례화
 
 ## 6. 빠른 사용 체크리스트
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -75,6 +75,16 @@
   - 완료(`COMPLETED`) 작업 CSV 다운로드
   - 미완료/실패 작업은 `409` 반환
 
+### 4.5 비동기 export 결과 정리 정책
+- 완료(`COMPLETED`) 또는 실패(`FAILED`) 상태의 작업은 스케줄러가 주기적으로 정리한다.
+- 기본 정책
+  - 보관 일수: 7일
+  - 정리 스케줄: 매일 03:15 UTC
+- 설정 값
+  - `EVENT_EXPORT_JOB_RETENTION_DAYS` (기본 7)
+  - `EVENT_EXPORT_JOB_CLEANUP_CRON` (기본 `0 15 3 * * *`)
+  - `EVENT_EXPORT_JOB_CLEANUP_ZONE` (기본 `UTC`)
+
 ## 5. 인덱스/성능 메모
 - 관리자 조회 패턴 최적화를 위해 아래 인덱스를 사용한다.
   - `idx_events_user_created` (`user_id`, `created_at`) - 기존
@@ -84,5 +94,5 @@
 - 운영 시 확인 항목
   - 관리자 이벤트 조회 응답 시간이 증가하면 `EXPLAIN ANALYZE`로 인덱스 사용 여부 확인
   - 이벤트 테이블 급증 시 CSV `limit` 정책과 백필/아카이빙 정책을 함께 점검
-  - 대용량 비동기 export는 `event_export_jobs` 테이블 크기/완료율/실패율을 함께 모니터링
+  - 대용량 비동기 export는 `event_export_jobs` 테이블 크기/완료율/실패율과 정리 삭제량을 함께 모니터링
 


### PR DESCRIPTION
## 요약
- 비동기 export 결과 보관 정책(만료/정리)을 배치로 추가했습니다.
- 완료/실패된 export job을 보관 일수 기준으로 자동 삭제합니다.
- 운영 설정값(보관 일수, cron, zone)과 테스트/문서를 함께 동기화했습니다.

## 주요 변경
1. 백엔드 정리 정책
- 신규 유스케이스: `CleanupEventExportJobsUseCase`
  - `cleanup(now)`에서 완료/실패 job 삭제 기준 시각 계산 후 일괄 삭제
  - 보관 일수 최소값 1일 보정
- 저장소 확장
  - `EventExportJobRepository.deleteCompletedOrFailedBefore(...)`
  - `EventExportJobJpaRepository.deleteByStatusInAndCompletedAtBefore(...)`
  - `EventExportJobRepositoryAdapter` 구현 반영

2. 스케줄러/설정
- 신규 스케줄러: `EventExportJobCleanupScheduler`
  - 기본 매일 03:15 UTC 실행
- 스케줄링 활성화: `SchedulingConfig` (`@EnableScheduling`)
- 설정 추가 (`application.yml`)
  - `events.export.jobs.retention-days`
  - `events.export.jobs.cleanup-cron`
  - `events.export.jobs.cleanup-zone`
- 테스트 프로필(`application-test.yml`)에서 스케줄러 비활성화

3. 테스트
- 단위 테스트 추가
  - `CleanupEventExportJobsUseCaseTest`
- 통합 테스트 추가
  - `CleanupEventExportJobsUseCaseIntegrationTest`
  - 완료/실패만 삭제되고 RUNNING은 유지되는지 검증
- 테스트 격리 보강
  - integration test `tearDown`에서 생성 데이터 정리

4. 문서 동기화
- `docs/events.md`
- `docs/current-usable-scope.md`
- `docs/changelog-dev.md`
- `docs/WORK_CYCLE.md`
- `CLAUDE.md`

## 검증
- `cd apps/api && ./gradlew.bat test --tests "com.eunhyehymn.application.usecases.CleanupEventExportJobsUseCaseTest" --tests "com.eunhyehymn.application.usecases.CleanupEventExportJobsUseCaseIntegrationTest" --no-daemon --stacktrace`
- `cd apps/api && ./gradlew.bat test --no-daemon --stacktrace`
- `cd apps/admin && npx tsc --noEmit`
- `cd apps/admin && npm run build`

## 리스크/후속
- 현재 정리 정책은 DB row 삭제 중심이며, 운영 관측은 로그 기반입니다.
- 후속으로 정리량/실패율/처리시간 지표를 대시보드/알람으로 정례화하는 작업이 필요합니다.