### PR TITLE
ci: add workflow lint for actions and deploy script

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -105,9 +105,9 @@ jobs:
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t ${ECR_REGISTRY}/eunhye-hymn/api:${IMAGE_TAG} -t ${ECR_REGISTRY}/eunhye-hymn/api:latest .
-          docker push ${ECR_REGISTRY}/eunhye-hymn/api:${IMAGE_TAG}
-          docker push ${ECR_REGISTRY}/eunhye-hymn/api:latest
+          docker build -t "${ECR_REGISTRY}/eunhye-hymn/api:${IMAGE_TAG}" -t "${ECR_REGISTRY}/eunhye-hymn/api:latest" .
+          docker push "${ECR_REGISTRY}/eunhye-hymn/api:${IMAGE_TAG}"
+          docker push "${ECR_REGISTRY}/eunhye-hymn/api:latest"
 
       - name: Build and push Admin image
         working-directory: apps/admin
@@ -115,9 +115,9 @@ jobs:
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t ${ECR_REGISTRY}/eunhye-hymn/admin:${IMAGE_TAG} -t ${ECR_REGISTRY}/eunhye-hymn/admin:latest .
-          docker push ${ECR_REGISTRY}/eunhye-hymn/admin:${IMAGE_TAG}
-          docker push ${ECR_REGISTRY}/eunhye-hymn/admin:latest
+          docker build -t "${ECR_REGISTRY}/eunhye-hymn/admin:${IMAGE_TAG}" -t "${ECR_REGISTRY}/eunhye-hymn/admin:latest" .
+          docker push "${ECR_REGISTRY}/eunhye-hymn/admin:${IMAGE_TAG}"
+          docker push "${ECR_REGISTRY}/eunhye-hymn/admin:latest"
 
   # ── 4. Deploy to EC2 ─────────────────────────────────────────
   deploy:

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,28 @@
+name: Workflow Lint
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - "infra/aws/deploy.sh"
+  push:
+    branches:
+      - develop
+    paths:
+      - ".github/workflows/**"
+      - "infra/aws/deploy.sh"
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint GitHub Actions workflows
+        uses: rhysd/actionlint@v1
+
+  deploy-script-syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate deploy script syntax
+        run: bash -n infra/aws/deploy.sh

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Lint GitHub Actions workflows
-        uses: rhysd/actionlint@v1
+        uses: rhysd/actionlint@v1.7.10
 
   deploy-script-syntax:
     runs-on: ubuntu-latest

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -585,4 +585,4 @@
 - `docs/changelog-dev.md` 업데이트
 
 ### 검증
-- `gh workflow view workflow-lint.yml --ref ci/workflow-lint --yaml`
+- `gh api repos/V4N1LLA/Eunhye_Hymn/contents/.github/workflows/workflow-lint.yml?ref=ci/workflow-lint --jq .sha`

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -576,6 +576,7 @@
 - `.github/workflows/workflow-lint.yml` 신규 추가
 - `rhysd/actionlint`로 GitHub Actions YAML/표현식 lint 수행
 - `bash -n infra/aws/deploy.sh`로 배포 스크립트 문법 검증 수행
+- lint 기준을 통과하도록 `deploy-staging.yml`의 Docker build/push 태그 변수를 quote 처리(SC2086 대응)
 
 2. 트리거 경로 최적화
 - `.github/workflows/**` 또는 `infra/aws/deploy.sh` 변경 시에만 실행되도록 path filter 적용

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -561,3 +561,27 @@
 
 ### 검증
 - `gh workflow view deploy-staging.yml --yaml`
+
+## 19. 이번 사이클 기록 (2026-02-14, 16차)
+
+### 목표
+- CI 누락 방지: workflow/배포 스크립트 변경에도 자동 검증이 항상 실행되도록 보강
+
+### 범위
+- 포함: workflow lint 파이프라인 추가, 문서 동기화
+- 제외: 애플리케이션 기능 코드 변경
+
+### 수행 작업
+1. workflow lint 파이프라인 추가
+- `.github/workflows/workflow-lint.yml` 신규 추가
+- `rhysd/actionlint`로 GitHub Actions YAML/표현식 lint 수행
+- `bash -n infra/aws/deploy.sh`로 배포 스크립트 문법 검증 수행
+
+2. 트리거 경로 최적화
+- `.github/workflows/**` 또는 `infra/aws/deploy.sh` 변경 시에만 실행되도록 path filter 적용
+
+3. 변경 이력 문서 동기화
+- `docs/changelog-dev.md` 업데이트
+
+### 검증
+- `gh workflow view workflow-lint.yml --ref ci/workflow-lint --yaml`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,15 @@
 
 ## 2026-02-14
 
+### CI workflow lint 추가(16차)
+- 신규 워크플로: `.github/workflows/workflow-lint.yml`
+  - `rhysd/actionlint`로 GitHub Actions workflow 정적 검증
+  - `bash -n infra/aws/deploy.sh`로 배포 스크립트 문법 검증
+- 트리거 범위
+  - `pull_request`/`push(develop)`에서 `.github/workflows/**`, `infra/aws/deploy.sh` 변경 시 실행
+- 효과
+  - workflow/배포 스크립트 변경이 API/Admin 경로 필터에 가려 검증 누락되는 리스크를 감소
+
 ### 스테이징 deploy 직렬화 가드(15차)
 - `deploy-staging.yml` 개선
   - `deploy` job에 GitHub Actions concurrency group(`staging-ec2-deploy`) 추가

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -8,6 +8,8 @@
 - 신규 워크플로: `.github/workflows/workflow-lint.yml`
   - `rhysd/actionlint`로 GitHub Actions workflow 정적 검증
   - `bash -n infra/aws/deploy.sh`로 배포 스크립트 문법 검증
+- lint 기준 반영
+  - `deploy-staging.yml`의 Docker build/push 명령에서 이미지 태그 변수를 quote 처리(SC2086 대응)
 - 트리거 범위
   - `pull_request`/`push(develop)`에서 `.github/workflows/**`, `infra/aws/deploy.sh` 변경 시 실행
 - 효과


### PR DESCRIPTION
﻿## 변경 요약
- 신규 워크플로 `.github/workflows/workflow-lint.yml`를 추가했습니다.
- `rhysd/actionlint@v1`로 GitHub Actions workflow 정적 검증을 수행합니다.
- `bash -n infra/aws/deploy.sh` 단계로 배포 스크립트 문법 검증을 추가했습니다.
- path filter를 적용해 `.github/workflows/**`, `infra/aws/deploy.sh` 변경 시에만 실행되도록 했습니다.

## 검증
- `gh api repos/V4N1LLA/Eunhye_Hymn/contents/.github/workflows/workflow-lint.yml?ref=ci/workflow-lint --jq .sha`
- 문서 동기화: `docs/changelog-dev.md`, `docs/WORK_CYCLE.md`

## 리스크
- 새 CI job 추가로 해당 경로 변경 PR의 체크 시간이 소폭 증가합니다.
