### PR TITLE
fix: serialize staging deploy job concurrency

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -123,6 +123,9 @@ jobs:
   deploy:
     needs: build-and-push
     runs-on: ubuntu-latest
+    concurrency:
+      group: staging-ec2-deploy
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -541,3 +541,23 @@
 
 ### 검증
 - `bash -n infra/aws/deploy.sh`
+
+## 18. 이번 사이클 기록 (2026-02-14, 15차)
+
+### 목표
+- 스테이징 배포 안정성 강화: 동일 EC2 대상 deploy job 동시 실행 차단
+
+### 범위
+- 포함: `deploy-staging.yml`에 deploy job concurrency 제어 추가
+- 제외: deploy 스크립트 로직 변경, 인프라 리소스 변경
+
+### 수행 작업
+1. deploy job 직렬화
+- `deploy` job에 concurrency group(`staging-ec2-deploy`) 추가
+- `cancel-in-progress: false`로 설정해 진행 중 배포를 중단하지 않고 대기 처리
+
+2. 변경 이력 문서 동기화
+- `docs/changelog-dev.md` 업데이트
+
+### 검증
+- `gh workflow view deploy-staging.yml --yaml`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,13 @@
 
 ## 2026-02-14
 
+### 스테이징 deploy 직렬화 가드(15차)
+- `deploy-staging.yml` 개선
+  - `deploy` job에 GitHub Actions concurrency group(`staging-ec2-deploy`) 추가
+  - `cancel-in-progress: false`로 설정해 동시 배포를 취소 대신 직렬 대기
+- 효과
+  - 동일 EC2 대상 deploy job이 겹쳐 실행되지 않아 compose/prune 경합 가능성을 사전에 차단
+
 ### 스테이징 deploy prune 경합 하드닝(14차)
 - `infra/aws/deploy.sh` 개선
   - `docker image prune -f`를 `cleanup_unused_images` 함수로 감쌈


### PR DESCRIPTION
﻿## 변경 요약
- `deploy-staging.yml`의 `deploy` job에 concurrency group(`staging-ec2-deploy`)을 추가했습니다.
- `cancel-in-progress: false`로 설정해, 진행 중 배포를 취소하지 않고 후속 배포를 대기시킵니다.
- 동일 EC2 대상 동시 배포로 발생하던 compose/prune 경합 가능성을 workflow 레벨에서 줄였습니다.

## 검증
- `git diff`로 workflow 문법 변경 범위를 확인했습니다.
- 문서 동기화: `docs/changelog-dev.md`, `docs/WORK_CYCLE.md`

## 리스크
- deploy job이 직렬화되므로, `develop`에 push가 매우 빈번한 시간대에는 배포 대기 시간이 길어질 수 있습니다.
