### PR TITLE
fix: harden csv export cells against formula injection

### DIFF
--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminEventExportJobUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminEventExportJobUseCase.java
@@ -1,6 +1,7 @@
 package com.eunhyehymn.application.usecases;
 
 import com.eunhyehymn.common.error.ApiException;
+import com.eunhyehymn.common.util.CsvUtils;
 import com.eunhyehymn.domain.model.Event;
 import com.eunhyehymn.domain.model.EventExportJob;
 import com.eunhyehymn.domain.model.EventExportJobStatus;
@@ -189,11 +190,7 @@ public class AdminEventExportJobUseCase {
     }
 
     private String csv(Object value) {
-        if (value == null) {
-            return "";
-        }
-        String raw = value.toString().replace("\"", "\"\"");
-        return "\"" + raw + "\"";
+        return CsvUtils.toSafeCsvCell(value);
     }
 
     private int normalizeExportLimit(Integer limit) {

--- a/apps/api/src/main/java/com/eunhyehymn/common/util/CsvUtils.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/util/CsvUtils.java
@@ -1,0 +1,37 @@
+package com.eunhyehymn.common.util;
+
+public final class CsvUtils {
+    private CsvUtils() {
+    }
+
+    public static String toSafeCsvCell(Object value) {
+        if (value == null) {
+            return "";
+        }
+
+        String raw = value.toString();
+        if (looksLikeSpreadsheetFormula(raw)) {
+            raw = "'" + raw;
+        }
+        raw = raw.replace("\"", "\"\"");
+        return "\"" + raw + "\"";
+    }
+
+    private static boolean looksLikeSpreadsheetFormula(String value) {
+        if (value.isEmpty()) {
+            return false;
+        }
+
+        int firstNonWhitespaceIndex = 0;
+        while (firstNonWhitespaceIndex < value.length()
+            && Character.isWhitespace(value.charAt(firstNonWhitespaceIndex))) {
+            firstNonWhitespaceIndex += 1;
+        }
+        if (firstNonWhitespaceIndex >= value.length()) {
+            return false;
+        }
+
+        char first = value.charAt(firstNonWhitespaceIndex);
+        return first == '=' || first == '+' || first == '-' || first == '@';
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminEventController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminEventController.java
@@ -5,6 +5,7 @@ import com.eunhyehymn.application.usecases.AdminListEventsUseCase;
 import com.eunhyehymn.application.usecases.GetEventExportOpsMetricsUseCase;
 import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.common.response.ApiResponse;
+import com.eunhyehymn.common.util.CsvUtils;
 import com.eunhyehymn.domain.model.Event;
 import com.eunhyehymn.domain.model.EventExportJob;
 import com.eunhyehymn.domain.model.EventExportJobStatus;
@@ -308,11 +309,7 @@ public class AdminEventController {
     }
 
     private String csv(Object value) {
-        if (value == null) {
-            return "";
-        }
-        String raw = value.toString().replace("\"", "\"\"");
-        return "\"" + raw + "\"";
+        return CsvUtils.toSafeCsvCell(value);
     }
 
     private EventType parseEventType(String value) {

--- a/apps/api/src/test/java/com/eunhyehymn/common/util/CsvUtilsTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/common/util/CsvUtilsTest.java
@@ -1,0 +1,25 @@
+package com.eunhyehymn.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class CsvUtilsTest {
+    @Test
+    void toSafeCsvCellPrefixesQuoteForFormulaLikeValue() {
+        String escaped = CsvUtils.toSafeCsvCell("=1+1");
+        assertThat(escaped).isEqualTo("\"'=1+1\"");
+    }
+
+    @Test
+    void toSafeCsvCellHandlesLeadingWhitespaceFormula() {
+        String escaped = CsvUtils.toSafeCsvCell("  -SUM(1,1)");
+        assertThat(escaped).isEqualTo("\"'  -SUM(1,1)\"");
+    }
+
+    @Test
+    void toSafeCsvCellEscapesQuotes() {
+        String escaped = CsvUtils.toSafeCsvCell("a\"b");
+        assertThat(escaped).isEqualTo("\"a\"\"b\"");
+    }
+}

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminEventApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminEventApiTest.java
@@ -292,6 +292,31 @@ class AdminEventApiTest {
     }
 
     @Test
+    void syncCsvExportSanitizesSpreadsheetFormulaCells() throws Exception {
+        Instant now = Instant.now();
+        saveEvent(
+            UUID.randomUUID(),
+            userAId,
+            EventType.HYMN_OPENED,
+            hymnAId,
+            PartType.ALL,
+            now.minus(1, ChronoUnit.MINUTES),
+            "=SUM(1,1)"
+        );
+
+        String csv = mockMvc.perform(get("/admin/events/export")
+                .header("Authorization", "Bearer " + adminToken)
+                .param("eventType", "HYMN_OPENED")
+                .param("limit", "10"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertThat(csv).contains("\"'=SUM(1,1)\"");
+    }
+
+    @Test
     void adminCanCreateAndDownloadAsyncExportJob() throws Exception {
         Instant now = Instant.now();
         saveEvent(UUID.randomUUID(), userAId, EventType.HYMN_OPENED, hymnAId, PartType.ALL, now.minus(2, ChronoUnit.MINUTES));
@@ -327,6 +352,42 @@ class AdminEventApiTest {
         assertThat(csv).contains("id,userId,eventType,hymnId,part,metadataJson,createdAt");
         assertThat(csv).contains("HYMN_OPENED");
         assertThat(csv).doesNotContain("NOTE_SAVED");
+    }
+
+    @Test
+    void asyncCsvExportSanitizesSpreadsheetFormulaCells() throws Exception {
+        Instant now = Instant.now();
+        saveEvent(
+            UUID.randomUUID(),
+            userAId,
+            EventType.HYMN_OPENED,
+            hymnAId,
+            PartType.ALL,
+            now.minus(1, ChronoUnit.MINUTES),
+            "@SUM(1,1)"
+        );
+
+        String createResponse = mockMvc.perform(post("/admin/events/export-jobs")
+                .header("Authorization", "Bearer " + adminToken)
+                .param("eventType", "HYMN_OPENED")
+                .param("limit", "5000"))
+            .andExpect(status().isAccepted())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        UUID jobId = UUID.fromString(objectMapper.readTree(createResponse).get("data").get("id").asText());
+        JsonNode finalState = waitForJobCompletion(jobId, adminToken);
+        assertThat(finalState.get("status").asText()).isEqualTo("COMPLETED");
+
+        String csv = mockMvc.perform(get("/admin/events/export-jobs/{jobId}/download", jobId)
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertThat(csv).contains("\"'@SUM(1,1)\"");
     }
 
     @Test
@@ -508,13 +569,25 @@ class AdminEventApiTest {
         PartType part,
         Instant createdAt
     ) {
+        saveEvent(id, userId, type, hymnId, part, createdAt, "{\"source\":\"test\"}");
+    }
+
+    private void saveEvent(
+        UUID id,
+        UUID userId,
+        EventType type,
+        UUID hymnId,
+        PartType part,
+        Instant createdAt,
+        String metadataJson
+    ) {
         eventJpaRepository.save(new EventEntity(
             id,
             userId,
             type,
             hymnId,
             part,
-            "{\"source\":\"test\"}",
+            metadataJson,
             createdAt
         ));
     }

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -437,3 +437,34 @@
 ### 검증
 - `./gradlew.bat test --no-daemon --stacktrace` (`apps/api`)
 - `npm run build` (`apps/admin`)
+
+## 14. 이번 사이클 기록 (2026-02-14, 11차)
+
+### 목표
+- 보안 리스크 완화: CSV export 수식 주입(Spreadsheet Formula Injection) 방어
+
+### 범위
+- 포함: 백엔드 CSV 셀 이스케이프 공통화, 동기/비동기 경로 검증 테스트, 문서 동기화
+- 제외: 파일 포맷 변경(xlsx 전환), 외부 AV/콘텐츠 스캐너 연동
+
+### 수행 작업
+1. 공통 CSV 보안 유틸 도입
+- `CsvUtils.toSafeCsvCell(...)` 추가
+- 수식 시작 문자열(`=`, `+`, `-`, `@`) 및 선행 공백 우회 케이스를 방어하도록 prefix 처리
+
+2. 동기/비동기 export 적용
+- `AdminEventController` 동기 CSV 경로 적용
+- `AdminEventExportJobUseCase` 비동기 CSV 경로 적용
+
+3. 테스트 확장
+- `CsvUtilsTest` 신규
+- `AdminEventApiTest`에 동기/비동기 CSV 수식 이스케이프 통합 테스트 추가
+
+4. 문서 동기화
+- `docs/events.md`
+- `docs/changelog-dev.md`
+
+### 검증
+- `./gradlew.bat test --tests "com.eunhyehymn.common.util.CsvUtilsTest" --tests "com.eunhyehymn.presentation.controllers.AdminEventApiTest" --no-daemon --stacktrace` (`apps/api`)
+- `./gradlew.bat test --no-daemon --stacktrace` (`apps/api`)
+- `npm run build` (`apps/admin`)

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -222,6 +222,7 @@ Base URL: `/api/v1`
 - `GET /admin/events/export` 응답:
   - `Content-Type: text/csv`
   - `Content-Disposition: attachment; filename="admin-events-*.csv"`
+  - 보안: CSV 셀 값이 수식(`=`, `+`, `-`, `@`)으로 시작하면 이스케이프 처리
 
 - `POST /admin/events/export-jobs` 응답 `data` 예시:
 ```json

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,16 @@
 
 ## 2026-02-14
 
+### CSV export 보안 하드닝(11차)
+- CSV 수식 주입 방어 추가
+  - 동기/비동기 CSV 내보내기 모두에서 수식 시작 문자열(`=`, `+`, `-`, `@`)을 이스케이프
+  - 공통 유틸 `CsvUtils.toSafeCsvCell(...)`로 통합 적용
+- 테스트 보강
+  - `CsvUtilsTest` 신규
+  - `AdminEventApiTest`에 동기/비동기 CSV 수식 주입 방어 통합 테스트 추가
+- 문서 동기화
+  - `docs/events.md` CSV 보안 정책 명시
+
 ### 비동기 export 안정화/운영 사이클(10차)
 - 내구성 복구 경로 추가
   - `EventExportJobRepository.claimQueued(...)` 도입으로 작업 실행 claim을 원자화

--- a/docs/events.md
+++ b/docs/events.md
@@ -62,6 +62,7 @@
 - 관리자 권한 필요
 - 필터: `eventType`, `userId`, `hymnId`, `from`, `to`
 - 제한: `limit` (서버 상한 적용)
+- 보안: CSV 셀 값이 스프레드시트 수식(`=`, `+`, `-`, `@`)으로 해석되지 않도록 이스케이프한다.
 
 ### 4.4 관리자 감사 로그 비동기 CSV (대용량)
 - `POST /api/v1/admin/events/export-jobs`
@@ -75,6 +76,7 @@
 - `GET /api/v1/admin/events/export-jobs/{jobId}/download`
   - 완료(`COMPLETED`) 작업 CSV 다운로드
   - 미완료/실패 작업은 `409` 반환
+  - 수식 셀 이스케이프 정책은 동기 CSV와 동일하게 적용한다.
 
 ### 4.5 비동기 export 결과 정리 정책
 - 완료(`COMPLETED`) 또는 실패(`FAILED`) 상태의 작업은 스케줄러가 주기적으로 정리한다.


### PR DESCRIPTION
## Summary
- add `CsvUtils.toSafeCsvCell` and apply it to sync/async CSV export paths
- escape formula-like cells (`=`, `+`, `-`, `@`) including leading-whitespace variants
- add integration tests for sync/async CSV formula sanitization and utility unit tests
- sync docs/work-cycle/changelog with CSV export security policy

## Verification
- `./gradlew.bat test --tests "com.eunhyehymn.common.util.CsvUtilsTest" --tests "com.eunhyehymn.presentation.controllers.AdminEventApiTest" --no-daemon --stacktrace` (apps/api)
- `./gradlew.bat test --no-daemon --stacktrace` (apps/api)
- `npm run build` (apps/admin)
