### PR TITLE
ci: verify staging container runtime states on deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -221,8 +221,42 @@ jobs:
             return 1
           }
 
+          check_container_state() {
+            local container_name="$1"
+            local expected_state="$2"
+            local max_attempts="$3"
+            local sleep_seconds="$4"
+            local attempt
+            local state
+
+            for attempt in $(seq 1 "${max_attempts}"); do
+              state="$(ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
+                "ec2-user@${host}" \
+                "docker inspect --format '{{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{end}}' '${container_name}'" \
+                2>/dev/null || true)"
+              state="$(printf '%s' "${state}" | xargs || true)"
+
+              if [[ "${expected_state}" == "running-healthy" && "${state}" == "running healthy" ]]; then
+                echo "${container_name} state check passed (${state}) on attempt ${attempt}"
+                return 0
+              fi
+              if [[ "${expected_state}" == "running" && "${state}" == running* ]]; then
+                echo "${container_name} state check passed (${state}) on attempt ${attempt}"
+                return 0
+              fi
+
+              echo "${container_name} state attempt ${attempt}/${max_attempts} returned '${state}'; retrying in ${sleep_seconds}s"
+              sleep "${sleep_seconds}"
+            done
+
+            echo "::error::${container_name} state check failed after ${max_attempts} attempts (expected=${expected_state}, last='${state}')"
+            return 1
+          }
+
           echo "Waiting for services to start..."
           sleep 30
           check_ping "http://${host}/api/v1/ping" 10 6
           check_http_status "admin-root" "http://${host}/" 5 4
           check_http_status "admin-auth-guard" "http://${host}/api/v1/admin/hymns" 5 4
+          check_container_state "eunhye-api" "running-healthy" 10 6
+          check_container_state "eunhye-nginx" "running" 5 4

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -611,3 +611,27 @@
 
 ### 검증
 - `gh api repos/V4N1LLA/Eunhye_Hymn/contents/.github/workflows/deploy-staging.yml?ref=chore/staging-smoke-verify-steps --jq .sha`
+
+## 21. 이번 사이클 기록 (2026-02-14, 18차)
+
+### 목표
+- 스테이징 배포 완료 기준 고도화: 외부 HTTP 응답뿐 아니라 EC2 컨테이너 런타임 상태까지 자동 검증
+
+### 범위
+- 포함: `deploy-staging.yml` verify 단계에 원격 컨테이너 상태 체크 추가, 문서 동기화
+- 제외: 애플리케이션 기능 코드 변경
+
+### 수행 작업
+1. 원격 컨테이너 상태 체크 추가
+- `ssh + docker inspect`로 `eunhye-api`가 `running healthy`인지 재시도 기반 검증
+- `eunhye-nginx`가 `running`인지 재시도 기반 검증
+
+2. 실패 신호 명확화
+- 상태 검증 재시도 소진 시 `::error::`로 즉시 실패 처리
+- 마지막 관측 상태를 로그에 남겨 장애 분석 단서 보강
+
+3. 변경 이력 문서 동기화
+- `docs/changelog-dev.md` 업데이트
+
+### 검증
+- `gh api repos/V4N1LLA/Eunhye_Hymn/contents/.github/workflows/deploy-staging.yml?ref=ci/staging-verify-container-health --jq .sha`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,14 @@
 
 ## 2026-02-14
 
+### 스테이징 컨테이너 상태 검증 추가(18차)
+- `deploy-staging.yml`의 `Verify deployment` 단계 보강
+  - EC2 원격에서 `docker inspect`로 `eunhye-api` 상태(`running healthy`) 검증 추가
+  - `eunhye-nginx` 상태(`running`) 검증 추가
+  - 재시도 소진 시 명시적으로 배포 실패 처리
+- 효과
+  - 외부 HTTP 체크뿐 아니라 실제 컨테이너 런타임 상태까지 포함한 배포 완료 판정 가능
+
 ### 스테이징 배포 검증 강화(17차)
 - `deploy-staging.yml`의 `Verify deployment` 단계 강화
   - `/api/v1/ping` 응답 본문에서 `"ok": true`를 retry 기반으로 검증


### PR DESCRIPTION
﻿## 변경 요약
- `deploy-staging.yml`의 `Verify deployment` 단계에 EC2 원격 컨테이너 상태 검증을 추가했습니다.
- `eunhye-api`가 `running healthy`인지 재시도 기반으로 확인합니다.
- `eunhye-nginx`가 `running`인지 재시도 기반으로 확인합니다.
- 재시도 소진 시 `::error::`로 명확히 실패 처리해 배포 성공 오판을 줄였습니다.

## 검증
- 문서 동기화: `docs/changelog-dev.md`, `docs/WORK_CYCLE.md`
- 원격 반영 확인: `gh api repos/V4N1LLA/Eunhye_Hymn/contents/.github/workflows/deploy-staging.yml?ref=ci/staging-verify-container-health --jq .sha`

## 리스크
- EC2 SSH 응답 지연 시 verify 단계 시간이 늘어날 수 있습니다(재시도 기반).
