### PR TITLE
ci: harden staging deploy verification checks

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -170,6 +170,59 @@ jobs:
 
       - name: Verify deployment
         run: |
+          set -euo pipefail
+
+          host="${{ secrets.EC2_HOST }}"
+
+          check_ping() {
+            local url="$1"
+            local max_attempts="$2"
+            local sleep_seconds="$3"
+            local attempt
+            local body
+
+            for attempt in $(seq 1 "${max_attempts}"); do
+              body="$(curl -fsS "${url}" 2>/dev/null || true)"
+              if printf "%s" "${body}" | grep -Eq '"ok"[[:space:]]*:[[:space:]]*true'; then
+                echo "Ping check passed on attempt ${attempt}"
+                return 0
+              fi
+              echo "Ping check attempt ${attempt}/${max_attempts} failed; retrying in ${sleep_seconds}s"
+              sleep "${sleep_seconds}"
+            done
+
+            echo "::error::Ping check failed after ${max_attempts} attempts (${url})"
+            return 1
+          }
+
+          check_http_status() {
+            local name="$1"
+            local url="$2"
+            local max_attempts="$3"
+            local sleep_seconds="$4"
+            local attempt
+            local code
+
+            for attempt in $(seq 1 "${max_attempts}"); do
+              code="$(curl -s -o /dev/null -w '%{http_code}' "${url}" || true)"
+              if [[ "$name" == "admin-root" && ( "${code}" == "200" || "${code}" == "301" || "${code}" == "302" ) ]]; then
+                echo "${name} check passed with HTTP ${code} on attempt ${attempt}"
+                return 0
+              fi
+              if [[ "$name" == "admin-auth-guard" && ( "${code}" == "401" || "${code}" == "403" ) ]]; then
+                echo "${name} check passed with HTTP ${code} on attempt ${attempt}"
+                return 0
+              fi
+              echo "${name} check attempt ${attempt}/${max_attempts} returned HTTP ${code}; retrying in ${sleep_seconds}s"
+              sleep "${sleep_seconds}"
+            done
+
+            echo "::error::${name} check failed after ${max_attempts} attempts (${url})"
+            return 1
+          }
+
           echo "Waiting for services to start..."
           sleep 30
-          curl -sf http://${{ secrets.EC2_HOST }}/api/v1/ping || echo "WARNING: Health check failed (services may still be starting)"
+          check_ping "http://${host}/api/v1/ping" 10 6
+          check_http_status "admin-root" "http://${host}/" 5 4
+          check_http_status "admin-auth-guard" "http://${host}/api/v1/admin/hymns" 5 4

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -586,3 +586,28 @@
 
 ### 검증
 - `gh api repos/V4N1LLA/Eunhye_Hymn/contents/.github/workflows/workflow-lint.yml?ref=ci/workflow-lint --jq .sha`
+
+## 20. 이번 사이클 기록 (2026-02-14, 17차)
+
+### 목표
+- 스테이징 실서비스 유사 검증 강화: 배포 완료 판정 조건을 헬스체크 단일 항목에서 핵심 경로 다중 항목으로 확장
+
+### 범위
+- 포함: `deploy-staging.yml` verify 단계 강화, 문서 동기화
+- 제외: 애플리케이션 기능 코드 변경
+
+### 수행 작업
+1. 배포 verify 단계 강화
+- `/api/v1/ping` 응답 본문 `"ok": true`를 재시도 기반으로 검증
+- Admin 루트(`/`)의 HTTP 200/301/302 응답 검증 추가
+- 보호 API(`/api/v1/admin/hymns`)가 비인증 상태에서 401/403을 반환하는지 검증 추가
+
+2. 실패 감지 정책 명확화
+- 각 검증 항목에 최대 시도 횟수/대기 간격을 부여해 일시적인 기동 지연은 허용
+- 재시도 소진 시 `::error::`로 명확히 실패 처리
+
+3. 변경 이력 문서 동기화
+- `docs/changelog-dev.md` 업데이트
+
+### 검증
+- `gh api repos/V4N1LLA/Eunhye_Hymn/contents/.github/workflows/deploy-staging.yml?ref=chore/staging-smoke-verify-steps --jq .sha`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,14 @@
 
 ## 2026-02-14
 
+### 스테이징 배포 검증 강화(17차)
+- `deploy-staging.yml`의 `Verify deployment` 단계 강화
+  - `/api/v1/ping` 응답 본문에서 `"ok": true`를 retry 기반으로 검증
+  - Admin 루트(`/`)의 HTTP 상태(200/301/302) 검증 추가
+  - 인증 보호 API(`/api/v1/admin/hymns`)가 401/403을 반환하는지 검증 추가
+- 효과
+  - 배포 완료 판정 시 헬스체크뿐 아니라 Admin 라우팅/인증 가드까지 자동 확인 가능
+
 ### CI workflow lint 추가(16차)
 - 신규 워크플로: `.github/workflows/workflow-lint.yml`
   - `rhysd/actionlint`로 GitHub Actions workflow 정적 검증


### PR DESCRIPTION
﻿## 변경 요약
- `deploy-staging.yml`의 `Verify deployment` 단계를 retry 기반 다중 검증으로 강화했습니다.
- API ping 본문에서 `"ok": true`를 확인하도록 변경했습니다.
- Admin 루트(`/`)의 HTTP 200/301/302 응답 검증을 추가했습니다.
- 보호 API(`/api/v1/admin/hymns`)가 비인증 상태에서 401/403을 반환하는지 검증을 추가했습니다.

## 검증
- 문서 동기화: `docs/changelog-dev.md`, `docs/WORK_CYCLE.md`
- 원격 반영 확인: `gh api repos/V4N1LLA/Eunhye_Hymn/contents/.github/workflows/deploy-staging.yml?ref=chore/staging-smoke-verify-steps --jq .sha`

## 리스크
- 서비스 기동 지연이 길어지면 deploy job이 실패할 수 있습니다. 이를 위해 ping 10회/6초, HTTP 검증 5회/4초 재시도를 적용했습니다.
