### PR TITLE
chore: ignore local temp and terraform plan artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ apps/api/bin/
 # Claude Code
 .claude/
 .codex/
+.tmp/
 
 # Local Flutter bootstrap artifacts
 tools/flutter/

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -494,3 +494,25 @@
 
 ### 검증
 - `rg -n "기준 커밋|근거 PR|PR #56|PR #55|PR #54|PR #53" docs/current-usable-scope.md`
+
+## 16. 이번 사이클 기록 (2026-02-14, 13차)
+
+### 목표
+- 작업 생산성 개선: 로컬 임시 아티팩트가 `git status`를 오염시키지 않도록 ignore 정리
+
+### 범위
+- 포함: `.tmp/`, `infra/aws/tfplan*` ignore 규칙 추가
+- 제외: 임시파일 실삭제, Terraform 실행 로직 변경
+
+### 수행 작업
+1. 루트 ignore 보강
+- `.gitignore`에 `.tmp/` 추가
+
+2. AWS 인프라 ignore 보강
+- `infra/aws/.gitignore`에 `tfplan*` 추가
+
+3. 변경 이력 문서 동기화
+- `docs/changelog-dev.md` 업데이트
+
+### 검증
+- `git status -sb`에서 `.tmp/`, `infra/aws/tfplan*` 미노출 확인

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,13 @@
 
 ## 2026-02-14
 
+### 로컬 아티팩트 ignore 정리(13차)
+- 작업 트리 노이즈 제거
+  - 루트 `.gitignore`에 `.tmp/` 추가
+  - `infra/aws/.gitignore`에 `tfplan*` 추가
+- 효과
+  - 로컬 임시파일/terraform plan 파일이 기본 `git status` 결과를 오염시키지 않음
+
 ### 기준 범위 문서 최신화(12차)
 - `docs/current-usable-scope.md` 기준점 정합성 업데이트
   - 기준 커밋을 최신 `develop` HEAD(`5b08dc0`)로 갱신

--- a/infra/aws/.gitignore
+++ b/infra/aws/.gitignore
@@ -1,5 +1,6 @@
 *.tfstate
 *.tfstate.backup
+tfplan*
 .terraform/
 .terraform.lock.hcl
 terraform.tfvars


### PR DESCRIPTION
## Summary
- add `.tmp/` to root `.gitignore`
- add `tfplan*` to `infra/aws/.gitignore`
- record this cleanup cycle in `docs/changelog-dev.md` and `docs/WORK_CYCLE.md`

## Verification
- `git status -sb` shows no `.tmp/` or `infra/aws/tfplan*` noise
