### PR TITLE
feat: harden async export reliability and guardrails

### DIFF
--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminEventExportJobUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminEventExportJobUseCase.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 public class AdminEventExportJobUseCase {
     private static final int DEFAULT_EXPORT_LIMIT = 20_000;
     private static final int MAX_EXPORT_LIMIT = 100_000;
+    private static final int MAX_DISPATCH_BATCH_SIZE = 200;
     private static final int CSV_FETCH_BATCH_SIZE = 1_000;
     private static final int MAX_ERROR_MESSAGE_LENGTH = 500;
     private static final String CSV_HEADER = "id,userId,eventType,hymnId,part,metadataJson,createdAt\n";
@@ -32,6 +33,7 @@ public class AdminEventExportJobUseCase {
 
     public EventExportJob create(CreateCommand command) {
         int exportLimit = normalizeExportLimit(command.limit());
+        Instant toExclusive = command.toExclusive() == null ? Instant.now() : command.toExclusive();
         EventExportJob job = new EventExportJob(
             UUID.randomUUID(),
             command.requestedBy(),
@@ -39,7 +41,7 @@ public class AdminEventExportJobUseCase {
             command.userId(),
             command.hymnId(),
             command.fromInclusive(),
-            command.toExclusive(),
+            toExclusive,
             exportLimit,
             EventExportJobStatus.QUEUED,
             null,
@@ -69,19 +71,17 @@ public class AdminEventExportJobUseCase {
     }
 
     public EventExportJob process(UUID jobId) {
-        EventExportJob queuedJob = eventExportJobRepository.findById(jobId)
-            .orElseThrow(() -> new ApiException(
-                HttpStatus.NOT_FOUND,
-                "export_job_not_found",
-                "Export job not found",
-                null
-            ));
-
-        if (queuedJob.status() != EventExportJobStatus.QUEUED) {
-            return queuedJob;
+        EventExportJob runningJob = eventExportJobRepository.claimQueued(jobId, Instant.now())
+            .orElseGet(() -> eventExportJobRepository.findById(jobId)
+                .orElseThrow(() -> new ApiException(
+                    HttpStatus.NOT_FOUND,
+                    "export_job_not_found",
+                    "Export job not found",
+                    null
+                )));
+        if (runningJob.status() != EventExportJobStatus.RUNNING) {
+            return runningJob;
         }
-
-        EventExportJob runningJob = eventExportJobRepository.save(queuedJob.markRunning(Instant.now()));
 
         try {
             CsvBuildResult csvBuildResult = buildCsv(runningJob);
@@ -96,6 +96,14 @@ public class AdminEventExportJobUseCase {
             String errorMessage = toErrorMessage(ex);
             return eventExportJobRepository.save(runningJob.markFailed(errorMessage, Instant.now()));
         }
+    }
+
+    public long requeueStaleRunningJobs(Instant staleBeforeExclusive) {
+        return eventExportJobRepository.requeueStaleRunningJobs(staleBeforeExclusive);
+    }
+
+    public List<UUID> findQueuedJobIds(int limit) {
+        return eventExportJobRepository.findQueuedJobIds(normalizeDispatchBatchSize(limit));
     }
 
     public DownloadResult getDownload(UUID jobId, UUID requestedBy) {
@@ -196,6 +204,13 @@ public class AdminEventExportJobUseCase {
             return 1;
         }
         return Math.min(limit, MAX_EXPORT_LIMIT);
+    }
+
+    private int normalizeDispatchBatchSize(int limit) {
+        if (limit < 1) {
+            return 1;
+        }
+        return Math.min(limit, MAX_DISPATCH_BATCH_SIZE);
     }
 
     private String buildFileName(UUID jobId) {

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/EventExportJobRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/EventExportJobRepository.java
@@ -12,6 +12,12 @@ public interface EventExportJobRepository {
 
     Optional<EventExportJob> findById(UUID id);
 
+    Optional<EventExportJob> claimQueued(UUID id, Instant startedAt);
+
+    List<UUID> findQueuedJobIds(int limit);
+
+    long requeueStaleRunningJobs(Instant staleBeforeExclusive);
+
     List<MetricsRow> findMetricsRows(Instant fromInclusive, Instant toExclusive);
 
     long deleteCompletedOrFailedBefore(Instant completedBeforeExclusive);

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobJpaRepository.java
@@ -5,12 +5,68 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface EventExportJobJpaRepository extends JpaRepository<EventExportJobEntity, UUID> {
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    @Query("""
+        UPDATE EventExportJobEntity e
+        SET e.status = :runningStatus,
+            e.startedAt = :startedAt,
+            e.completedAt = NULL,
+            e.rowCount = NULL,
+            e.fileName = NULL,
+            e.csvContent = NULL,
+            e.errorMessage = NULL
+        WHERE e.id = :id
+          AND e.status = :queuedStatus
+        """)
+    int claimQueued(
+        @Param("id") UUID id,
+        @Param("startedAt") Instant startedAt,
+        @Param("queuedStatus") EventExportJobStatus queuedStatus,
+        @Param("runningStatus") EventExportJobStatus runningStatus
+    );
+
+    @Query("""
+        SELECT e.id
+        FROM EventExportJobEntity e
+        WHERE e.status = :status
+        ORDER BY e.createdAt ASC, e.id ASC
+        """)
+    List<UUID> findQueuedJobIds(
+        @Param("status") EventExportJobStatus status,
+        Pageable pageable
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    @Query("""
+        UPDATE EventExportJobEntity e
+        SET e.status = :queuedStatus,
+            e.startedAt = NULL,
+            e.completedAt = NULL,
+            e.rowCount = NULL,
+            e.fileName = NULL,
+            e.csvContent = NULL,
+            e.errorMessage = :requeuedMessage
+        WHERE e.status = :runningStatus
+          AND e.startedAt IS NOT NULL
+          AND e.startedAt < :staleBeforeExclusive
+        """)
+    int requeueStaleRunningJobs(
+        @Param("staleBeforeExclusive") Instant staleBeforeExclusive,
+        @Param("runningStatus") EventExportJobStatus runningStatus,
+        @Param("queuedStatus") EventExportJobStatus queuedStatus,
+        @Param("requeuedMessage") String requeuedMessage
+    );
+
     @Query("""
         SELECT e.status AS status, e.startedAt AS startedAt, e.completedAt AS completedAt
         FROM EventExportJobEntity e

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventExportJobRepositoryAdapter.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -27,6 +28,39 @@ public class EventExportJobRepositoryAdapter implements EventExportJobRepository
     @Override
     public Optional<EventExportJob> findById(UUID id) {
         return jpaRepository.findById(id).map(EventExportJobMapper::toDomain);
+    }
+
+    @Override
+    public Optional<EventExportJob> claimQueued(UUID id, Instant startedAt) {
+        int updated = jpaRepository.claimQueued(
+            id,
+            startedAt,
+            EventExportJobStatus.QUEUED,
+            EventExportJobStatus.RUNNING
+        );
+        if (updated == 0) {
+            return Optional.empty();
+        }
+        return findById(id);
+    }
+
+    @Override
+    public List<UUID> findQueuedJobIds(int limit) {
+        int normalizedLimit = Math.max(limit, 1);
+        return jpaRepository.findQueuedJobIds(
+            EventExportJobStatus.QUEUED,
+            PageRequest.of(0, normalizedLimit)
+        );
+    }
+
+    @Override
+    public long requeueStaleRunningJobs(Instant staleBeforeExclusive) {
+        return jpaRepository.requeueStaleRunningJobs(
+            staleBeforeExclusive,
+            EventExportJobStatus.RUNNING,
+            EventExportJobStatus.QUEUED,
+            "Recovered stale running job"
+        );
     }
 
     @Override

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/EventJpaRepository.java
@@ -20,7 +20,7 @@ public interface EventJpaRepository extends JpaRepository<EventEntity, UUID> {
           AND (:eventType IS NULL OR e.eventType = :eventType)
           AND (:userId IS NULL OR e.userId = :userId)
           AND (:hymnId IS NULL OR e.hymnId = :hymnId)
-        ORDER BY e.createdAt DESC
+        ORDER BY e.createdAt DESC, e.id DESC
         """)
     List<EventEntity> findRecent(
         @Param("fromInclusive") Instant fromInclusive,

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/scheduling/EventExportJobOpsAlertScheduler.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/scheduling/EventExportJobOpsAlertScheduler.java
@@ -1,0 +1,81 @@
+package com.eunhyehymn.infrastructure.scheduling;
+
+import com.eunhyehymn.application.usecases.GetEventExportOpsMetricsUseCase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventExportJobOpsAlertScheduler {
+    private static final Logger logger = LoggerFactory.getLogger(EventExportJobOpsAlertScheduler.class);
+
+    private final GetEventExportOpsMetricsUseCase getEventExportOpsMetricsUseCase;
+    private final int windowDays;
+    private final int minFinishedJobs;
+    private final int maxQueuedJobs;
+    private final double maxFailureRatePercent;
+    private final double maxP95Seconds;
+
+    public EventExportJobOpsAlertScheduler(
+        GetEventExportOpsMetricsUseCase getEventExportOpsMetricsUseCase,
+        @Value("${events.export.jobs.alert.window-days:1}") int windowDays,
+        @Value("${events.export.jobs.alert.min-finished-jobs:5}") int minFinishedJobs,
+        @Value("${events.export.jobs.alert.max-queued-jobs:20}") int maxQueuedJobs,
+        @Value("${events.export.jobs.alert.max-failure-rate-percent:20}") double maxFailureRatePercent,
+        @Value("${events.export.jobs.alert.max-p95-seconds:120}") double maxP95Seconds
+    ) {
+        this.getEventExportOpsMetricsUseCase = getEventExportOpsMetricsUseCase;
+        this.windowDays = normalizePositive(windowDays, 1);
+        this.minFinishedJobs = normalizePositive(minFinishedJobs, 5);
+        this.maxQueuedJobs = normalizePositive(maxQueuedJobs, 20);
+        this.maxFailureRatePercent = Math.max(maxFailureRatePercent, 0.0);
+        this.maxP95Seconds = Math.max(maxP95Seconds, 1.0);
+    }
+
+    @Scheduled(
+        cron = "${events.export.jobs.alert.cron:0 */10 * * * *}",
+        zone = "${events.export.jobs.alert.zone:UTC}"
+    )
+    public void evaluateOpsAlerts() {
+        GetEventExportOpsMetricsUseCase.Result metrics = getEventExportOpsMetricsUseCase.execute(windowDays);
+        long finishedJobs = metrics.jobs().completed() + metrics.jobs().failed();
+
+        if (finishedJobs >= minFinishedJobs && metrics.jobs().failureRatePercent() > maxFailureRatePercent) {
+            logger.warn(
+                "event-export alert: failureRatePercent={} exceeds threshold={} (windowDays={}, finishedJobs={})",
+                metrics.jobs().failureRatePercent(),
+                maxFailureRatePercent,
+                metrics.windowDays(),
+                finishedJobs
+            );
+        }
+
+        if (metrics.processing().measuredJobs() >= minFinishedJobs && metrics.processing().p95Seconds() > maxP95Seconds) {
+            logger.warn(
+                "event-export alert: p95Seconds={} exceeds threshold={} (windowDays={}, measuredJobs={})",
+                metrics.processing().p95Seconds(),
+                maxP95Seconds,
+                metrics.windowDays(),
+                metrics.processing().measuredJobs()
+            );
+        }
+
+        if (metrics.jobs().queued() > maxQueuedJobs) {
+            logger.warn(
+                "event-export alert: queuedJobs={} exceeds threshold={} (windowDays={})",
+                metrics.jobs().queued(),
+                maxQueuedJobs,
+                metrics.windowDays()
+            );
+        }
+    }
+
+    private int normalizePositive(int value, int fallback) {
+        if (value < 1) {
+            return fallback;
+        }
+        return value;
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/scheduling/EventExportJobRecoveryScheduler.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/scheduling/EventExportJobRecoveryScheduler.java
@@ -1,0 +1,76 @@
+package com.eunhyehymn.infrastructure.scheduling;
+
+import com.eunhyehymn.application.usecases.AdminEventExportJobUseCase;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.TaskRejectedException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EventExportJobRecoveryScheduler {
+    private static final Logger logger = LoggerFactory.getLogger(EventExportJobRecoveryScheduler.class);
+
+    private final AdminEventExportJobUseCase adminEventExportJobUseCase;
+    private final TaskExecutor eventExportTaskExecutor;
+    private final int staleRunningMinutes;
+    private final int dispatchBatchSize;
+
+    public EventExportJobRecoveryScheduler(
+        AdminEventExportJobUseCase adminEventExportJobUseCase,
+        @Qualifier("eventExportTaskExecutor") TaskExecutor eventExportTaskExecutor,
+        @Value("${events.export.jobs.recovery.stale-running-minutes:15}") int staleRunningMinutes,
+        @Value("${events.export.jobs.recovery.dispatch-batch-size:20}") int dispatchBatchSize
+    ) {
+        this.adminEventExportJobUseCase = adminEventExportJobUseCase;
+        this.eventExportTaskExecutor = eventExportTaskExecutor;
+        this.staleRunningMinutes = normalizePositive(staleRunningMinutes, 15);
+        this.dispatchBatchSize = normalizePositive(dispatchBatchSize, 20);
+    }
+
+    @Scheduled(
+        cron = "${events.export.jobs.recovery.cron:0/30 * * * * *}",
+        zone = "${events.export.jobs.recovery.zone:UTC}"
+    )
+    public void recoverAndDispatch() {
+        Instant now = Instant.now();
+        Instant staleBeforeExclusive = now.minus(staleRunningMinutes, ChronoUnit.MINUTES);
+        long requeued = adminEventExportJobUseCase.requeueStaleRunningJobs(staleBeforeExclusive);
+
+        List<UUID> queuedJobIds = adminEventExportJobUseCase.findQueuedJobIds(dispatchBatchSize);
+        int dispatched = 0;
+        for (UUID jobId : queuedJobIds) {
+            try {
+                eventExportTaskExecutor.execute(() -> adminEventExportJobUseCase.process(jobId));
+                dispatched += 1;
+            } catch (TaskRejectedException ex) {
+                logger.warn("event export recovery dispatch rejected for jobId={}", jobId, ex);
+                break;
+            }
+        }
+
+        if (requeued > 0 || dispatched > 0) {
+            logger.info(
+                "event-export recovery cycle: requeued={}, dispatched={}, staleRunningMinutes={}, dispatchBatchSize={}",
+                requeued,
+                dispatched,
+                staleRunningMinutes,
+                dispatchBatchSize
+            );
+        }
+    }
+
+    private int normalizePositive(int value, int fallback) {
+        if (value < 1) {
+            return fallback;
+        }
+        return value;
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminEventController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminEventController.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.TaskRejectedException;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -30,11 +31,14 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RestController
 @RequestMapping("/admin/events")
 @Validated
 public class AdminEventController {
+    private static final Logger logger = LoggerFactory.getLogger(AdminEventController.class);
     private final AdminListEventsUseCase adminListEventsUseCase;
     private final AdminEventExportJobUseCase adminEventExportJobUseCase;
     private final GetEventExportOpsMetricsUseCase getEventExportOpsMetricsUseCase;
@@ -124,7 +128,12 @@ public class AdminEventController {
             limit
         ));
 
-        eventExportTaskExecutor.execute(() -> adminEventExportJobUseCase.process(job.id()));
+        try {
+            eventExportTaskExecutor.execute(() -> adminEventExportJobUseCase.process(job.id()));
+        } catch (TaskRejectedException ex) {
+            // Keep the job in QUEUED so recovery scheduler can pick it up later.
+            logger.warn("event export dispatch rejected for jobId={}", job.id(), ex);
+        }
 
         HttpHeaders headers = new HttpHeaders();
         headers.setLocation(URI.create("/admin/events/export-jobs/" + job.id()));

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -52,3 +52,16 @@ events:
       retention-days: ${EVENT_EXPORT_JOB_RETENTION_DAYS:7}
       cleanup-cron: ${EVENT_EXPORT_JOB_CLEANUP_CRON:0 15 3 * * *}
       cleanup-zone: ${EVENT_EXPORT_JOB_CLEANUP_ZONE:UTC}
+      recovery:
+        stale-running-minutes: ${EVENT_EXPORT_JOB_RECOVERY_STALE_RUNNING_MINUTES:15}
+        dispatch-batch-size: ${EVENT_EXPORT_JOB_RECOVERY_DISPATCH_BATCH_SIZE:20}
+        cron: ${EVENT_EXPORT_JOB_RECOVERY_CRON:0/30 * * * * *}
+        zone: ${EVENT_EXPORT_JOB_RECOVERY_ZONE:UTC}
+      alert:
+        window-days: ${EVENT_EXPORT_JOB_ALERT_WINDOW_DAYS:1}
+        min-finished-jobs: ${EVENT_EXPORT_JOB_ALERT_MIN_FINISHED_JOBS:5}
+        max-queued-jobs: ${EVENT_EXPORT_JOB_ALERT_MAX_QUEUED_JOBS:20}
+        max-failure-rate-percent: ${EVENT_EXPORT_JOB_ALERT_MAX_FAILURE_RATE_PERCENT:20}
+        max-p95-seconds: ${EVENT_EXPORT_JOB_ALERT_MAX_P95_SECONDS:120}
+        cron: ${EVENT_EXPORT_JOB_ALERT_CRON:0 */10 * * * *}
+        zone: ${EVENT_EXPORT_JOB_ALERT_ZONE:UTC}

--- a/apps/api/src/main/resources/db/migration/V10__event_export_jobs_cleanup_index.sql
+++ b/apps/api/src/main/resources/db/migration/V10__event_export_jobs_cleanup_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_event_export_jobs_status_completed_at
+    ON event_export_jobs(status, completed_at);

--- a/apps/api/src/test/java/com/eunhyehymn/application/usecases/AdminEventExportJobUseCaseTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/application/usecases/AdminEventExportJobUseCaseTest.java
@@ -1,0 +1,181 @@
+package com.eunhyehymn.application.usecases;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.eunhyehymn.domain.model.Event;
+import com.eunhyehymn.domain.model.EventExportJob;
+import com.eunhyehymn.domain.model.EventExportJobStatus;
+import com.eunhyehymn.domain.model.EventType;
+import com.eunhyehymn.domain.repository.EventExportJobRepository;
+import com.eunhyehymn.domain.repository.EventRepository;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class AdminEventExportJobUseCaseTest {
+    @Test
+    void createSnapshotsToExclusiveWhenUpperBoundIsOmitted() {
+        InMemoryEventExportJobRepository jobRepository = new InMemoryEventExportJobRepository();
+        AdminEventExportJobUseCase useCase = new AdminEventExportJobUseCase(new NoopEventRepository(), jobRepository);
+        Instant before = Instant.now();
+
+        EventExportJob created = useCase.create(new AdminEventExportJobUseCase.CreateCommand(
+            UUID.randomUUID(),
+            EventType.HYMN_OPENED,
+            null,
+            null,
+            null,
+            null,
+            null
+        ));
+
+        Instant after = Instant.now();
+        assertThat(created.toExclusive()).isNotNull();
+        assertThat(created.toExclusive()).isBetween(before, after);
+    }
+
+    @Test
+    void processReturnsCurrentJobWhenClaimFails() {
+        InMemoryEventExportJobRepository jobRepository = new InMemoryEventExportJobRepository();
+        AdminEventExportJobUseCase useCase = new AdminEventExportJobUseCase(new NoopEventRepository(), jobRepository);
+        EventExportJob queuedJob = new EventExportJob(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            null,
+            null,
+            null,
+            null,
+            Instant.now(),
+            100,
+            EventExportJobStatus.QUEUED,
+            null,
+            null,
+            null,
+            null,
+            Instant.now(),
+            null,
+            null
+        );
+        jobRepository.findByIdResult = Optional.of(queuedJob);
+        jobRepository.claimQueuedResult = Optional.empty();
+
+        EventExportJob result = useCase.process(queuedJob.id());
+
+        assertThat(result.status()).isEqualTo(EventExportJobStatus.QUEUED);
+        assertThat(jobRepository.savedJobs).isEmpty();
+    }
+
+    @Test
+    void findQueuedJobIdsNormalizesBatchSize() {
+        InMemoryEventExportJobRepository jobRepository = new InMemoryEventExportJobRepository();
+        AdminEventExportJobUseCase useCase = new AdminEventExportJobUseCase(new NoopEventRepository(), jobRepository);
+        UUID queuedId = UUID.randomUUID();
+        jobRepository.queuedIds = List.of(queuedId);
+
+        List<UUID> idsForZero = useCase.findQueuedJobIds(0);
+        List<UUID> idsForLarge = useCase.findQueuedJobIds(999);
+
+        assertThat(idsForZero).containsExactly(queuedId);
+        assertThat(idsForLarge).containsExactly(queuedId);
+        assertThat(jobRepository.findQueuedLimitHistory).containsExactly(1, 200);
+    }
+
+    private static final class InMemoryEventExportJobRepository implements EventExportJobRepository {
+        private Optional<EventExportJob> findByIdResult = Optional.empty();
+        private Optional<EventExportJob> claimQueuedResult = Optional.empty();
+        private List<UUID> queuedIds = List.of();
+        private final List<EventExportJob> savedJobs = new ArrayList<>();
+        private final List<Integer> findQueuedLimitHistory = new ArrayList<>();
+
+        @Override
+        public EventExportJob save(EventExportJob job) {
+            savedJobs.add(job);
+            findByIdResult = Optional.of(job);
+            return job;
+        }
+
+        @Override
+        public Optional<EventExportJob> findById(UUID id) {
+            return findByIdResult.filter(job -> job.id().equals(id));
+        }
+
+        @Override
+        public Optional<EventExportJob> claimQueued(UUID id, Instant startedAt) {
+            return claimQueuedResult;
+        }
+
+        @Override
+        public List<UUID> findQueuedJobIds(int limit) {
+            findQueuedLimitHistory.add(limit);
+            return queuedIds;
+        }
+
+        @Override
+        public long requeueStaleRunningJobs(Instant staleBeforeExclusive) {
+            return 0;
+        }
+
+        @Override
+        public List<MetricsRow> findMetricsRows(Instant fromInclusive, Instant toExclusive) {
+            return List.of();
+        }
+
+        @Override
+        public long deleteCompletedOrFailedBefore(Instant completedBeforeExclusive) {
+            return 0;
+        }
+    }
+
+    private static final class NoopEventRepository implements EventRepository {
+        @Override
+        public Event save(Event event) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<Event> saveAll(List<Event> events) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<Event> findById(UUID id) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<Event> findRecent(
+            Instant fromInclusive,
+            Instant toExclusive,
+            EventType eventType,
+            UUID userId,
+            UUID hymnId,
+            int page,
+            int size
+        ) {
+            return List.of();
+        }
+
+        @Override
+        public long countRecent(Instant fromInclusive, Instant toExclusive, EventType eventType, UUID userId, UUID hymnId) {
+            return 0;
+        }
+
+        @Override
+        public List<EventTypeCount> countByEventType(
+            Instant fromInclusive,
+            Instant toExclusive,
+            EventType eventType,
+            UUID userId,
+            UUID hymnId
+        ) {
+            return List.of();
+        }
+
+        @Override
+        public void deleteByHymnId(UUID hymnId) {
+        }
+    }
+}

--- a/apps/api/src/test/java/com/eunhyehymn/application/usecases/CleanupEventExportJobsUseCaseTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/application/usecases/CleanupEventExportJobsUseCaseTest.java
@@ -53,6 +53,21 @@ class CleanupEventExportJobsUseCaseTest {
         }
 
         @Override
+        public Optional<EventExportJob> claimQueued(UUID id, Instant startedAt) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<UUID> findQueuedJobIds(int limit) {
+            return List.of();
+        }
+
+        @Override
+        public long requeueStaleRunningJobs(Instant staleBeforeExclusive) {
+            return 0;
+        }
+
+        @Override
         public List<MetricsRow> findMetricsRows(Instant fromInclusive, Instant toExclusive) {
             return List.of();
         }

--- a/apps/api/src/test/java/com/eunhyehymn/application/usecases/GetEventExportOpsMetricsUseCaseTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/application/usecases/GetEventExportOpsMetricsUseCaseTest.java
@@ -90,6 +90,21 @@ class GetEventExportOpsMetricsUseCaseTest {
         }
 
         @Override
+        public Optional<EventExportJob> claimQueued(UUID id, Instant startedAt) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<UUID> findQueuedJobIds(int limit) {
+            return List.of();
+        }
+
+        @Override
+        public long requeueStaleRunningJobs(Instant staleBeforeExclusive) {
+            return 0;
+        }
+
+        @Override
         public List<MetricsRow> findMetricsRows(Instant fromInclusive, Instant toExclusive) {
             this.lastFromInclusive = fromInclusive;
             this.lastToExclusive = toExclusive;

--- a/apps/api/src/test/java/com/eunhyehymn/infrastructure/scheduling/EventExportJobOpsAlertSchedulerTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/infrastructure/scheduling/EventExportJobOpsAlertSchedulerTest.java
@@ -1,0 +1,36 @@
+package com.eunhyehymn.infrastructure.scheduling;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eunhyehymn.application.usecases.GetEventExportOpsMetricsUseCase;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class EventExportJobOpsAlertSchedulerTest {
+    @Test
+    void evaluateOpsAlertsUsesConfiguredWindowDays() {
+        GetEventExportOpsMetricsUseCase metricsUseCase = mock(GetEventExportOpsMetricsUseCase.class);
+        when(metricsUseCase.execute(7)).thenReturn(new GetEventExportOpsMetricsUseCase.Result(
+            7,
+            Instant.parse("2026-02-13T00:00:00Z"),
+            Instant.parse("2026-02-14T00:00:00Z"),
+            new GetEventExportOpsMetricsUseCase.JobMetrics(3, 0, 0, 3, 0, 0.0),
+            new GetEventExportOpsMetricsUseCase.ProcessingMetrics(3, 12.0, 20.0),
+            new GetEventExportOpsMetricsUseCase.CleanupMetrics(1, 5)
+        ));
+
+        EventExportJobOpsAlertScheduler scheduler = new EventExportJobOpsAlertScheduler(
+            metricsUseCase,
+            7,
+            5,
+            20,
+            20.0,
+            120.0
+        );
+        scheduler.evaluateOpsAlerts();
+
+        verify(metricsUseCase).execute(7);
+    }
+}

--- a/apps/api/src/test/java/com/eunhyehymn/infrastructure/scheduling/EventExportJobRecoverySchedulerTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/infrastructure/scheduling/EventExportJobRecoverySchedulerTest.java
@@ -1,0 +1,48 @@
+package com.eunhyehymn.infrastructure.scheduling;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eunhyehymn.application.usecases.AdminEventExportJobUseCase;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.TaskRejectedException;
+
+class EventExportJobRecoverySchedulerTest {
+    @Test
+    void recoverAndDispatchRequeuesStaleJobsAndDispatchesQueuedJobs() {
+        AdminEventExportJobUseCase useCase = mock(AdminEventExportJobUseCase.class);
+        TaskExecutor executor = mock(TaskExecutor.class);
+        UUID jobA = UUID.randomUUID();
+        UUID jobB = UUID.randomUUID();
+        when(useCase.requeueStaleRunningJobs(any())).thenReturn(2L);
+        when(useCase.findQueuedJobIds(20)).thenReturn(List.of(jobA, jobB));
+
+        EventExportJobRecoveryScheduler scheduler = new EventExportJobRecoveryScheduler(useCase, executor, 15, 20);
+        scheduler.recoverAndDispatch();
+
+        verify(useCase, times(1)).requeueStaleRunningJobs(any());
+        verify(useCase, times(1)).findQueuedJobIds(20);
+        verify(executor, times(2)).execute(any(Runnable.class));
+    }
+
+    @Test
+    void recoverAndDispatchStopsDispatchingWhenQueueRejectsTask() {
+        AdminEventExportJobUseCase useCase = mock(AdminEventExportJobUseCase.class);
+        TaskExecutor executor = mock(TaskExecutor.class);
+        when(useCase.requeueStaleRunningJobs(any())).thenReturn(0L);
+        when(useCase.findQueuedJobIds(20)).thenReturn(List.of(UUID.randomUUID(), UUID.randomUUID()));
+        doThrow(new TaskRejectedException("queue saturated")).when(executor).execute(any(Runnable.class));
+
+        EventExportJobRecoveryScheduler scheduler = new EventExportJobRecoveryScheduler(useCase, executor, 15, 20);
+        scheduler.recoverAndDispatch();
+
+        verify(executor, times(1)).execute(any(Runnable.class));
+    }
+}

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminEventApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminEventApiTest.java
@@ -247,6 +247,29 @@ class AdminEventApiTest {
     }
 
     @Test
+    void adminEventOrderingIsStableWhenCreatedAtIsSame() throws Exception {
+        Instant createdAt = Instant.parse("2026-02-14T00:00:00Z");
+        UUID smallerId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID largerId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+
+        saveEvent(smallerId, userAId, EventType.HYMN_OPENED, hymnAId, PartType.ALL, createdAt);
+        saveEvent(largerId, userAId, EventType.NOTE_SAVED, hymnAId, null, createdAt);
+
+        String response = mockMvc.perform(get("/admin/events")
+                .header("Authorization", "Bearer " + adminToken)
+                .param("size", "2"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.items.length()").value(2))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        JsonNode items = objectMapper.readTree(response).get("data").get("items");
+        assertThat(items.get(0).get("id").asText()).isEqualTo(largerId.toString());
+        assertThat(items.get(1).get("id").asText()).isEqualTo(smallerId.toString());
+    }
+
+    @Test
     void adminCanExportEventsCsv() throws Exception {
         Instant now = Instant.now();
         saveEvent(UUID.randomUUID(), userAId, EventType.HYMN_OPENED, hymnAId, PartType.ALL, now.minus(2, ChronoUnit.MINUTES));
@@ -307,6 +330,39 @@ class AdminEventApiTest {
     }
 
     @Test
+    void asyncExportUsesCreationSnapshotWhenToIsOmitted() throws Exception {
+        UUID firstEventId = UUID.randomUUID();
+        UUID futureEventId = UUID.randomUUID();
+        Instant now = Instant.now();
+        saveEvent(firstEventId, userAId, EventType.HYMN_OPENED, hymnAId, PartType.ALL, now.minus(1, ChronoUnit.MINUTES));
+
+        String createResponse = mockMvc.perform(post("/admin/events/export-jobs")
+                .header("Authorization", "Bearer " + adminToken)
+                .param("eventType", "HYMN_OPENED")
+                .param("limit", "5000"))
+            .andExpect(status().isAccepted())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        UUID jobId = UUID.fromString(objectMapper.readTree(createResponse).get("data").get("id").asText());
+        saveEvent(futureEventId, userAId, EventType.HYMN_OPENED, hymnAId, PartType.ALL, now.plus(1, ChronoUnit.HOURS));
+
+        JsonNode finalState = waitForJobCompletion(jobId, adminToken);
+        assertThat(finalState.get("status").asText()).isEqualTo("COMPLETED");
+
+        String csv = mockMvc.perform(get("/admin/events/export-jobs/{jobId}/download", jobId)
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertThat(csv).contains(firstEventId.toString());
+        assertThat(csv).doesNotContain(futureEventId.toString());
+    }
+
+    @Test
     void asyncExportJobIsVisibleOnlyToRequester() throws Exception {
         UUID secondAdminId = UUID.randomUUID();
         userJpaRepository.save(new UserEntity(
@@ -333,6 +389,21 @@ class AdminEventApiTest {
             .andExpect(jsonPath("$.error.code").value("export_job_not_found"));
 
         waitForJobCompletion(jobId, adminToken);
+    }
+
+    @Test
+    void downloadReturnsConflictWhenAsyncExportJobIsNotCompleted() throws Exception {
+        UUID queuedJobId = saveExportJob(
+            EventExportJobStatus.QUEUED,
+            Instant.now().minus(1, ChronoUnit.MINUTES),
+            null,
+            null
+        );
+
+        mockMvc.perform(get("/admin/events/export-jobs/{jobId}/download", queuedJobId)
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.error.code").value("export_job_not_ready"));
     }
 
     @Test
@@ -448,14 +519,15 @@ class AdminEventApiTest {
         ));
     }
 
-    private void saveExportJob(
+    private UUID saveExportJob(
         EventExportJobStatus status,
         Instant createdAt,
         Instant startedAt,
         Instant completedAt
     ) {
+        UUID id = UUID.randomUUID();
         eventExportJobJpaRepository.save(new com.eunhyehymn.infrastructure.persistence.EventExportJobEntity(
-            UUID.randomUUID(),
+            id,
             adminId,
             EventType.HYMN_OPENED,
             userAId,
@@ -472,6 +544,7 @@ class AdminEventApiTest {
             startedAt,
             completedAt
         ));
+        return id;
     }
 
     private void saveCleanupRun(Instant executedAt, long deletedCount) {

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminEventControllerTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminEventControllerTest.java
@@ -1,0 +1,81 @@
+package com.eunhyehymn.presentation.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.eunhyehymn.application.usecases.AdminEventExportJobUseCase;
+import com.eunhyehymn.application.usecases.AdminListEventsUseCase;
+import com.eunhyehymn.application.usecases.GetEventExportOpsMetricsUseCase;
+import com.eunhyehymn.common.response.ApiResponse;
+import com.eunhyehymn.domain.model.EventExportJob;
+import com.eunhyehymn.domain.model.EventExportJobStatus;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.TaskRejectedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+class AdminEventControllerTest {
+    @Test
+    void createExportJobReturnsAcceptedWhenTaskDispatchIsRejected() {
+        AdminListEventsUseCase listEventsUseCase = mock(AdminListEventsUseCase.class);
+        AdminEventExportJobUseCase exportJobUseCase = mock(AdminEventExportJobUseCase.class);
+        GetEventExportOpsMetricsUseCase metricsUseCase = mock(GetEventExportOpsMetricsUseCase.class);
+        TaskExecutor taskExecutor = mock(TaskExecutor.class);
+
+        UUID requestedBy = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+        EventExportJob queuedJob = new EventExportJob(
+            jobId,
+            requestedBy,
+            null,
+            null,
+            null,
+            null,
+            Instant.now(),
+            10_000,
+            EventExportJobStatus.QUEUED,
+            null,
+            null,
+            null,
+            null,
+            Instant.now(),
+            null,
+            null
+        );
+
+        when(exportJobUseCase.create(any())).thenReturn(queuedJob);
+        doThrow(new TaskRejectedException("queue saturated")).when(taskExecutor).execute(any(Runnable.class));
+
+        AdminEventController controller = new AdminEventController(
+            listEventsUseCase,
+            exportJobUseCase,
+            metricsUseCase,
+            taskExecutor
+        );
+        Authentication authentication = new UsernamePasswordAuthenticationToken(requestedBy.toString(), "N/A");
+
+        ResponseEntity<ApiResponse<AdminEventController.EventExportJobResponse>> response = controller.createExportJob(
+            null,
+            null,
+            null,
+            null,
+            null,
+            10_000,
+            authentication
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().data().id()).isEqualTo(jobId);
+        verify(taskExecutor).execute(any(Runnable.class));
+    }
+}

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -393,3 +393,47 @@
 - `./gradlew.bat test --tests "com.eunhyehymn.application.usecases.GetEventExportOpsMetricsUseCaseTest" --tests "com.eunhyehymn.presentation.controllers.AdminEventApiTest" --no-daemon --stacktrace` (`apps/api`)
 - `./gradlew.bat test --no-daemon --stacktrace` (`apps/api`)
 - `npx tsc --noEmit` + `npm run build` (`apps/admin`)
+
+## 13. 이번 사이클 기록 (2026-02-14, 10차)
+
+### 목표
+- 기능 백로그 완료: 비동기 export 내구성/정합성/성능/알림/테스트 강화
+
+### 범위
+- 포함: 복구 스케줄러, 원자적 claim, snapshot 정합성, 정리 인덱스, 알림 스케줄러, 테스트 확장, 문서 동기화
+- 제외: 외부 알림 채널(CloudWatch/SNS/PagerDuty) 직접 연동
+
+### 수행 작업
+1. 내구성 복구 경로 구현
+- `EventExportJobRepository.claimQueued(...)` 추가로 작업 실행 claim 원자화
+- `EventExportJobRecoveryScheduler` 추가
+  - stale `RUNNING` 재큐잉
+  - `QUEUED` 작업 배치 재디스패치
+- `AdminEventController`에서 executor reject 시 `QUEUED` 유지(요청은 `202 Accepted`)
+
+2. export 결과 정합성 강화
+- `to` 미지정 시 작업 생성 시각을 `toExclusive`로 고정(snapshot)
+- 이벤트 조회 정렬을 `createdAt DESC, id DESC`로 안정화
+
+3. 정리 배치 성능 보강
+- `V10__event_export_jobs_cleanup_index.sql` 추가
+- 인덱스: `idx_event_export_jobs_status_completed_at (status, completed_at)`
+
+4. 운영 알림 베이스라인 추가
+- `EventExportJobOpsAlertScheduler` 추가
+- 실패율/p95/queued 임계치 초과 시 WARN 로그 출력
+- 알림/복구 스케줄러 설정 키를 `application.yml`에 추가
+
+5. 테스트 확장
+- 신규: `AdminEventExportJobUseCaseTest`
+- 신규: `EventExportJobRecoverySchedulerTest`
+- 신규: `EventExportJobOpsAlertSchedulerTest`
+- 신규: `AdminEventControllerTest` (queue rejection 시 `202`)
+- 보강: `AdminEventApiTest`
+  - 미완료 다운로드 `409`
+  - snapshot 결과 검증
+  - 동일 시각 데이터 안정 정렬 검증
+
+### 검증
+- `./gradlew.bat test --no-daemon --stacktrace` (`apps/api`)
+- `npm run build` (`apps/admin`)

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -180,6 +180,9 @@ Base URL: `/api/v1`
   - `limit`: 하위 호환 조회 개수 파라미터(미지정 시 `page/size` 사용)
   - `summaryDays`: 최근 집계 일수 (기본 7, 최대 90)
   - `days`: 운영 지표 집계 일수 (기본 7, 최대 90, `GET /admin/events/export-jobs/metrics` 전용)
+- 비동기 export 스냅샷 규칙:
+  - `POST /admin/events/export-jobs`에서 `to`를 생략하면 서버가 작업 생성 시각을 `toExclusive`로 고정한다.
+  - 실행 대기 중 신규 유입 이벤트는 해당 작업 결과에서 제외된다.
 - 응답 `data` 예시:
 ```json
 {

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,27 @@
 
 ## 2026-02-14
 
+### 비동기 export 안정화/운영 사이클(10차)
+- 내구성 복구 경로 추가
+  - `EventExportJobRepository.claimQueued(...)` 도입으로 작업 실행 claim을 원자화
+  - `EventExportJobRecoveryScheduler` 추가: stale `RUNNING` 재큐잉 + `QUEUED` 재디스패치
+  - 큐 포화 시 요청 실패 대신 `QUEUED` 유지(후속 복구 사이클에서 재처리)
+- 결과 일관성 강화
+  - `POST /admin/events/export-jobs`에서 `to` 미지정 시 생성 시각 snapshot 고정
+  - 이벤트 조회 정렬을 `createdAt DESC, id DESC`로 안정화
+- 성능 보강
+  - `V10__event_export_jobs_cleanup_index.sql` 추가
+  - 정리 쿼리 최적화 인덱스: `idx_event_export_jobs_status_completed_at`
+- 운영 알림 베이스라인 추가
+  - `EventExportJobOpsAlertScheduler` 추가
+  - 실패율/p95/queued 임계치 초과 시 WARN 로그 출력
+- 테스트 확장
+  - `AdminEventExportJobUseCaseTest` 신규(스냅샷/claim-fail/배치 제한)
+  - `EventExportJobRecoverySchedulerTest` 신규(재디스패치/queue rejection)
+  - `EventExportJobOpsAlertSchedulerTest` 신규(설정 기반 평가 호출)
+  - `AdminEventControllerTest` 신규(queue rejection 시 202 유지)
+  - `AdminEventApiTest` 보강(미완료 다운로드 `409`, snapshot 결과, 안정 정렬)
+
 ### 비동기 export 운영 지표 정례화(9차)
 - 백엔드 운영 지표 API 추가
   - `GET /api/v1/admin/events/export-jobs/metrics`

--- a/docs/events.md
+++ b/docs/events.md
@@ -68,6 +68,7 @@
   - 비동기 내보내기 작업 생성(202 Accepted)
   - 필터: `eventType`, `userId`, `hymnId`, `from`, `to`
   - `limit`: 기본 20,000 / 최대 100,000
+  - `to` 미지정 시 작업 생성 시각(`now`)을 상한으로 고정해 내보내기 결과를 스냅샷으로 보장
 - `GET /api/v1/admin/events/export-jobs/{jobId}`
   - 작업 상태 조회
   - 상태: `QUEUED`, `RUNNING`, `COMPLETED`, `FAILED`
@@ -95,12 +96,40 @@
   - `cleanup`: 정리 스케줄 실행 횟수와 삭제량
 - `cleanup` 지표는 `event_export_job_cleanup_runs` 실행 이력 테이블을 기반으로 계산한다.
 
+### 4.7 비동기 export 복구 스케줄러
+- 큐 적체/프로세스 재기동 상황에서 `QUEUED` 작업 재디스패치, stale `RUNNING` 작업 재큐잉을 수행한다.
+- 기본 정책
+  - stale 판정 기준: 15분
+  - 디스패치 배치 크기: 20건
+  - 실행 스케줄: 30초 간격 (`0/30 * * * * *`, UTC)
+- 설정 값
+  - `EVENT_EXPORT_JOB_RECOVERY_STALE_RUNNING_MINUTES`
+  - `EVENT_EXPORT_JOB_RECOVERY_DISPATCH_BATCH_SIZE`
+  - `EVENT_EXPORT_JOB_RECOVERY_CRON`
+  - `EVENT_EXPORT_JOB_RECOVERY_ZONE`
+
+### 4.8 비동기 export 알림(베이스라인)
+- 운영 지표를 주기적으로 평가해 임계치 초과 시 WARN 로그를 남긴다.
+- 기본 임계치
+  - 실패율: 20%
+  - p95 처리시간: 120초
+  - queued 작업 수: 20건
+- 설정 값
+  - `EVENT_EXPORT_JOB_ALERT_WINDOW_DAYS`
+  - `EVENT_EXPORT_JOB_ALERT_MIN_FINISHED_JOBS`
+  - `EVENT_EXPORT_JOB_ALERT_MAX_QUEUED_JOBS`
+  - `EVENT_EXPORT_JOB_ALERT_MAX_FAILURE_RATE_PERCENT`
+  - `EVENT_EXPORT_JOB_ALERT_MAX_P95_SECONDS`
+  - `EVENT_EXPORT_JOB_ALERT_CRON`
+  - `EVENT_EXPORT_JOB_ALERT_ZONE`
+
 ## 5. 인덱스/성능 메모
 - 관리자 조회 패턴 최적화를 위해 아래 인덱스를 사용한다.
   - `idx_events_user_created` (`user_id`, `created_at`) - 기존
   - `idx_events_created_at_desc` (`created_at DESC`)
   - `idx_events_event_type_created` (`event_type`, `created_at DESC`)
   - `idx_events_hymn_created` (`hymn_id`, `created_at DESC`)
+  - `idx_event_export_jobs_status_completed_at` (`status`, `completed_at`)
 - 운영 시 확인 항목
   - 관리자 이벤트 조회 응답 시간이 증가하면 `EXPLAIN ANALYZE`로 인덱스 사용 여부 확인
   - 이벤트 테이블 급증 시 CSV `limit` 정책과 백필/아카이빙 정책을 함께 점검


### PR DESCRIPTION
﻿## Summary
- harden async export job processing with atomic claim (`QUEUED` -> `RUNNING`) to reduce duplicate/racy execution
- add recovery scheduler for stale `RUNNING` requeue + queued dispatch and keep `202 Accepted` on executor rejection
- improve export consistency with `toExclusive` snapshot when `to` is omitted and stable event ordering (`createdAt DESC, id DESC`)
- add cleanup index migration (`V10`) and ops alert baseline scheduler for failure rate/p95/queue thresholds
- expand tests for recovery/rejection/snapshot/order/conflict scenarios and sync docs

## Verification
- `./gradlew.bat test --no-daemon --stacktrace` (apps/api)
- `npm run build` (apps/admin)
