### PR TITLE
feat: regularize async export ops metrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
 ```
 Eunhye_Hymn/
 ├── apps/
-│   ├── api/              # Spring Boot 백엔드 (Java 17, Gradle) ← MVP 완료 (28 UseCase)
+│   ├── api/              # Spring Boot 백엔드 (Java 17, Gradle) ← MVP 완료 (29 UseCase)
 │   │   └── Dockerfile    # Multi-stage (JDK build → JRE run + curl for healthcheck)
 │   ├── admin/            # React + Vite + TypeScript 관리자 웹  ← 8페이지 완료
 │   │   ├── Dockerfile    # Multi-stage (Node build → Nginx serve)
@@ -160,7 +160,7 @@ com.eunhyehymn/
 │   └── repository/     # Repository 인터페이스
 ├── application/
 │   ├── ports/          # 외부 서비스 인터페이스 (SocialTokenVerifier)
-│   └── usecases/       # 비즈니스 로직 Use Cases (28개)
+│   └── usecases/       # 비즈니스 로직 Use Cases (29개)
 ├── presentation/
 │   ├── controllers/    # REST 컨트롤러 (11개)
 │   └── dto/            # Request/Response DTOs
@@ -266,6 +266,7 @@ com.eunhyehymn/
 | POST | `/admin/events/export-jobs` | ADMIN | 비동기 대용량 CSV 작업 생성 (202 Accepted) |
 | GET | `/admin/events/export-jobs/{jobId}` | ADMIN | 비동기 CSV 작업 상태 조회 |
 | GET | `/admin/events/export-jobs/{jobId}/download` | ADMIN | 완료된 비동기 CSV 다운로드 |
+| GET | `/admin/events/export-jobs/metrics` | ADMIN | 비동기 export 운영 지표(실패율/처리시간/정리량) 조회 |
 
 ### 7.8 사용자 개인 (`MeController`)
 
@@ -293,7 +294,7 @@ com.eunhyehymn/
 
 ---
 
-## 8. Use Cases (28개)
+## 8. Use Cases (29개)
 
 | Use Case | 메서드 | 핵심 로직 |
 |----------|--------|-----------|
@@ -321,6 +322,7 @@ com.eunhyehymn/
 | `AdminListEventsUseCase` | `execute(query)` | 관리자 이벤트 로그 조회 + 이벤트 타입 집계 |
 | `AdminEventExportJobUseCase` | `create/get/process/getDownload` | 관리자 비동기 대용량 CSV 작업 생성/상태/처리/다운로드 |
 | `CleanupEventExportJobsUseCase` | `cleanup(now)` | 완료/실패 비동기 export 작업 보관기한 정리 |
+| `GetEventExportOpsMetricsUseCase` | `execute(windowDays)` | 비동기 export 운영 지표(실패율/처리시간/정리량) 집계 |
 | `AdminCreateInviteCodeUseCase` | `create(code, createdBy, ...)` | 초대코드 생성 (중복 검사) |
 | `AdminListInviteCodesUseCase` | `listAll()` | 전체 초대코드 목록 |
 | `AdminRevokeInviteCodeUseCase` | `revoke(code)` | 초대코드 비활성화 (enabled=false) |
@@ -342,6 +344,7 @@ com.eunhyehymn/
 | `V6__invite_codes.sql` | invite_codes 테이블 생성 (code PK, created_by FK, max_uses, used_count, enabled, expires_at) |
 | `V7__events_admin_indexes.sql` | 관리자 이벤트 조회/CSV 최적화 인덱스 3개 추가 |
 | `V8__event_export_jobs.sql` | 비동기 대용량 CSV 작업 테이블(event_export_jobs) 추가 |
+| `V9__event_export_job_cleanup_runs.sql` | 비동기 export 정리 실행 이력 테이블(event_export_job_cleanup_runs) 추가 |
 
 ### 주요 인덱스
 - `idx_refresh_tokens_user_id` ON refresh_tokens(user_id)
@@ -409,12 +412,13 @@ com.eunhyehymn/
 | `GetHistoryUseCaseTest` | 히스토리 Use Case 단위 |
 | `CleanupEventExportJobsUseCaseTest` | 비동기 export 정리 Use Case 단위 |
 | `CleanupEventExportJobsUseCaseIntegrationTest` | 비동기 export 정리 정책 통합 |
+| `GetEventExportOpsMetricsUseCaseTest` | 비동기 export 운영 지표 Use Case 단위 |
 | `AdminUserApiTest` | 사용자 관리 API (목록, 역할/상태 변경, 권한 검사) |
 | `AdminEventApiTest` | 관리자 이벤트 API (로그 조회, 집계, 페이지네이션, 동기/비동기 CSV export, 접근 제어 검증) |
 | `AdminInviteCodeApiTest` | 초대코드 관리 API (생성, 목록, 비활성화, 검증) |
 
 - **테스트 DB**: H2 인메모리 (test 프로필)
-- **전체 테스트 통과** 확인 (2026-02-13 기준)
+- **전체 테스트 통과** 확인 (2026-02-14 기준)
 
 ---
 
@@ -658,7 +662,7 @@ develop push → GitHub Actions
 
 ### 완료
 
-**백엔드 API (28 UseCase, 11 Controller)**
+**백엔드 API (29 UseCase, 11 Controller)**
 - 찬양 CRUD + 삭제 (cascade: 에셋/메모/상태/이벤트)
 - S3 에셋 관리 (presign/confirm/삭제)
 - JWT 인증 + 소셜 로그인 (Google/Kakao) + 토큰 회전
@@ -666,15 +670,16 @@ develop push → GitHub Actions
 - 사용자 관리 (역할/상태 변경)
 - 멤버 기능 (즐겨찾기, 메모, 히스토리, 이벤트 기록)
 - 비동기 export 결과 정리 배치 (완료/실패 작업 기본 7일 보관 후 정리)
-- DB 스키마 Flyway 마이그레이션 (V1~V8)
-- 테스트 14개 파일 전체 통과 (SocialLoginApiTest 포함)
+- 비동기 export 운영 지표 API (`/admin/events/export-jobs/metrics`) + cleanup 실행 이력 기록
+- DB 스키마 Flyway 마이그레이션 (V1~V9)
+- 테스트 15개 파일 전체 통과 (SocialLoginApiTest 포함)
 
 **Admin 프론트엔드 (8페이지)**
 - 찬양 목록/생성/수정/삭제 + 검색/필터 + 활성화 토글
 - 에셋 업로드 3단계 (presign/upload/confirm) + 삭제
 - 사용자 관리 (역할/상태 변경, 검색/필터)
 - 초대코드 관리 (생성/비활성화/만료일 설정)
-- 감사 로그/분석 화면 (`GET /admin/events`) - 필터/페이지네이션 조회 + 집계 기간(1~90일) 커스텀 + 동기 CSV 내보내기 + 비동기 대용량 CSV 작업/다운로드
+- 감사 로그/분석 화면 (`GET /admin/events`) - 필터/페이지네이션 조회 + 집계 기간(1~90일) 커스텀 + 동기 CSV 내보내기 + 비동기 대용량 CSV 작업/다운로드 + 운영 지표 카드(실패율/처리시간/정리량)
 - 소셜 로그인 UI (Google/Kakao) + 초대코드 입력 플로우
 - Access Token 자동 갱신 (401 → refresh → 재시도, mutex 패턴)
 - 인증 컨텍스트 (`loginWithSocial`, `setTokensAndUser`), 공통 API 클라이언트, 사이드바 레이아웃
@@ -753,7 +758,8 @@ develop push → GitHub Actions
 - 배포 후 스모크 테스트 항목과 점검 결과를 `docs/staging-rehearsal-log.md`에 주기적으로 갱신
 
 **3. 기능 백로그**
-- 비동기 export 운영 지표(실패율/처리시간/정리량) 정례화
+- 비동기 export 운영 지표(실패율/처리시간/정리량) 정례화 완료 (2026-02-14)
+- 후속: 지표 임계치 기반 알림/대시보드 연동 설계
 
 **4. 모바일 배포 패키징**
 - 현재 저장소 기준 실행은 `flutter run -d chrome` 중심

--- a/apps/admin/src/api/adminEvents.ts
+++ b/apps/admin/src/api/adminEvents.ts
@@ -98,6 +98,29 @@ export interface AdminEventExportJob {
   downloadable: boolean;
 }
 
+export interface AdminEventExportOpsMetrics {
+  windowDays: number;
+  fromInclusive: string;
+  toExclusive: string;
+  jobs: {
+    total: number;
+    queued: number;
+    running: number;
+    completed: number;
+    failed: number;
+    failureRatePercent: number;
+  };
+  processing: {
+    measuredJobs: number;
+    averageSeconds: number;
+    p95Seconds: number;
+  };
+  cleanup: {
+    runCount: number;
+    deletedJobs: number;
+  };
+}
+
 export interface CreateAdminEventExportJobParams {
   eventType?: EventType;
   userId?: string;
@@ -155,6 +178,16 @@ export function createAdminEventExportJob(
 
 export function getAdminEventExportJob(jobId: string): Promise<AdminEventExportJob> {
   return apiGet<AdminEventExportJob>(`/admin/events/export-jobs/${jobId}`);
+}
+
+export function getAdminEventExportOpsMetrics(days?: number): Promise<AdminEventExportOpsMetrics> {
+  const query = new URLSearchParams();
+  if (days != null) {
+    query.set("days", String(days));
+  }
+  const suffix = query.toString();
+  const path = suffix ? `/admin/events/export-jobs/metrics?${suffix}` : "/admin/events/export-jobs/metrics";
+  return apiGet<AdminEventExportOpsMetrics>(path);
 }
 
 export async function downloadAdminEventExportJobCsv(jobId: string): Promise<ExportAdminEventsCsvResult> {

--- a/apps/admin/src/pages/AdminEventPage.tsx
+++ b/apps/admin/src/pages/AdminEventPage.tsx
@@ -21,8 +21,7 @@ const EVENT_TYPE_OPTIONS: Array<{ label: string; value: "all" | EventType }> = [
   { label: "즐겨찾기", value: "FAVORITE_TOGGLED" },
 ];
 
-const SUMMARY_DAY_PRESETS = [1, 7, 30, 60, 90];
-const OPS_METRIC_DAY_PRESETS = [1, 7, 30, 60, 90];
+const DAY_PRESETS = [1, 7, 30, 60, 90];
 const MIN_SUMMARY_DAYS = 1;
 const MAX_SUMMARY_DAYS = 90;
 const SIZE_OPTIONS = [20, 50, 100, 200];
@@ -273,7 +272,7 @@ export default function AdminEventPage() {
             )}
           </div>
           <div className="flex flex-wrap gap-2">
-            {OPS_METRIC_DAY_PRESETS.map((days) => (
+            {DAY_PRESETS.map((days) => (
               <button
                 key={days}
                 type="button"
@@ -401,7 +400,7 @@ export default function AdminEventPage() {
         </div>
         <div className="mt-3 flex flex-wrap items-center gap-2">
           <span className="text-xs text-gray-500">집계 기간 프리셋</span>
-          {SUMMARY_DAY_PRESETS.map((days) => (
+          {DAY_PRESETS.map((days) => (
             <button
               key={days}
               type="button"

--- a/apps/admin/src/pages/AdminEventPage.tsx
+++ b/apps/admin/src/pages/AdminEventPage.tsx
@@ -3,8 +3,10 @@ import {
   createAdminEventExportJob,
   downloadAdminEventExportJobCsv,
   exportAdminEventsCsv,
+  getAdminEventExportOpsMetrics,
   getAdminEventExportJob,
   type AdminEventExportJob,
+  type AdminEventExportOpsMetrics,
   listAdminEvents,
   type AdminEventItem,
   type AdminEventSummary,
@@ -20,6 +22,7 @@ const EVENT_TYPE_OPTIONS: Array<{ label: string; value: "all" | EventType }> = [
 ];
 
 const SUMMARY_DAY_PRESETS = [1, 7, 30, 60, 90];
+const OPS_METRIC_DAY_PRESETS = [1, 7, 30, 60, 90];
 const MIN_SUMMARY_DAYS = 1;
 const MAX_SUMMARY_DAYS = 90;
 const SIZE_OPTIONS = [20, 50, 100, 200];
@@ -56,6 +59,10 @@ function clampSummaryDays(days: number): number {
   return Math.min(Math.max(days, MIN_SUMMARY_DAYS), MAX_SUMMARY_DAYS);
 }
 
+function formatSeconds(value: number): string {
+  return `${value.toLocaleString("ko-KR", { maximumFractionDigits: 2 })}s`;
+}
+
 function formatAsyncJobStatus(status: AdminEventExportJob["status"]): string {
   if (status === "QUEUED") {
     return "대기 중";
@@ -76,6 +83,7 @@ export default function AdminEventPage() {
   const [fromLocal, setFromLocal] = useState("");
   const [toLocal, setToLocal] = useState("");
   const [summaryDays, setSummaryDays] = useState(7);
+  const [opsMetricsDays, setOpsMetricsDays] = useState(7);
   const [size, setSize] = useState(50);
   const [page, setPage] = useState(1);
 
@@ -94,6 +102,8 @@ export default function AdminEventPage() {
   const [creatingAsyncJob, setCreatingAsyncJob] = useState(false);
   const [downloadingAsyncJob, setDownloadingAsyncJob] = useState(false);
   const [asyncJob, setAsyncJob] = useState<AdminEventExportJob | null>(null);
+  const [opsMetrics, setOpsMetrics] = useState<AdminEventExportOpsMetrics | null>(null);
+  const [opsMetricsLoading, setOpsMetricsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const isSummaryWindowFromDateFilter = Boolean(fromLocal || toLocal);
 
@@ -128,10 +138,27 @@ export default function AdminEventPage() {
     }
   };
 
+  const fetchOpsMetrics = async (days: number) => {
+    setOpsMetricsLoading(true);
+    try {
+      const data = await getAdminEventExportOpsMetrics(days);
+      setOpsMetrics(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "운영 지표를 불러오지 못했습니다.");
+    } finally {
+      setOpsMetricsLoading(false);
+    }
+  };
+
   useEffect(() => {
     void fetchEvents(page);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page]);
+
+  useEffect(() => {
+    void fetchOpsMetrics(opsMetricsDays);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [opsMetricsDays]);
 
   useEffect(() => {
     if (!asyncJob || (asyncJob.status !== "QUEUED" && asyncJob.status !== "RUNNING")) {
@@ -234,6 +261,73 @@ export default function AdminEventPage() {
   return (
     <div>
       <h1 className="text-2xl font-bold mb-6">감사 로그/분석</h1>
+
+      <div className="bg-white rounded-lg shadow p-4 mb-4 border border-indigo-100">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-base font-semibold text-gray-900">Async Export Ops Metrics</h2>
+            {opsMetrics && (
+              <p className="text-xs text-gray-500 mt-1">
+                {formatDateTime(opsMetrics.fromInclusive)} ~ {formatDateTime(opsMetrics.toExclusive)}
+              </p>
+            )}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {OPS_METRIC_DAY_PRESETS.map((days) => (
+              <button
+                key={days}
+                type="button"
+                onClick={() => setOpsMetricsDays(days)}
+                className={`px-2 py-1 text-xs rounded border ${
+                  opsMetricsDays === days
+                    ? "bg-indigo-600 text-white border-indigo-600"
+                    : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+                }`}
+              >
+                {`${days}d`}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {opsMetricsLoading && <p className="text-sm text-gray-500 mt-3">Loading metrics...</p>}
+
+        {!opsMetricsLoading && opsMetrics && (
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-3 mt-3">
+            <div className="rounded border border-gray-200 px-3 py-2">
+              <p className="text-xs text-gray-500">Total Jobs</p>
+              <p className="text-xl font-semibold text-gray-900">{opsMetrics.jobs.total.toLocaleString("ko-KR")}</p>
+              <p className="text-xs text-gray-500 mt-1">
+                completed {opsMetrics.jobs.completed.toLocaleString("ko-KR")} / failed{" "}
+                {opsMetrics.jobs.failed.toLocaleString("ko-KR")}
+              </p>
+            </div>
+            <div className="rounded border border-gray-200 px-3 py-2">
+              <p className="text-xs text-gray-500">Failure Rate</p>
+              <p className="text-xl font-semibold text-rose-600">{opsMetrics.jobs.failureRatePercent.toFixed(2)}%</p>
+              <p className="text-xs text-gray-500 mt-1">
+                queued {opsMetrics.jobs.queued.toLocaleString("ko-KR")} / running{" "}
+                {opsMetrics.jobs.running.toLocaleString("ko-KR")}
+              </p>
+            </div>
+            <div className="rounded border border-gray-200 px-3 py-2">
+              <p className="text-xs text-gray-500">Processing Time</p>
+              <p className="text-xl font-semibold text-gray-900">{formatSeconds(opsMetrics.processing.averageSeconds)}</p>
+              <p className="text-xs text-gray-500 mt-1">
+                p95 {formatSeconds(opsMetrics.processing.p95Seconds)} / sample{" "}
+                {opsMetrics.processing.measuredJobs.toLocaleString("ko-KR")}
+              </p>
+            </div>
+            <div className="rounded border border-gray-200 px-3 py-2">
+              <p className="text-xs text-gray-500">Cleanup Volume</p>
+              <p className="text-xl font-semibold text-emerald-700">
+                {opsMetrics.cleanup.deletedJobs.toLocaleString("ko-KR")}
+              </p>
+              <p className="text-xs text-gray-500 mt-1">runs {opsMetrics.cleanup.runCount.toLocaleString("ko-KR")}</p>
+            </div>
+          </div>
+        )}
+      </div>
 
       <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow p-4 mb-4">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3">

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/GetEventExportOpsMetricsUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/GetEventExportOpsMetricsUseCase.java
@@ -1,0 +1,141 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.domain.model.EventExportJobStatus;
+import com.eunhyehymn.domain.repository.EventExportJobCleanupRunRepository;
+import com.eunhyehymn.domain.repository.EventExportJobRepository;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class GetEventExportOpsMetricsUseCase {
+    private static final int DEFAULT_WINDOW_DAYS = 7;
+    private static final int MIN_WINDOW_DAYS = 1;
+    private static final int MAX_WINDOW_DAYS = 90;
+
+    private final EventExportJobRepository eventExportJobRepository;
+    private final EventExportJobCleanupRunRepository cleanupRunRepository;
+
+    public GetEventExportOpsMetricsUseCase(
+        EventExportJobRepository eventExportJobRepository,
+        EventExportJobCleanupRunRepository cleanupRunRepository
+    ) {
+        this.eventExportJobRepository = eventExportJobRepository;
+        this.cleanupRunRepository = cleanupRunRepository;
+    }
+
+    public Result execute(Integer windowDays) {
+        return execute(windowDays, Instant.now());
+    }
+
+    Result execute(Integer windowDays, Instant now) {
+        int normalizedWindowDays = normalizeWindowDays(windowDays);
+        Instant toExclusive = now;
+        Instant fromInclusive = toExclusive.minus(normalizedWindowDays, ChronoUnit.DAYS);
+
+        List<EventExportJobRepository.MetricsRow> rows = eventExportJobRepository.findMetricsRows(fromInclusive, toExclusive);
+        JobMetrics jobMetrics = summarizeJobs(rows);
+        ProcessingMetrics processingMetrics = summarizeProcessing(rows);
+        EventExportJobCleanupRunRepository.Summary cleanupSummary = cleanupRunRepository.summarize(fromInclusive, toExclusive);
+
+        return new Result(
+            normalizedWindowDays,
+            fromInclusive,
+            toExclusive,
+            jobMetrics,
+            processingMetrics,
+            new CleanupMetrics(cleanupSummary.runCount(), cleanupSummary.deletedJobCount())
+        );
+    }
+
+    private int normalizeWindowDays(Integer windowDays) {
+        if (windowDays == null) {
+            return DEFAULT_WINDOW_DAYS;
+        }
+        if (windowDays < MIN_WINDOW_DAYS) {
+            return MIN_WINDOW_DAYS;
+        }
+        return Math.min(windowDays, MAX_WINDOW_DAYS);
+    }
+
+    private JobMetrics summarizeJobs(List<EventExportJobRepository.MetricsRow> rows) {
+        long queued = rows.stream().filter(row -> row.status() == EventExportJobStatus.QUEUED).count();
+        long running = rows.stream().filter(row -> row.status() == EventExportJobStatus.RUNNING).count();
+        long completed = rows.stream().filter(row -> row.status() == EventExportJobStatus.COMPLETED).count();
+        long failed = rows.stream().filter(row -> row.status() == EventExportJobStatus.FAILED).count();
+        long finished = completed + failed;
+        double failureRatePercent = finished == 0 ? 0.0 : roundTo2((failed * 100.0) / finished);
+
+        return new JobMetrics(rows.size(), queued, running, completed, failed, failureRatePercent);
+    }
+
+    private ProcessingMetrics summarizeProcessing(List<EventExportJobRepository.MetricsRow> rows) {
+        List<Double> durationsSeconds = new ArrayList<>();
+        for (EventExportJobRepository.MetricsRow row : rows) {
+            if (row.startedAt() == null || row.completedAt() == null) {
+                continue;
+            }
+            long seconds = Duration.between(row.startedAt(), row.completedAt()).toSeconds();
+            if (seconds < 0) {
+                continue;
+            }
+            durationsSeconds.add((double) seconds);
+        }
+
+        if (durationsSeconds.isEmpty()) {
+            return new ProcessingMetrics(0, 0.0, 0.0);
+        }
+
+        double sumSeconds = durationsSeconds.stream().mapToDouble(Double::doubleValue).sum();
+        double averageSeconds = roundTo2(sumSeconds / durationsSeconds.size());
+        double p95Seconds = roundTo2(percentile(durationsSeconds, 0.95));
+
+        return new ProcessingMetrics(durationsSeconds.size(), averageSeconds, p95Seconds);
+    }
+
+    private double percentile(List<Double> values, double percentile) {
+        List<Double> sorted = values.stream().sorted(Comparator.naturalOrder()).toList();
+        int rank = (int) Math.ceil(percentile * sorted.size());
+        int index = Math.max(rank - 1, 0);
+        return sorted.get(index);
+    }
+
+    private double roundTo2(double value) {
+        return Math.round(value * 100.0) / 100.0;
+    }
+
+    public record Result(
+        int windowDays,
+        Instant fromInclusive,
+        Instant toExclusive,
+        JobMetrics jobs,
+        ProcessingMetrics processing,
+        CleanupMetrics cleanup
+    ) {
+    }
+
+    public record JobMetrics(
+        long total,
+        long queued,
+        long running,
+        long completed,
+        long failed,
+        double failureRatePercent
+    ) {
+    }
+
+    public record ProcessingMetrics(
+        int measuredJobs,
+        double averageSeconds,
+        double p95Seconds
+    ) {
+    }
+
+    public record CleanupMetrics(
+        long runCount,
+        long deletedJobs
+    ) {
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/GetEventExportOpsMetricsUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/GetEventExportOpsMetricsUseCase.java
@@ -7,7 +7,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 public class GetEventExportOpsMetricsUseCase {
@@ -61,10 +60,22 @@ public class GetEventExportOpsMetricsUseCase {
     }
 
     private JobMetrics summarizeJobs(List<EventExportJobRepository.MetricsRow> rows) {
-        long queued = rows.stream().filter(row -> row.status() == EventExportJobStatus.QUEUED).count();
-        long running = rows.stream().filter(row -> row.status() == EventExportJobStatus.RUNNING).count();
-        long completed = rows.stream().filter(row -> row.status() == EventExportJobStatus.COMPLETED).count();
-        long failed = rows.stream().filter(row -> row.status() == EventExportJobStatus.FAILED).count();
+        long queued = 0;
+        long running = 0;
+        long completed = 0;
+        long failed = 0;
+        for (EventExportJobRepository.MetricsRow row : rows) {
+            EventExportJobStatus status = row.status();
+            if (status == EventExportJobStatus.QUEUED) {
+                queued += 1;
+            } else if (status == EventExportJobStatus.RUNNING) {
+                running += 1;
+            } else if (status == EventExportJobStatus.COMPLETED) {
+                completed += 1;
+            } else if (status == EventExportJobStatus.FAILED) {
+                failed += 1;
+            }
+        }
         long finished = completed + failed;
         double failureRatePercent = finished == 0 ? 0.0 : roundTo2((failed * 100.0) / finished);
 
@@ -72,7 +83,7 @@ public class GetEventExportOpsMetricsUseCase {
     }
 
     private ProcessingMetrics summarizeProcessing(List<EventExportJobRepository.MetricsRow> rows) {
-        List<Double> durationsSeconds = new ArrayList<>();
+        List<Long> durationsSeconds = new ArrayList<>();
         for (EventExportJobRepository.MetricsRow row : rows) {
             if (row.startedAt() == null || row.completedAt() == null) {
                 continue;
@@ -81,25 +92,25 @@ public class GetEventExportOpsMetricsUseCase {
             if (seconds < 0) {
                 continue;
             }
-            durationsSeconds.add((double) seconds);
+            durationsSeconds.add(seconds);
         }
 
         if (durationsSeconds.isEmpty()) {
             return new ProcessingMetrics(0, 0.0, 0.0);
         }
 
-        double sumSeconds = durationsSeconds.stream().mapToDouble(Double::doubleValue).sum();
+        durationsSeconds.sort(Long::compareTo);
+        double sumSeconds = durationsSeconds.stream().mapToLong(Long::longValue).sum();
         double averageSeconds = roundTo2(sumSeconds / durationsSeconds.size());
         double p95Seconds = roundTo2(percentile(durationsSeconds, 0.95));
 
         return new ProcessingMetrics(durationsSeconds.size(), averageSeconds, p95Seconds);
     }
 
-    private double percentile(List<Double> values, double percentile) {
-        List<Double> sorted = values.stream().sorted(Comparator.naturalOrder()).toList();
-        int rank = (int) Math.ceil(percentile * sorted.size());
+    private double percentile(List<Long> sortedValues, double percentile) {
+        int rank = (int) Math.ceil(percentile * sortedValues.size());
         int index = Math.max(rank - 1, 0);
-        return sorted.get(index);
+        return sortedValues.get(index);
     }
 
     private double roundTo2(double value) {

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/UseCaseConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/UseCaseConfig.java
@@ -9,6 +9,7 @@ import com.eunhyehymn.application.usecases.AdminListUsersUseCase;
 import com.eunhyehymn.application.usecases.AdminUpdateHymnUseCase;
 import com.eunhyehymn.application.usecases.AdminUpdateUserUseCase;
 import com.eunhyehymn.application.usecases.CleanupEventExportJobsUseCase;
+import com.eunhyehymn.application.usecases.GetEventExportOpsMetricsUseCase;
 import com.eunhyehymn.application.usecases.GetFavoriteUseCase;
 import com.eunhyehymn.application.usecases.GetHistoryUseCase;
 import com.eunhyehymn.application.usecases.GetHymnDetailUseCase;
@@ -18,6 +19,7 @@ import com.eunhyehymn.application.usecases.RecordEventsUseCase;
 import com.eunhyehymn.application.usecases.SaveHymnNoteUseCase;
 import com.eunhyehymn.application.usecases.ToggleFavoriteUseCase;
 import com.eunhyehymn.domain.repository.AssetRepository;
+import com.eunhyehymn.domain.repository.EventExportJobCleanupRunRepository;
 import com.eunhyehymn.domain.repository.EventExportJobRepository;
 import com.eunhyehymn.domain.repository.EventRepository;
 import com.eunhyehymn.domain.repository.HymnNoteRepository;
@@ -114,6 +116,14 @@ public class UseCaseConfig {
         @Value("${events.export.jobs.retention-days:7}") int retentionDays
     ) {
         return new CleanupEventExportJobsUseCase(eventExportJobRepository, retentionDays);
+    }
+
+    @Bean
+    GetEventExportOpsMetricsUseCase getEventExportOpsMetricsUseCase(
+        EventExportJobRepository eventExportJobRepository,
+        EventExportJobCleanupRunRepository eventExportJobCleanupRunRepository
+    ) {
+        return new GetEventExportOpsMetricsUseCase(eventExportJobRepository, eventExportJobCleanupRunRepository);
     }
 
     @Bean

--- a/apps/api/src/main/java/com/eunhyehymn/domain/model/EventExportJobCleanupRun.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/model/EventExportJobCleanupRun.java
@@ -1,0 +1,12 @@
+package com.eunhyehymn.domain.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record EventExportJobCleanupRun(
+    UUID id,
+    Instant executedAt,
+    int retentionDays,
+    long deletedCount
+) {
+}

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/EventExportJobCleanupRunRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/EventExportJobCleanupRunRepository.java
@@ -1,0 +1,16 @@
+package com.eunhyehymn.domain.repository;
+
+import com.eunhyehymn.domain.model.EventExportJobCleanupRun;
+import java.time.Instant;
+
+public interface EventExportJobCleanupRunRepository {
+    EventExportJobCleanupRun save(EventExportJobCleanupRun run);
+
+    Summary summarize(Instant fromInclusive, Instant toExclusive);
+
+    record Summary(
+        long runCount,
+        long deletedJobCount
+    ) {
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/EventExportJobRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/EventExportJobRepository.java
@@ -1,7 +1,9 @@
 package com.eunhyehymn.domain.repository;
 
 import com.eunhyehymn.domain.model.EventExportJob;
+import com.eunhyehymn.domain.model.EventExportJobStatus;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -10,5 +12,14 @@ public interface EventExportJobRepository {
 
     Optional<EventExportJob> findById(UUID id);
 
+    List<MetricsRow> findMetricsRows(Instant fromInclusive, Instant toExclusive);
+
     long deleteCompletedOrFailedBefore(Instant completedBeforeExclusive);
+
+    record MetricsRow(
+        EventExportJobStatus status,
+        Instant startedAt,
+        Instant completedAt
+    ) {
+    }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobCleanupRunEntity.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobCleanupRunEntity.java
@@ -1,0 +1,56 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "event_export_job_cleanup_runs")
+public class EventExportJobCleanupRunEntity {
+    @Id
+    @Column(nullable = false)
+    private UUID id;
+
+    @Column(name = "executed_at", nullable = false)
+    private Instant executedAt;
+
+    @Column(name = "retention_days", nullable = false)
+    private int retentionDays;
+
+    @Column(name = "deleted_count", nullable = false)
+    private long deletedCount;
+
+    protected EventExportJobCleanupRunEntity() {
+    }
+
+    public EventExportJobCleanupRunEntity(
+        UUID id,
+        Instant executedAt,
+        int retentionDays,
+        long deletedCount
+    ) {
+        this.id = id;
+        this.executedAt = executedAt;
+        this.retentionDays = retentionDays;
+        this.deletedCount = deletedCount;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public Instant getExecutedAt() {
+        return executedAt;
+    }
+
+    public int getRetentionDays() {
+        return retentionDays;
+    }
+
+    public long getDeletedCount() {
+        return deletedCount;
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobCleanupRunJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobCleanupRunJpaRepository.java
@@ -1,0 +1,26 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface EventExportJobCleanupRunJpaRepository extends JpaRepository<EventExportJobCleanupRunEntity, UUID> {
+    @Query("""
+        SELECT COUNT(r) AS runCount, COALESCE(SUM(r.deletedCount), 0) AS deletedCount
+        FROM EventExportJobCleanupRunEntity r
+        WHERE r.executedAt >= :fromInclusive
+          AND r.executedAt < :toExclusive
+        """)
+    SummaryProjection summarize(
+        @Param("fromInclusive") Instant fromInclusive,
+        @Param("toExclusive") Instant toExclusive
+    );
+
+    interface SummaryProjection {
+        long getRunCount();
+
+        long getDeletedCount();
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobCleanupRunRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobCleanupRunRepositoryAdapter.java
@@ -1,0 +1,31 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import com.eunhyehymn.domain.model.EventExportJobCleanupRun;
+import com.eunhyehymn.domain.repository.EventExportJobCleanupRunRepository;
+import com.eunhyehymn.infrastructure.persistence.mapper.EventExportJobCleanupRunMapper;
+import java.time.Instant;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class EventExportJobCleanupRunRepositoryAdapter implements EventExportJobCleanupRunRepository {
+    private final EventExportJobCleanupRunJpaRepository jpaRepository;
+
+    public EventExportJobCleanupRunRepositoryAdapter(EventExportJobCleanupRunJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public EventExportJobCleanupRun save(EventExportJobCleanupRun run) {
+        EventExportJobCleanupRunEntity saved = jpaRepository.save(EventExportJobCleanupRunMapper.toEntity(run));
+        return EventExportJobCleanupRunMapper.toDomain(saved);
+    }
+
+    @Override
+    public Summary summarize(Instant fromInclusive, Instant toExclusive) {
+        EventExportJobCleanupRunJpaRepository.SummaryProjection projection = jpaRepository.summarize(fromInclusive, toExclusive);
+        if (projection == null) {
+            return new Summary(0, 0);
+        }
+        return new Summary(projection.getRunCount(), projection.getDeletedCount());
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobJpaRepository.java
@@ -3,11 +3,33 @@ package com.eunhyehymn.infrastructure.persistence;
 import com.eunhyehymn.domain.model.EventExportJobStatus;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface EventExportJobJpaRepository extends JpaRepository<EventExportJobEntity, UUID> {
+    @Query("""
+        SELECT e.status AS status, e.startedAt AS startedAt, e.completedAt AS completedAt
+        FROM EventExportJobEntity e
+        WHERE e.createdAt >= :fromInclusive
+          AND e.createdAt < :toExclusive
+        """)
+    List<MetricsRowProjection> findMetricsRows(
+        @Param("fromInclusive") Instant fromInclusive,
+        @Param("toExclusive") Instant toExclusive
+    );
+
     @Transactional
     long deleteByStatusInAndCompletedAtBefore(Collection<EventExportJobStatus> statuses, Instant completedBeforeExclusive);
+
+    interface MetricsRowProjection {
+        EventExportJobStatus getStatus();
+
+        Instant getStartedAt();
+
+        Instant getCompletedAt();
+    }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobRepositoryAdapter.java
@@ -30,6 +30,13 @@ public class EventExportJobRepositoryAdapter implements EventExportJobRepository
     }
 
     @Override
+    public List<MetricsRow> findMetricsRows(Instant fromInclusive, Instant toExclusive) {
+        return jpaRepository.findMetricsRows(fromInclusive, toExclusive).stream()
+            .map(row -> new MetricsRow(row.getStatus(), row.getStartedAt(), row.getCompletedAt()))
+            .toList();
+    }
+
+    @Override
     public long deleteCompletedOrFailedBefore(Instant completedBeforeExclusive) {
         return jpaRepository.deleteByStatusInAndCompletedAtBefore(
             List.of(EventExportJobStatus.COMPLETED, EventExportJobStatus.FAILED),

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/mapper/EventExportJobCleanupRunMapper.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/mapper/EventExportJobCleanupRunMapper.java
@@ -1,0 +1,27 @@
+package com.eunhyehymn.infrastructure.persistence.mapper;
+
+import com.eunhyehymn.domain.model.EventExportJobCleanupRun;
+import com.eunhyehymn.infrastructure.persistence.EventExportJobCleanupRunEntity;
+
+public final class EventExportJobCleanupRunMapper {
+    private EventExportJobCleanupRunMapper() {
+    }
+
+    public static EventExportJobCleanupRun toDomain(EventExportJobCleanupRunEntity entity) {
+        return new EventExportJobCleanupRun(
+            entity.getId(),
+            entity.getExecutedAt(),
+            entity.getRetentionDays(),
+            entity.getDeletedCount()
+        );
+    }
+
+    public static EventExportJobCleanupRunEntity toEntity(EventExportJobCleanupRun run) {
+        return new EventExportJobCleanupRunEntity(
+            run.id(),
+            run.executedAt(),
+            run.retentionDays(),
+            run.deletedCount()
+        );
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/scheduling/EventExportJobCleanupScheduler.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/scheduling/EventExportJobCleanupScheduler.java
@@ -1,7 +1,10 @@
 package com.eunhyehymn.infrastructure.scheduling;
 
 import com.eunhyehymn.application.usecases.CleanupEventExportJobsUseCase;
+import com.eunhyehymn.domain.model.EventExportJobCleanupRun;
+import com.eunhyehymn.domain.repository.EventExportJobCleanupRunRepository;
 import java.time.Instant;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -12,9 +15,14 @@ public class EventExportJobCleanupScheduler {
     private static final Logger logger = LoggerFactory.getLogger(EventExportJobCleanupScheduler.class);
 
     private final CleanupEventExportJobsUseCase cleanupEventExportJobsUseCase;
+    private final EventExportJobCleanupRunRepository cleanupRunRepository;
 
-    public EventExportJobCleanupScheduler(CleanupEventExportJobsUseCase cleanupEventExportJobsUseCase) {
+    public EventExportJobCleanupScheduler(
+        CleanupEventExportJobsUseCase cleanupEventExportJobsUseCase,
+        EventExportJobCleanupRunRepository cleanupRunRepository
+    ) {
         this.cleanupEventExportJobsUseCase = cleanupEventExportJobsUseCase;
+        this.cleanupRunRepository = cleanupRunRepository;
     }
 
     @Scheduled(
@@ -22,7 +30,14 @@ public class EventExportJobCleanupScheduler {
         zone = "${events.export.jobs.cleanup-zone:UTC}"
     )
     public void cleanupFinishedJobs() {
-        CleanupEventExportJobsUseCase.Result result = cleanupEventExportJobsUseCase.cleanup(Instant.now());
+        Instant executedAt = Instant.now();
+        CleanupEventExportJobsUseCase.Result result = cleanupEventExportJobsUseCase.cleanup(executedAt);
+        cleanupRunRepository.save(new EventExportJobCleanupRun(
+            UUID.randomUUID(),
+            executedAt,
+            result.retentionDays(),
+            result.deletedCount()
+        ));
         logger.info(
             "event-export cleanup completed: deleted={}, retentionDays={}, completedBeforeExclusive={}",
             result.deletedCount(),

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminEventController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminEventController.java
@@ -2,6 +2,7 @@ package com.eunhyehymn.presentation.controllers;
 
 import com.eunhyehymn.application.usecases.AdminEventExportJobUseCase;
 import com.eunhyehymn.application.usecases.AdminListEventsUseCase;
+import com.eunhyehymn.application.usecases.GetEventExportOpsMetricsUseCase;
 import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.common.response.ApiResponse;
 import com.eunhyehymn.domain.model.Event;
@@ -36,15 +37,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminEventController {
     private final AdminListEventsUseCase adminListEventsUseCase;
     private final AdminEventExportJobUseCase adminEventExportJobUseCase;
+    private final GetEventExportOpsMetricsUseCase getEventExportOpsMetricsUseCase;
     private final TaskExecutor eventExportTaskExecutor;
 
     public AdminEventController(
         AdminListEventsUseCase adminListEventsUseCase,
         AdminEventExportJobUseCase adminEventExportJobUseCase,
+        GetEventExportOpsMetricsUseCase getEventExportOpsMetricsUseCase,
         @Qualifier("eventExportTaskExecutor") TaskExecutor eventExportTaskExecutor
     ) {
         this.adminListEventsUseCase = adminListEventsUseCase;
         this.adminEventExportJobUseCase = adminEventExportJobUseCase;
+        this.getEventExportOpsMetricsUseCase = getEventExportOpsMetricsUseCase;
         this.eventExportTaskExecutor = eventExportTaskExecutor;
     }
 
@@ -152,6 +156,14 @@ public class AdminEventController {
         return new ResponseEntity<>(result.csvContent(), headers, HttpStatus.OK);
     }
 
+    @GetMapping("/export-jobs/metrics")
+    public ApiResponse<EventExportJobOpsMetricsResponse> getExportJobOpsMetrics(
+        @RequestParam(required = false) Integer days
+    ) {
+        GetEventExportOpsMetricsUseCase.Result metrics = getEventExportOpsMetricsUseCase.execute(days);
+        return ApiResponse.success(toExportJobOpsMetricsResponse(metrics));
+    }
+
     @GetMapping("/export")
     public ResponseEntity<String> exportCsv(
         @RequestParam(required = false) String eventType,
@@ -199,6 +211,31 @@ public class AdminEventController {
             statusUrl,
             downloadUrl,
             job.status() == EventExportJobStatus.COMPLETED
+        );
+    }
+
+    private EventExportJobOpsMetricsResponse toExportJobOpsMetricsResponse(GetEventExportOpsMetricsUseCase.Result metrics) {
+        return new EventExportJobOpsMetricsResponse(
+            metrics.windowDays(),
+            metrics.fromInclusive(),
+            metrics.toExclusive(),
+            new EventExportJobOpsMetricsJobResponse(
+                metrics.jobs().total(),
+                metrics.jobs().queued(),
+                metrics.jobs().running(),
+                metrics.jobs().completed(),
+                metrics.jobs().failed(),
+                metrics.jobs().failureRatePercent()
+            ),
+            new EventExportJobOpsMetricsProcessingResponse(
+                metrics.processing().measuredJobs(),
+                metrics.processing().averageSeconds(),
+                metrics.processing().p95Seconds()
+            ),
+            new EventExportJobOpsMetricsCleanupResponse(
+                metrics.cleanup().runCount(),
+                metrics.cleanup().deletedJobs()
+            )
         );
     }
 
@@ -367,6 +404,39 @@ public class AdminEventController {
         String statusUrl,
         String downloadUrl,
         boolean downloadable
+    ) {
+    }
+
+    public record EventExportJobOpsMetricsResponse(
+        int windowDays,
+        Instant fromInclusive,
+        Instant toExclusive,
+        EventExportJobOpsMetricsJobResponse jobs,
+        EventExportJobOpsMetricsProcessingResponse processing,
+        EventExportJobOpsMetricsCleanupResponse cleanup
+    ) {
+    }
+
+    public record EventExportJobOpsMetricsJobResponse(
+        long total,
+        long queued,
+        long running,
+        long completed,
+        long failed,
+        double failureRatePercent
+    ) {
+    }
+
+    public record EventExportJobOpsMetricsProcessingResponse(
+        int measuredJobs,
+        double averageSeconds,
+        double p95Seconds
+    ) {
+    }
+
+    public record EventExportJobOpsMetricsCleanupResponse(
+        long runCount,
+        long deletedJobs
     ) {
     }
 

--- a/apps/api/src/main/resources/db/migration/V9__event_export_job_cleanup_runs.sql
+++ b/apps/api/src/main/resources/db/migration/V9__event_export_job_cleanup_runs.sql
@@ -1,0 +1,9 @@
+CREATE TABLE event_export_job_cleanup_runs (
+    id UUID PRIMARY KEY,
+    executed_at TIMESTAMP NOT NULL,
+    retention_days INTEGER NOT NULL,
+    deleted_count BIGINT NOT NULL
+);
+
+CREATE INDEX idx_event_export_job_cleanup_runs_executed_at_desc
+    ON event_export_job_cleanup_runs(executed_at DESC);

--- a/apps/api/src/test/java/com/eunhyehymn/application/usecases/CleanupEventExportJobsUseCaseTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/application/usecases/CleanupEventExportJobsUseCaseTest.java
@@ -6,6 +6,7 @@ import com.eunhyehymn.domain.model.EventExportJob;
 import com.eunhyehymn.domain.repository.EventExportJobRepository;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -49,6 +50,11 @@ class CleanupEventExportJobsUseCaseTest {
         @Override
         public Optional<EventExportJob> findById(UUID id) {
             return Optional.empty();
+        }
+
+        @Override
+        public List<MetricsRow> findMetricsRows(Instant fromInclusive, Instant toExclusive) {
+            return List.of();
         }
 
         @Override

--- a/apps/api/src/test/java/com/eunhyehymn/application/usecases/GetEventExportOpsMetricsUseCaseTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/application/usecases/GetEventExportOpsMetricsUseCaseTest.java
@@ -1,0 +1,118 @@
+package com.eunhyehymn.application.usecases;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.eunhyehymn.domain.model.EventExportJob;
+import com.eunhyehymn.domain.model.EventExportJobCleanupRun;
+import com.eunhyehymn.domain.model.EventExportJobStatus;
+import com.eunhyehymn.domain.repository.EventExportJobCleanupRunRepository;
+import com.eunhyehymn.domain.repository.EventExportJobRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class GetEventExportOpsMetricsUseCaseTest {
+    @Test
+    void executeCalculatesFailureRateProcessingAndCleanupSummary() {
+        Instant now = Instant.parse("2026-02-14T12:00:00Z");
+        InMemoryEventExportJobRepository jobRepository = new InMemoryEventExportJobRepository();
+        InMemoryCleanupRunRepository cleanupRunRepository = new InMemoryCleanupRunRepository();
+
+        jobRepository.metricsRows = List.of(
+            new EventExportJobRepository.MetricsRow(
+                EventExportJobStatus.COMPLETED,
+                now.minus(20, ChronoUnit.MINUTES),
+                now.minus(20, ChronoUnit.MINUTES).plusSeconds(10)
+            ),
+            new EventExportJobRepository.MetricsRow(
+                EventExportJobStatus.FAILED,
+                now.minus(10, ChronoUnit.MINUTES),
+                now.minus(10, ChronoUnit.MINUTES).plusSeconds(30)
+            ),
+            new EventExportJobRepository.MetricsRow(EventExportJobStatus.RUNNING, now.minus(5, ChronoUnit.MINUTES), null),
+            new EventExportJobRepository.MetricsRow(EventExportJobStatus.QUEUED, null, null)
+        );
+        cleanupRunRepository.summary = new EventExportJobCleanupRunRepository.Summary(2, 9);
+
+        GetEventExportOpsMetricsUseCase useCase = new GetEventExportOpsMetricsUseCase(jobRepository, cleanupRunRepository);
+
+        GetEventExportOpsMetricsUseCase.Result result = useCase.execute(7, now);
+
+        assertThat(jobRepository.lastFromInclusive).isEqualTo(now.minus(7, ChronoUnit.DAYS));
+        assertThat(jobRepository.lastToExclusive).isEqualTo(now);
+        assertThat(result.jobs().total()).isEqualTo(4);
+        assertThat(result.jobs().completed()).isEqualTo(1);
+        assertThat(result.jobs().failed()).isEqualTo(1);
+        assertThat(result.jobs().failureRatePercent()).isEqualTo(50.0);
+        assertThat(result.processing().measuredJobs()).isEqualTo(2);
+        assertThat(result.processing().averageSeconds()).isEqualTo(20.0);
+        assertThat(result.processing().p95Seconds()).isEqualTo(30.0);
+        assertThat(result.cleanup().runCount()).isEqualTo(2);
+        assertThat(result.cleanup().deletedJobs()).isEqualTo(9);
+    }
+
+    @Test
+    void executeNormalizesWindowAndHandlesEmptyMetricsRows() {
+        Instant now = Instant.parse("2026-02-14T12:00:00Z");
+        InMemoryEventExportJobRepository jobRepository = new InMemoryEventExportJobRepository();
+        InMemoryCleanupRunRepository cleanupRunRepository = new InMemoryCleanupRunRepository();
+        cleanupRunRepository.summary = new EventExportJobCleanupRunRepository.Summary(0, 0);
+
+        GetEventExportOpsMetricsUseCase useCase = new GetEventExportOpsMetricsUseCase(jobRepository, cleanupRunRepository);
+
+        GetEventExportOpsMetricsUseCase.Result result = useCase.execute(0, now);
+
+        assertThat(result.windowDays()).isEqualTo(1);
+        assertThat(result.jobs().total()).isZero();
+        assertThat(result.jobs().failureRatePercent()).isEqualTo(0.0);
+        assertThat(result.processing().measuredJobs()).isZero();
+        assertThat(result.processing().averageSeconds()).isEqualTo(0.0);
+        assertThat(result.processing().p95Seconds()).isEqualTo(0.0);
+    }
+
+    private static class InMemoryEventExportJobRepository implements EventExportJobRepository {
+        private List<MetricsRow> metricsRows = new ArrayList<>();
+        private Instant lastFromInclusive;
+        private Instant lastToExclusive;
+
+        @Override
+        public EventExportJob save(EventExportJob job) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<EventExportJob> findById(UUID id) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<MetricsRow> findMetricsRows(Instant fromInclusive, Instant toExclusive) {
+            this.lastFromInclusive = fromInclusive;
+            this.lastToExclusive = toExclusive;
+            return metricsRows;
+        }
+
+        @Override
+        public long deleteCompletedOrFailedBefore(Instant completedBeforeExclusive) {
+            return 0;
+        }
+    }
+
+    private static class InMemoryCleanupRunRepository implements EventExportJobCleanupRunRepository {
+        private Summary summary = new Summary(0, 0);
+
+        @Override
+        public EventExportJobCleanupRun save(EventExportJobCleanupRun run) {
+            return run;
+        }
+
+        @Override
+        public Summary summarize(Instant fromInclusive, Instant toExclusive) {
+            return summary;
+        }
+    }
+}

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminEventApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminEventApiTest.java
@@ -8,12 +8,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.eunhyehymn.domain.model.EventType;
+import com.eunhyehymn.domain.model.EventExportJobStatus;
 import com.eunhyehymn.domain.model.PartType;
 import com.eunhyehymn.domain.model.Role;
 import com.eunhyehymn.domain.model.UserStatus;
 import com.eunhyehymn.infrastructure.persistence.AssetJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.AuthIdentityJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.EventEntity;
+import com.eunhyehymn.infrastructure.persistence.EventExportJobCleanupRunEntity;
+import com.eunhyehymn.infrastructure.persistence.EventExportJobCleanupRunJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.EventExportJobJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.EventJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.HymnEntity;
@@ -54,6 +57,7 @@ class AdminEventApiTest {
     @Autowired private HymnNoteJpaRepository hymnNoteJpaRepository;
     @Autowired private UserHymnStateJpaRepository userHymnStateJpaRepository;
     @Autowired private EventJpaRepository eventJpaRepository;
+    @Autowired private EventExportJobCleanupRunJpaRepository eventExportJobCleanupRunJpaRepository;
     @Autowired private EventExportJobJpaRepository eventExportJobJpaRepository;
     @Autowired private AuthIdentityJpaRepository authIdentityJpaRepository;
     @Autowired private RefreshTokenJpaRepository refreshTokenJpaRepository;
@@ -70,6 +74,7 @@ class AdminEventApiTest {
     @BeforeEach
     void setUp() {
         inviteCodeJpaRepository.deleteAll();
+        eventExportJobCleanupRunJpaRepository.deleteAll();
         eventExportJobJpaRepository.deleteAll();
         eventJpaRepository.deleteAll();
         userHymnStateJpaRepository.deleteAll();
@@ -331,6 +336,59 @@ class AdminEventApiTest {
     }
 
     @Test
+    void adminCanGetAsyncExportOpsMetrics() throws Exception {
+        Instant now = Instant.now();
+        saveExportJob(
+            EventExportJobStatus.COMPLETED,
+            now.minus(2, ChronoUnit.HOURS),
+            now.minus(2, ChronoUnit.HOURS).plusSeconds(10),
+            now.minus(2, ChronoUnit.HOURS).plusSeconds(20)
+        );
+        saveExportJob(
+            EventExportJobStatus.FAILED,
+            now.minus(90, ChronoUnit.MINUTES),
+            now.minus(90, ChronoUnit.MINUTES).plusSeconds(5),
+            now.minus(90, ChronoUnit.MINUTES).plusSeconds(35)
+        );
+        saveExportJob(
+            EventExportJobStatus.RUNNING,
+            now.minus(1, ChronoUnit.HOURS),
+            now.minus(1, ChronoUnit.HOURS).plusSeconds(5),
+            null
+        );
+        saveExportJob(
+            EventExportJobStatus.QUEUED,
+            now.minus(30, ChronoUnit.MINUTES),
+            null,
+            null
+        );
+        saveExportJob(
+            EventExportJobStatus.COMPLETED,
+            now.minus(20, ChronoUnit.DAYS),
+            now.minus(20, ChronoUnit.DAYS).plusSeconds(5),
+            now.minus(20, ChronoUnit.DAYS).plusSeconds(30)
+        );
+
+        saveCleanupRun(now.minus(1, ChronoUnit.DAYS), 4L);
+        saveCleanupRun(now.minus(12, ChronoUnit.DAYS), 20L);
+
+        mockMvc.perform(get("/admin/events/export-jobs/metrics")
+                .header("Authorization", "Bearer " + adminToken)
+                .param("days", "7"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.windowDays").value(7))
+            .andExpect(jsonPath("$.data.jobs.total").value(4))
+            .andExpect(jsonPath("$.data.jobs.completed").value(1))
+            .andExpect(jsonPath("$.data.jobs.failed").value(1))
+            .andExpect(jsonPath("$.data.jobs.failureRatePercent").value(50.0))
+            .andExpect(jsonPath("$.data.processing.measuredJobs").value(2))
+            .andExpect(jsonPath("$.data.processing.averageSeconds").value(20.0))
+            .andExpect(jsonPath("$.data.processing.p95Seconds").value(30.0))
+            .andExpect(jsonPath("$.data.cleanup.runCount").value(1))
+            .andExpect(jsonPath("$.data.cleanup.deletedJobs").value(4));
+    }
+
+    @Test
     void invalidUserIdReturnsBadRequest() throws Exception {
         mockMvc.perform(get("/admin/events")
                 .header("Authorization", "Bearer " + adminToken)
@@ -387,6 +445,41 @@ class AdminEventApiTest {
             part,
             "{\"source\":\"test\"}",
             createdAt
+        ));
+    }
+
+    private void saveExportJob(
+        EventExportJobStatus status,
+        Instant createdAt,
+        Instant startedAt,
+        Instant completedAt
+    ) {
+        eventExportJobJpaRepository.save(new com.eunhyehymn.infrastructure.persistence.EventExportJobEntity(
+            UUID.randomUUID(),
+            adminId,
+            EventType.HYMN_OPENED,
+            userAId,
+            hymnAId,
+            null,
+            null,
+            10_000,
+            status,
+            status == EventExportJobStatus.COMPLETED ? 10L : null,
+            status == EventExportJobStatus.COMPLETED ? "test.csv" : null,
+            status == EventExportJobStatus.COMPLETED ? "id,userId\n" : null,
+            status == EventExportJobStatus.FAILED ? "test failure" : null,
+            createdAt,
+            startedAt,
+            completedAt
+        ));
+    }
+
+    private void saveCleanupRun(Instant executedAt, long deletedCount) {
+        eventExportJobCleanupRunJpaRepository.save(new EventExportJobCleanupRunEntity(
+            UUID.randomUUID(),
+            executedAt,
+            7,
+            deletedCount
         ));
     }
 }

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -359,3 +359,37 @@
 - `./gradlew.bat test --tests "com.eunhyehymn.application.usecases.CleanupEventExportJobsUseCaseTest" --tests "com.eunhyehymn.application.usecases.CleanupEventExportJobsUseCaseIntegrationTest" --no-daemon --stacktrace` (`apps/api`)
 - `./gradlew.bat test --no-daemon --stacktrace` (`apps/api`)
 - `npx tsc --noEmit` + `npm run build` (`apps/admin`)
+
+## 12. 이번 사이클 기록 (2026-02-14, 9차)
+
+### 목표
+- 기능 백로그 완료: 비동기 export 운영 지표(실패율/처리시간/정리량) 정례화
+
+### 범위
+- 포함: 운영 지표 API/저장소/정리 이력 저장, Admin UI 지표 카드, 테스트/문서 동기화
+- 제외: 지표 기반 알림(CloudWatch/SNS) 자동 연동
+
+### 수행 작업
+1. 백엔드 운영 지표 조회 기능 추가
+- `GetEventExportOpsMetricsUseCase` 추가
+- `GET /admin/events/export-jobs/metrics` 엔드포인트 추가
+- 작업 상태별 집계, 실패율, 평균/95퍼센타일 처리시간 계산
+
+2. 정리량 집계 이력 저장 추가
+- `V9__event_export_job_cleanup_runs.sql` 추가
+- `EventExportJobCleanupRun` 도메인/저장소/어댑터 추가
+- `EventExportJobCleanupScheduler`가 실행 시 정리 결과를 이력 테이블에 저장
+
+3. 관리자 UI 운영 지표 카드 추가
+- `apps/admin/src/api/adminEvents.ts`: 운영 지표 API 클라이언트 추가
+- `apps/admin/src/pages/AdminEventPage.tsx`: 기간 프리셋(1/7/30/60/90일) 기반 지표 카드 추가
+
+4. 테스트 및 문서 동기화
+- 단위 테스트: `GetEventExportOpsMetricsUseCaseTest`
+- 통합 테스트: `AdminEventApiTest` 운영 지표 검증 케이스 추가
+- 문서: `docs/events.md`, `docs/api-contract.md`, `docs/current-usable-scope.md`, `docs/changelog-dev.md`, `CLAUDE.md`
+
+### 검증
+- `./gradlew.bat test --tests "com.eunhyehymn.application.usecases.GetEventExportOpsMetricsUseCaseTest" --tests "com.eunhyehymn.presentation.controllers.AdminEventApiTest" --no-daemon --stacktrace` (`apps/api`)
+- `./gradlew.bat test --no-daemon --stacktrace` (`apps/api`)
+- `npx tsc --noEmit` + `npm run build` (`apps/admin`)

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -170,6 +170,7 @@ Base URL: `/api/v1`
 - `POST /admin/events/export-jobs` (비동기 대용량 CSV 작업 생성, 202 Accepted)
 - `GET /admin/events/export-jobs/{jobId}` (작업 상태 조회)
 - `GET /admin/events/export-jobs/{jobId}/download` (완료 작업 다운로드)
+- `GET /admin/events/export-jobs/metrics` (비동기 export 운영 지표)
 - 지원 쿼리:
   - `eventType`: `HYMN_OPENED` | `PART_PLAYED` | `NOTE_SAVED` | `FAVORITE_TOGGLED`
   - `userId`, `hymnId`: UUID
@@ -178,6 +179,7 @@ Base URL: `/api/v1`
   - `size`: 페이지 크기 (기본 50, 최대 200)
   - `limit`: 하위 호환 조회 개수 파라미터(미지정 시 `page/size` 사용)
   - `summaryDays`: 최근 집계 일수 (기본 7, 최대 90)
+  - `days`: 운영 지표 집계 일수 (기본 7, 최대 90, `GET /admin/events/export-jobs/metrics` 전용)
 - 응답 `data` 예시:
 ```json
 {
@@ -233,6 +235,32 @@ Base URL: `/api/v1`
   "statusUrl": "/admin/events/export-jobs/job-uuid",
   "downloadUrl": "/admin/events/export-jobs/job-uuid/download",
   "downloadable": false
+}
+```
+
+- `GET /admin/events/export-jobs/metrics` 응답 `data` 예시:
+```json
+{
+  "windowDays": 7,
+  "fromInclusive": "2026-02-07T05:00:00Z",
+  "toExclusive": "2026-02-14T05:00:00Z",
+  "jobs": {
+    "total": 24,
+    "queued": 1,
+    "running": 0,
+    "completed": 21,
+    "failed": 2,
+    "failureRatePercent": 8.7
+  },
+  "processing": {
+    "measuredJobs": 23,
+    "averageSeconds": 14.8,
+    "p95Seconds": 39.0
+  },
+  "cleanup": {
+    "runCount": 7,
+    "deletedJobs": 43
+  }
 }
 ```
 

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,22 @@
 
 ## 2026-02-14
 
+### 비동기 export 운영 지표 정례화(9차)
+- 백엔드 운영 지표 API 추가
+  - `GET /api/v1/admin/events/export-jobs/metrics`
+  - 기간(`days`, 1~90일) 기준으로 실패율/처리시간/정리량 집계 반환
+- 정리량 집계 이력 저장 추가
+  - `V9__event_export_job_cleanup_runs.sql`
+  - 스케줄러 실행마다 `event_export_job_cleanup_runs`에 삭제량/보관일수 기록
+- 관리자 UI 반영
+  - `apps/admin/src/pages/AdminEventPage.tsx`에 운영 지표 카드(작업량/실패율/평균·p95 처리시간/정리량) 추가
+  - `apps/admin/src/api/adminEvents.ts`에 운영 지표 API 클라이언트 추가
+- 테스트 보강
+  - `GetEventExportOpsMetricsUseCaseTest` 신규 추가
+  - `AdminEventApiTest`에 운영 지표 엔드포인트 통합 테스트 추가
+- 문서 동기화
+  - `docs/events.md`, `docs/api-contract.md`, `docs/current-usable-scope.md`, `docs/WORK_CYCLE.md`, `CLAUDE.md`
+
 ### 비동기 export 결과 정리 배치(8차)
 - 백엔드 정리 정책 추가
   - `CleanupEventExportJobsUseCase` 추가 (완료/실패 작업 보관 기한 기준 삭제)

--- a/docs/current-usable-scope.md
+++ b/docs/current-usable-scope.md
@@ -138,7 +138,8 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
   - `docs/runbook.md` + `docs/staging-smoke-checklist.md` 기준 Admin/Mobile 수동 스모크 실행
   - 리허설/스모크 결과를 `docs/changelog-dev.md`에 주기 반영
 - 운영 기능 백로그
-  - 비동기 export 운영 모니터링 지표(실패율/처리시간/정리량) 정례화
+  - 비동기 export 운영 모니터링 지표(실패율/처리시간/정리량) 정례화 완료
+  - 후속 과제: 지표 임계치 기반 알림/대시보드 연동 설계
 
 ## 6. 빠른 사용 체크리스트
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -85,6 +85,16 @@
   - `EVENT_EXPORT_JOB_CLEANUP_CRON` (기본 `0 15 3 * * *`)
   - `EVENT_EXPORT_JOB_CLEANUP_ZONE` (기본 `UTC`)
 
+### 4.6 비동기 export 운영 지표
+- `GET /api/v1/admin/events/export-jobs/metrics`
+- 관리자 권한 필요
+- 쿼리: `days` (`1~90`, 기본 `7`)
+- 응답 핵심 항목
+  - `jobs`: 전체 작업 수, 상태별 카운트, 실패율
+  - `processing`: 측정 가능 작업 기준 평균/95퍼센타일 처리시간(초)
+  - `cleanup`: 정리 스케줄 실행 횟수와 삭제량
+- `cleanup` 지표는 `event_export_job_cleanup_runs` 실행 이력 테이블을 기반으로 계산한다.
+
 ## 5. 인덱스/성능 메모
 - 관리자 조회 패턴 최적화를 위해 아래 인덱스를 사용한다.
   - `idx_events_user_created` (`user_id`, `created_at`) - 기존


### PR DESCRIPTION
## 요약
- 관리자 비동기 export 운영 지표 API를 추가했습니다: `GET /api/v1/admin/events/export-jobs/metrics`
- 지표 정례화를 위해 cleanup 스케줄 실행 결과를 `event_export_job_cleanup_runs`에 저장하도록 확장했습니다.
- Admin 감사로그 화면에 운영 지표 카드(실패율/평균·p95 처리시간/정리량)를 추가했습니다.

## 주요 변경
- API
  - `GetEventExportOpsMetricsUseCase` 추가 (기간별 작업 상태/실패율/처리시간/정리량 계산)
  - `AdminEventController`에 `/admin/events/export-jobs/metrics` 엔드포인트 추가
  - `EventExportJobRepository` 지표 조회 메서드 추가
  - cleanup 실행 이력 도메인/저장소/어댑터 추가
- DB
  - `V9__event_export_job_cleanup_runs.sql` 마이그레이션 추가
- Scheduler
  - `EventExportJobCleanupScheduler`가 cleanup 실행 후 이력 저장
- Admin UI
  - `apps/admin/src/pages/AdminEventPage.tsx` 운영 지표 카드/기간 프리셋 추가
  - `apps/admin/src/api/adminEvents.ts` 운영 지표 API 클라이언트 추가
- Tests
  - `GetEventExportOpsMetricsUseCaseTest` 추가
  - `AdminEventApiTest` 운영 지표 엔드포인트 통합 테스트 추가
  - `CleanupEventExportJobsUseCaseTest` 인터페이스 확장 대응
- Docs
  - `docs/events.md`, `docs/api-contract.md`, `docs/current-usable-scope.md`, `docs/changelog-dev.md`, `docs/WORK_CYCLE.md`, `CLAUDE.md`

## 검증
- `./gradlew.bat test --tests "com.eunhyehymn.application.usecases.GetEventExportOpsMetricsUseCaseTest" --tests "com.eunhyehymn.presentation.controllers.AdminEventApiTest" --no-daemon --stacktrace` (`apps/api`)
- `./gradlew.bat test --no-daemon --stacktrace` (`apps/api`)
- `npx tsc --noEmit` (`apps/admin`)
- `npm run build` (`apps/admin`)

## 리스크/메모
- 운영 지표의 처리시간은 `startedAt/completedAt`가 모두 존재하는 작업만 측정합니다.
- `cleanup` 지표는 scheduler 실행 이력(`event_export_job_cleanup_runs`) 기준으로 집계합니다.