### PR TITLE
fix: tolerate concurrent docker prune during deploy

### DIFF
--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -516,3 +516,28 @@
 
 ### 검증
 - `git status -sb`에서 `.tmp/`, `infra/aws/tfplan*` 미노출 확인
+
+## 17. 이번 사이클 기록 (2026-02-14, 14차)
+
+### 목표
+- 스테이징 배포 안정성 강화: `docker image prune` 동시 실행 충돌로 deploy 실패하는 케이스 차단
+
+### 범위
+- 포함: `infra/aws/deploy.sh` cleanup 단계 재시도/경고 처리
+- 제외: Docker prune 정책 자체 변경, ECR lifecycle 설정 변경
+
+### 수행 작업
+1. prune cleanup 함수화
+- `cleanup_unused_images` 함수 추가
+- `docker image prune -f`를 함수 호출로 대체
+
+2. 경합 에러 하드닝
+- `prune operation is already running` 감지 시 5초 간격 최대 3회 재시도
+- 재시도 후에도 경합이면 경고 출력 후 배포는 성공 처리
+- 기타 prune 오류도 경고로 기록하고 배포 진행(정리 단계 non-fatal)
+
+3. 변경 이력 문서 동기화
+- `docs/changelog-dev.md` 업데이트
+
+### 검증
+- `bash -n infra/aws/deploy.sh`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,14 @@
 
 ## 2026-02-14
 
+### 스테이징 deploy prune 경합 하드닝(14차)
+- `infra/aws/deploy.sh` 개선
+  - `docker image prune -f`를 `cleanup_unused_images` 함수로 감쌈
+  - `prune operation is already running` 오류 시 재시도(최대 3회) 후 경고 처리
+  - prune 실패를 배포 실패로 전파하지 않도록 non-fatal 처리
+- 효과
+  - 배포 완료 후 이미지 정리 단계의 일시적 경합으로 전체 deploy job이 실패하지 않음
+
 ### 로컬 아티팩트 ignore 정리(13차)
 - 작업 트리 노이즈 제거
   - 루트 `.gitignore`에 `.tmp/` 추가

--- a/infra/aws/deploy.sh
+++ b/infra/aws/deploy.sh
@@ -30,6 +30,39 @@ is_true() {
   esac
 }
 
+cleanup_unused_images() {
+  local max_attempts=3
+  local attempt=1
+  local prune_output=""
+  local prune_exit=0
+
+  while [ "${attempt}" -le "${max_attempts}" ]; do
+    set +e
+    prune_output="$(docker image prune -f 2>&1)"
+    prune_exit=$?
+    set -e
+
+    if [ "${prune_exit}" -eq 0 ]; then
+      echo "${prune_output}"
+      return 0
+    fi
+
+    if echo "${prune_output}" | grep -qi "prune operation is already running"; then
+      echo "WARNING: docker image prune is already running (attempt ${attempt}/${max_attempts}); retrying..."
+      attempt=$((attempt + 1))
+      sleep 5
+      continue
+    fi
+
+    echo "WARNING: docker image prune failed but deployment will continue."
+    echo "${prune_output}"
+    return 0
+  done
+
+  echo "WARNING: docker image prune skipped after concurrent prune retries."
+  return 0
+}
+
 has_awslogs_driver() {
   docker info --format '{{range .Plugins.Log}}{{println .}}{{end}}' 2>/dev/null | grep -qx 'awslogs'
 }
@@ -89,7 +122,7 @@ fi
 
 # ── 4. Cleanup old images ───────────────────────────────────
 echo "[4/4] Cleaning up unused images..."
-docker image prune -f
+cleanup_unused_images
 
 echo "=== Deploy complete ==="
 docker compose "${COMPOSE_ARGS[@]}" ps


### PR DESCRIPTION
## Summary
- harden `infra/aws/deploy.sh` image cleanup to tolerate concurrent docker prune operations
- add retry loop (max 3, 5s interval) when prune is already running
- make prune cleanup non-fatal so deploy success is not blocked by transient cleanup contention
- sync cycle/changelog docs

## Verification
- `bash -n infra/aws/deploy.sh`
