### PR TITLE
ci: extract staging verify script and harden deploy job

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -123,6 +123,7 @@ jobs:
   deploy:
     needs: build-and-push
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     concurrency:
       group: staging-ec2-deploy
       cancel-in-progress: false
@@ -135,6 +136,12 @@ jobs:
           echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H ${{ secrets.EC2_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Ensure remote app directory exists
+        run: |
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
+            ec2-user@${{ secrets.EC2_HOST }} \
+            "mkdir -p /home/ec2-user/app"
 
       - name: Copy compose file and deploy script to EC2
         run: |
@@ -171,125 +178,10 @@ jobs:
              ./deploy.sh"
 
       - name: Verify deployment
+        env:
+          STAGING_HOST: ${{ secrets.EC2_HOST }}
+          STAGING_SSH_KEY: ~/.ssh/deploy_key
+          EXPECTED_IMAGE_TAG: ${{ github.sha }}
         run: |
-          set -euo pipefail
-
-          host="${{ secrets.EC2_HOST }}"
-          image_tag="${{ github.sha }}"
-
-          check_ping() {
-            local url="$1"
-            local max_attempts="$2"
-            local sleep_seconds="$3"
-            local attempt
-            local body
-
-            for attempt in $(seq 1 "${max_attempts}"); do
-              body="$(curl -fsS "${url}" 2>/dev/null || true)"
-              if printf "%s" "${body}" | grep -Eq '"ok"[[:space:]]*:[[:space:]]*true'; then
-                echo "Ping check passed on attempt ${attempt}"
-                return 0
-              fi
-              echo "Ping check attempt ${attempt}/${max_attempts} failed; retrying in ${sleep_seconds}s"
-              sleep "${sleep_seconds}"
-            done
-
-            echo "::error::Ping check failed after ${max_attempts} attempts (${url})"
-            return 1
-          }
-
-          check_http_status() {
-            local name="$1"
-            local url="$2"
-            local max_attempts="$3"
-            local sleep_seconds="$4"
-            local attempt
-            local code
-
-            for attempt in $(seq 1 "${max_attempts}"); do
-              code="$(curl -s -o /dev/null -w '%{http_code}' "${url}" || true)"
-              if [[ "$name" == "admin-root" && ( "${code}" == "200" || "${code}" == "301" || "${code}" == "302" ) ]]; then
-                echo "${name} check passed with HTTP ${code} on attempt ${attempt}"
-                return 0
-              fi
-              if [[ "$name" == "admin-auth-guard" && ( "${code}" == "401" || "${code}" == "403" ) ]]; then
-                echo "${name} check passed with HTTP ${code} on attempt ${attempt}"
-                return 0
-              fi
-              echo "${name} check attempt ${attempt}/${max_attempts} returned HTTP ${code}; retrying in ${sleep_seconds}s"
-              sleep "${sleep_seconds}"
-            done
-
-            echo "::error::${name} check failed after ${max_attempts} attempts (${url})"
-            return 1
-          }
-
-          check_container_state() {
-            local container_name="$1"
-            local expected_state="$2"
-            local max_attempts="$3"
-            local sleep_seconds="$4"
-            local attempt
-            local state
-
-            for attempt in $(seq 1 "${max_attempts}"); do
-              state="$(ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
-                "ec2-user@${host}" \
-                "docker inspect --format '{{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{end}}' '${container_name}'" \
-                2>/dev/null || true)"
-              state="$(printf '%s' "${state}" | xargs || true)"
-
-              if [[ "${expected_state}" == "running-healthy" && "${state}" == "running healthy" ]]; then
-                echo "${container_name} state check passed (${state}) on attempt ${attempt}"
-                return 0
-              fi
-              if [[ "${expected_state}" == "running" && "${state}" == running* ]]; then
-                echo "${container_name} state check passed (${state}) on attempt ${attempt}"
-                return 0
-              fi
-
-              echo "${container_name} state attempt ${attempt}/${max_attempts} returned '${state}'; retrying in ${sleep_seconds}s"
-              sleep "${sleep_seconds}"
-            done
-
-            echo "::error::${container_name} state check failed after ${max_attempts} attempts (expected=${expected_state}, last='${state}')"
-            return 1
-          }
-
-          check_container_image_tag() {
-            local container_name="$1"
-            local expected_tag="$2"
-            local max_attempts="$3"
-            local sleep_seconds="$4"
-            local attempt
-            local image_ref
-
-            for attempt in $(seq 1 "${max_attempts}"); do
-              image_ref="$(ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
-                "ec2-user@${host}" \
-                "docker inspect --format '{{.Config.Image}}' '${container_name}'" \
-                2>/dev/null || true)"
-              image_ref="$(printf '%s' "${image_ref}" | xargs || true)"
-
-              if [[ "${image_ref}" == *":${expected_tag}" ]]; then
-                echo "${container_name} image check passed (${image_ref}) on attempt ${attempt}"
-                return 0
-              fi
-
-              echo "${container_name} image attempt ${attempt}/${max_attempts} returned '${image_ref}'; retrying in ${sleep_seconds}s"
-              sleep "${sleep_seconds}"
-            done
-
-            echo "::error::${container_name} image tag check failed after ${max_attempts} attempts (expected=:${expected_tag}, last='${image_ref}')"
-            return 1
-          }
-
-          echo "Waiting for services to start..."
-          sleep 30
-          check_ping "http://${host}/api/v1/ping" 10 6
-          check_http_status "admin-root" "http://${host}/" 5 4
-          check_http_status "admin-auth-guard" "http://${host}/api/v1/admin/hymns" 5 4
-          check_container_state "eunhye-api" "running-healthy" 10 6
-          check_container_state "eunhye-nginx" "running" 5 4
-          check_container_image_tag "eunhye-api" "${image_tag}" 10 6
-          check_container_image_tag "eunhye-nginx" "${image_tag}" 5 4
+          chmod +x infra/aws/verify-staging.sh
+          infra/aws/verify-staging.sh

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - ".github/workflows/**"
       - "infra/aws/deploy.sh"
+      - "infra/aws/verify-staging.sh"
   push:
     branches:
       - develop
     paths:
       - ".github/workflows/**"
       - "infra/aws/deploy.sh"
+      - "infra/aws/verify-staging.sh"
 
 jobs:
   actionlint:
@@ -25,4 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Validate deploy script syntax
-        run: bash -n infra/aws/deploy.sh
+        run: |
+          bash -n infra/aws/deploy.sh
+          bash -n infra/aws/verify-staging.sh

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -661,3 +661,33 @@
 
 ### 검증
 - `gh api repos/V4N1LLA/Eunhye_Hymn/contents/.github/workflows/deploy-staging.yml?ref=ci/staging-deploy-sha-tag --jq .sha`
+
+## 23. 이번 사이클 기록 (2026-02-14, 20차)
+
+### 목표
+- 스테이징 배포 검증 유지보수성 강화: workflow 인라인 검증 스크립트를 분리해 재사용성과 변경 안정성 확보
+
+### 범위
+- 포함: verify 스크립트 분리, deploy workflow 하드닝(타임아웃/원격 디렉터리 보장), workflow lint 대상 확장, 문서 동기화
+- 제외: 애플리케이션 기능 코드 변경, 배포 대상/인프라 리소스 변경
+
+### 수행 작업
+1. verify 단계 스크립트 분리
+- `infra/aws/verify-staging.sh` 신규 추가
+- 기존 `deploy-staging.yml` 인라인 함수(`check_ping`, `check_http_status`, `check_container_state`, `check_container_image_tag`)를 스크립트로 이관
+- 워크플로우는 `STAGING_HOST`, `STAGING_SSH_KEY`, `EXPECTED_IMAGE_TAG` 환경 변수로 스크립트를 실행하도록 변경
+
+2. deploy 단계 하드닝
+- `deploy` job에 `timeout-minutes: 30` 추가
+- 파일 전송 전에 `mkdir -p /home/ec2-user/app`를 수행해 원격 배포 디렉터리 부재로 인한 실패를 예방
+
+3. lint 검증 범위 확장
+- `.github/workflows/workflow-lint.yml` path filter에 `infra/aws/verify-staging.sh` 추가
+- `bash -n infra/aws/verify-staging.sh` 문법 검증 추가
+
+4. 변경 이력 문서 동기화
+- `docs/changelog-dev.md` 업데이트
+
+### 검증
+- `bash -n infra/aws/deploy.sh`
+- `bash -n infra/aws/verify-staging.sh`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,20 @@
 
 ## 2026-02-14
 
+### 스테이징 검증 스크립트 분리/하드닝(20차)
+- `deploy-staging.yml` 검증 단계 리팩토링
+  - 인라인 verify 로직을 `infra/aws/verify-staging.sh`로 분리
+  - 워크플로우는 `STAGING_HOST`, `STAGING_SSH_KEY`, `EXPECTED_IMAGE_TAG`를 주입해 스크립트를 호출
+- `deploy-staging.yml` 배포 안정성 보강
+  - `deploy` job에 `timeout-minutes: 30` 추가
+  - 배포 전 원격 `/home/ec2-user/app` 디렉터리를 `mkdir -p`로 보장
+- `workflow-lint.yml` 검증 범위 확장
+  - path filter에 `infra/aws/verify-staging.sh` 추가
+  - `bash -n infra/aws/verify-staging.sh` 문법 검증 추가
+- 효과
+  - 배포 검증 로직을 단일 스크립트로 재사용 가능하게 정리해 변경 추적성과 유지보수성을 높이고,
+    신규/재생성 EC2에서도 경로 누락으로 인한 배포 실패 가능성을 낮춤
+
 ### 스테이징 SHA 고정 배포(19차)
 - `docker-compose.prod.yml` 이미지 태그 전략 변경
   - API/Admin 이미지를 `:latest` 고정 대신 `${IMAGE_TAG:-latest}`로 사용

--- a/infra/aws/verify-staging.sh
+++ b/infra/aws/verify-staging.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_env() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "ERROR: ${name} is required"
+    exit 1
+  fi
+}
+
+trim_text() {
+  printf '%s' "$1" | xargs || true
+}
+
+remote_ssh() {
+  ssh -i "${STAGING_SSH_KEY}" -o StrictHostKeyChecking=no "ec2-user@${STAGING_HOST}" "$@"
+}
+
+check_ping() {
+  local url="$1"
+  local max_attempts="$2"
+  local sleep_seconds="$3"
+  local attempt
+  local body
+
+  for attempt in $(seq 1 "${max_attempts}"); do
+    body="$(curl -fsS "${url}" 2>/dev/null || true)"
+    if printf '%s' "${body}" | grep -Eq '"ok"[[:space:]]*:[[:space:]]*true'; then
+      echo "Ping check passed on attempt ${attempt}"
+      return 0
+    fi
+    echo "Ping check attempt ${attempt}/${max_attempts} failed; retrying in ${sleep_seconds}s"
+    sleep "${sleep_seconds}"
+  done
+
+  echo "::error::Ping check failed after ${max_attempts} attempts (${url})"
+  return 1
+}
+
+check_http_status() {
+  local name="$1"
+  local url="$2"
+  local allowed_codes_pattern="$3"
+  local max_attempts="$4"
+  local sleep_seconds="$5"
+  local attempt
+  local code
+
+  for attempt in $(seq 1 "${max_attempts}"); do
+    code="$(curl -s -o /dev/null -w '%{http_code}' "${url}" || true)"
+    if [[ "${code}" =~ ${allowed_codes_pattern} ]]; then
+      echo "${name} check passed with HTTP ${code} on attempt ${attempt}"
+      return 0
+    fi
+    echo "${name} check attempt ${attempt}/${max_attempts} returned HTTP ${code}; retrying in ${sleep_seconds}s"
+    sleep "${sleep_seconds}"
+  done
+
+  echo "::error::${name} check failed after ${max_attempts} attempts (${url})"
+  return 1
+}
+
+check_container_state() {
+  local container_name="$1"
+  local expected_state="$2"
+  local max_attempts="$3"
+  local sleep_seconds="$4"
+  local attempt
+  local state
+
+  for attempt in $(seq 1 "${max_attempts}"); do
+    state="$(remote_ssh "docker inspect --format '{{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{end}}' '${container_name}'" 2>/dev/null || true)"
+    state="$(trim_text "${state}")"
+
+    if [[ "${expected_state}" == "running-healthy" && "${state}" == "running healthy" ]]; then
+      echo "${container_name} state check passed (${state}) on attempt ${attempt}"
+      return 0
+    fi
+    if [[ "${expected_state}" == "running" && "${state}" == running* ]]; then
+      echo "${container_name} state check passed (${state}) on attempt ${attempt}"
+      return 0
+    fi
+
+    echo "${container_name} state attempt ${attempt}/${max_attempts} returned '${state}'; retrying in ${sleep_seconds}s"
+    sleep "${sleep_seconds}"
+  done
+
+  echo "::error::${container_name} state check failed after ${max_attempts} attempts (expected=${expected_state}, last='${state}')"
+  return 1
+}
+
+check_container_image_tag() {
+  local container_name="$1"
+  local expected_tag="$2"
+  local max_attempts="$3"
+  local sleep_seconds="$4"
+  local attempt
+  local image_ref
+
+  for attempt in $(seq 1 "${max_attempts}"); do
+    image_ref="$(remote_ssh "docker inspect --format '{{.Config.Image}}' '${container_name}'" 2>/dev/null || true)"
+    image_ref="$(trim_text "${image_ref}")"
+
+    if [[ "${image_ref}" == *":${expected_tag}" ]]; then
+      echo "${container_name} image check passed (${image_ref}) on attempt ${attempt}"
+      return 0
+    fi
+
+    echo "${container_name} image attempt ${attempt}/${max_attempts} returned '${image_ref}'; retrying in ${sleep_seconds}s"
+    sleep "${sleep_seconds}"
+  done
+
+  echo "::error::${container_name} image tag check failed after ${max_attempts} attempts (expected=:${expected_tag}, last='${image_ref}')"
+  return 1
+}
+
+main() {
+  require_env STAGING_HOST
+  require_env STAGING_SSH_KEY
+  require_env EXPECTED_IMAGE_TAG
+
+  local ping_url="${PING_URL:-http://${STAGING_HOST}/api/v1/ping}"
+  local admin_root_url="${ADMIN_ROOT_URL:-http://${STAGING_HOST}/}"
+  local admin_auth_guard_url="${ADMIN_AUTH_GUARD_URL:-http://${STAGING_HOST}/api/v1/admin/hymns}"
+
+  echo "Waiting for services to start..."
+  sleep 30
+
+  check_ping "${ping_url}" 10 6
+  check_http_status "admin-root" "${admin_root_url}" '^(200|301|302)$' 5 4
+  check_http_status "admin-auth-guard" "${admin_auth_guard_url}" '^(401|403)$' 5 4
+  check_container_state "eunhye-api" "running-healthy" 10 6
+  check_container_state "eunhye-nginx" "running" 5 4
+  check_container_image_tag "eunhye-api" "${EXPECTED_IMAGE_TAG}" 10 6
+  check_container_image_tag "eunhye-nginx" "${EXPECTED_IMAGE_TAG}" 5 4
+}
+
+main "$@"

--- a/infra/aws/verify-staging.sh
+++ b/infra/aws/verify-staging.sh
@@ -13,6 +13,15 @@ trim_text() {
   printf '%s' "$1" | xargs || true
 }
 
+expand_home_path() {
+  local path="$1"
+  if [[ "${path}" == "~/"* ]]; then
+    printf '%s/%s' "${HOME}" "${path#~/}"
+    return 0
+  fi
+  printf '%s' "${path}"
+}
+
 remote_ssh() {
   ssh -i "${STAGING_SSH_KEY}" -o StrictHostKeyChecking=no "ec2-user@${STAGING_HOST}" "$@"
 }
@@ -119,6 +128,12 @@ main() {
   require_env STAGING_HOST
   require_env STAGING_SSH_KEY
   require_env EXPECTED_IMAGE_TAG
+
+  STAGING_SSH_KEY="$(expand_home_path "${STAGING_SSH_KEY}")"
+  if [ ! -f "${STAGING_SSH_KEY}" ]; then
+    echo "ERROR: STAGING_SSH_KEY does not exist (${STAGING_SSH_KEY})"
+    exit 1
+  fi
 
   local ping_url="${PING_URL:-http://${STAGING_HOST}/api/v1/ping}"
   local admin_root_url="${ADMIN_ROOT_URL:-http://${STAGING_HOST}/}"


### PR DESCRIPTION
﻿## 요약
- deploy workflow의 인라인 검증 로직을 `infra/aws/verify-staging.sh`로 분리했습니다.
- deploy job에 타임아웃(30분)과 원격 app 디렉터리 사전 생성 단계를 추가했습니다.
- workflow lint가 새 검증 스크립트 변경도 감지하고 문법 검사하도록 확장했습니다.
- 변경 이력을 `docs/changelog-dev.md`, `docs/WORK_CYCLE.md`에 동기화했습니다.

## 검증
- `bash -n infra/aws/deploy.sh`
- `bash -n infra/aws/verify-staging.sh`

## 리스크/롤백
- 리스크: verify 스크립트 분리 과정에서 환경변수 주입이 누락되면 검증 단계가 즉시 실패할 수 있습니다.
- 대응: workflow의 `Verify deployment` 단계에서 필수 env(`STAGING_HOST`, `STAGING_SSH_KEY`, `EXPECTED_IMAGE_TAG`)를 명시 주입했습니다.
- 롤백: PR revert 시 이전 인라인 검증 로직으로 즉시 복귀 가능합니다.
