### PR TITLE
ci: pin staging deploy to workflow sha images

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -157,12 +157,14 @@ jobs:
       - name: Run deploy script
         env:
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          IMAGE_TAG: ${{ github.sha }}
           ENABLE_AWSLOGS: ${{ github.event_name == 'workflow_dispatch' && inputs.enable_awslogs || secrets.ENABLE_AWSLOGS }}
         run: |
           ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
             ec2-user@${{ secrets.EC2_HOST }} \
             "cd /home/ec2-user/app && \
              export ECR_REGISTRY=${ECR_REGISTRY} && \
+             export IMAGE_TAG=${IMAGE_TAG} && \
              export AWS_REGION=${{ env.AWS_REGION }} && \
              export ENABLE_AWSLOGS=${ENABLE_AWSLOGS} && \
              chmod +x deploy.sh && \
@@ -173,6 +175,7 @@ jobs:
           set -euo pipefail
 
           host="${{ secrets.EC2_HOST }}"
+          image_tag="${{ github.sha }}"
 
           check_ping() {
             local url="$1"
@@ -253,6 +256,34 @@ jobs:
             return 1
           }
 
+          check_container_image_tag() {
+            local container_name="$1"
+            local expected_tag="$2"
+            local max_attempts="$3"
+            local sleep_seconds="$4"
+            local attempt
+            local image_ref
+
+            for attempt in $(seq 1 "${max_attempts}"); do
+              image_ref="$(ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
+                "ec2-user@${host}" \
+                "docker inspect --format '{{.Config.Image}}' '${container_name}'" \
+                2>/dev/null || true)"
+              image_ref="$(printf '%s' "${image_ref}" | xargs || true)"
+
+              if [[ "${image_ref}" == *":${expected_tag}" ]]; then
+                echo "${container_name} image check passed (${image_ref}) on attempt ${attempt}"
+                return 0
+              fi
+
+              echo "${container_name} image attempt ${attempt}/${max_attempts} returned '${image_ref}'; retrying in ${sleep_seconds}s"
+              sleep "${sleep_seconds}"
+            done
+
+            echo "::error::${container_name} image tag check failed after ${max_attempts} attempts (expected=:${expected_tag}, last='${image_ref}')"
+            return 1
+          }
+
           echo "Waiting for services to start..."
           sleep 30
           check_ping "http://${host}/api/v1/ping" 10 6
@@ -260,3 +291,5 @@ jobs:
           check_http_status "admin-auth-guard" "http://${host}/api/v1/admin/hymns" 5 4
           check_container_state "eunhye-api" "running-healthy" 10 6
           check_container_state "eunhye-nginx" "running" 5 4
+          check_container_image_tag "eunhye-api" "${image_tag}" 10 6
+          check_container_image_tag "eunhye-nginx" "${image_tag}" 5 4

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -635,3 +635,29 @@
 
 ### 검증
 - `gh api repos/V4N1LLA/Eunhye_Hymn/contents/.github/workflows/deploy-staging.yml?ref=ci/staging-verify-container-health --jq .sha`
+
+## 22. 이번 사이클 기록 (2026-02-14, 19차)
+
+### 목표
+- 스테이징 배포 재현성 강화: `latest` 의존도를 낮추고 워크플로우 SHA 이미지로 배포/검증 일치 보장
+
+### 범위
+- 포함: compose 이미지 태그 전략 변경, deploy/env 전달 보강, 배포 후 이미지 태그 검증 추가, 문서 동기화
+- 제외: 애플리케이션 기능 코드 변경
+
+### 수행 작업
+1. 이미지 태그 전략 전환
+- `infra/aws/docker-compose.prod.yml`의 API/Admin 이미지를 `${IMAGE_TAG:-latest}`로 변경
+
+2. 배포 파이프라인 연계
+- `deploy-staging.yml`에서 `IMAGE_TAG=${{ github.sha }}`를 deploy 스크립트에 전달
+- `infra/aws/deploy.sh`가 `IMAGE_TAG`를 기본값 `latest`로 처리하고 로그에 노출
+
+3. 배포 검증 강화
+- Verify 단계에서 `docker inspect`로 `eunhye-api`, `eunhye-nginx`의 실제 이미지 태그가 `github.sha`와 일치하는지 확인
+
+4. 변경 이력 문서 동기화
+- `docs/changelog-dev.md` 업데이트
+
+### 검증
+- `gh api repos/V4N1LLA/Eunhye_Hymn/contents/.github/workflows/deploy-staging.yml?ref=ci/staging-deploy-sha-tag --jq .sha`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,18 @@
 
 ## 2026-02-14
 
+### 스테이징 SHA 고정 배포(19차)
+- `docker-compose.prod.yml` 이미지 태그 전략 변경
+  - API/Admin 이미지를 `:latest` 고정 대신 `${IMAGE_TAG:-latest}`로 사용
+- `deploy-staging.yml` 배포 환경 변수 보강
+  - deploy 시 `IMAGE_TAG=${{ github.sha }}`를 EC2 deploy 스크립트로 전달
+- `deploy-staging.yml` 검증 보강
+  - 배포 후 `docker inspect`로 `eunhye-api`, `eunhye-nginx`의 실제 이미지 태그가 해당 SHA인지 확인
+- `infra/aws/deploy.sh` 출력/동작 정합성
+  - `IMAGE_TAG`를 기본값 `latest`로 지원하고, 배포 로그에 현재 태그를 명시
+- 효과
+  - 동시 push 상황에서도 스테이징이 항상 해당 워크플로우 SHA 이미지로 배포되어 재현성과 추적성이 향상
+
 ### 스테이징 컨테이너 상태 검증 추가(18차)
 - `deploy-staging.yml`의 `Verify deployment` 단계 보강
   - EC2 원격에서 `docker inspect`로 `eunhye-api` 상태(`running healthy`) 검증 추가

--- a/infra/aws/deploy.sh
+++ b/infra/aws/deploy.sh
@@ -18,6 +18,7 @@ if [ -z "${AWS_REGION:-}" ]; then
 fi
 
 ENABLE_AWSLOGS="${ENABLE_AWSLOGS:-false}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
 
 to_lower() {
   echo "$1" | tr '[:upper:]' '[:lower:]'
@@ -84,12 +85,13 @@ if is_true "${ENABLE_AWSLOGS}"; then
   fi
 fi
 
-export ECR_REGISTRY AWS_REGION ENABLE_AWSLOGS
+export ECR_REGISTRY AWS_REGION ENABLE_AWSLOGS IMAGE_TAG
 
 echo "=== Eunhye Hymn Deploy ==="
 echo "ECR Registry: ${ECR_REGISTRY}"
 echo "AWS Region:   ${AWS_REGION}"
 echo "AWS Logs:     ${ENABLE_AWSLOGS} (effective=${USE_AWSLOGS})"
+echo "Image Tag:    ${IMAGE_TAG}"
 
 # ── 1. ECR Login ─────────────────────────────────────────────
 echo "[1/4] Logging in to ECR..."
@@ -97,7 +99,7 @@ aws ecr get-login-password --region "${AWS_REGION}" | \
   docker login --username AWS --password-stdin "${ECR_REGISTRY}"
 
 # ── 2. Pull latest images ───────────────────────────────────
-echo "[2/4] Pulling latest images..."
+echo "[2/4] Pulling target images (tag=${IMAGE_TAG})..."
 docker compose "${COMPOSE_ARGS[@]}" pull
 
 # ── 3. Restart containers ───────────────────────────────────

--- a/infra/aws/docker-compose.prod.yml
+++ b/infra/aws/docker-compose.prod.yml
@@ -7,7 +7,7 @@ x-default-logging: &default-logging
 services:
   # ── Spring Boot API ──────────────────────────────────────────
   api:
-    image: ${ECR_REGISTRY}/eunhye-hymn/api:latest
+    image: ${ECR_REGISTRY}/eunhye-hymn/api:${IMAGE_TAG:-latest}
     container_name: eunhye-api
     restart: unless-stopped
     env_file: .env
@@ -23,7 +23,7 @@ services:
 
   # ── Nginx (Admin + API Proxy) ────────────────────────────────
   nginx:
-    image: ${ECR_REGISTRY}/eunhye-hymn/admin:latest
+    image: ${ECR_REGISTRY}/eunhye-hymn/admin:${IMAGE_TAG:-latest}
     container_name: eunhye-nginx
     restart: unless-stopped
     ports:


### PR DESCRIPTION
﻿## 변경 요약
- 스테이징 compose 이미지를 `latest` 고정 대신 `${IMAGE_TAG:-latest}`로 전환했습니다.
- `deploy-staging.yml`에서 `IMAGE_TAG=${{ github.sha }}`를 deploy 스크립트로 전달하도록 변경했습니다.
- deploy verify 단계에 컨테이너 실제 이미지 태그 검증(`docker inspect .Config.Image`)을 추가했습니다.
- `infra/aws/deploy.sh`가 `IMAGE_TAG`를 기본값 `latest`로 처리하고 로그에 출력하도록 보강했습니다.

## 검증
- `bash -n infra/aws/deploy.sh`
- `docker compose -f infra/aws/docker-compose.prod.yml config` (임시 `.env`로 `IMAGE_TAG=abc123` 주입 확인)
- `rg -n "image:" .tmp/compose-config.txt` 결과:
  - `example.com/eunhye-hymn/api:abc123`
  - `example.com/eunhye-hymn/admin:abc123`
- 문서 동기화: `docs/changelog-dev.md`, `docs/WORK_CYCLE.md`

## 기대 효과
- 같은 시점에 여러 push가 발생해도, 각 deploy run이 자기 SHA 이미지로 배포되어 staging 재현성과 추적성이 올라갑니다.
