### PR TITLE
fix: restore staging verify ssh key path handling

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Verify deployment
         env:
           STAGING_HOST: ${{ secrets.EC2_HOST }}
-          STAGING_SSH_KEY: ~/.ssh/deploy_key
+          STAGING_SSH_KEY: /home/runner/.ssh/deploy_key
           EXPECTED_IMAGE_TAG: ${{ github.sha }}
         run: |
           chmod +x infra/aws/verify-staging.sh

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -691,3 +691,26 @@
 ### 검증
 - `bash -n infra/aws/deploy.sh`
 - `bash -n infra/aws/verify-staging.sh`
+
+## 24. 이번 사이클 기록 (2026-02-14, 21차)
+
+### 목표
+- 스테이징 배포 회귀 복구: verify 단계 SSH 키 경로 해석 오류로 인한 실패 제거
+
+### 범위
+- 포함: `verify-staging.sh` 경로 정규화 버그 수정, workflow verify env 경로 고정, 문서 동기화
+- 제외: 애플리케이션 기능 코드/배포 대상 인프라 변경
+
+### 수행 작업
+1. SSH 키 경로 정규화 버그 수정
+- `expand_home_path`에서 `~/` 처리 시 문자열 슬라이싱(`${path:2}`)을 사용하도록 변경
+- `~` 단일 값도 `${HOME}`으로 해석하도록 처리 추가
+
+2. workflow 경로 명시
+- `deploy-staging.yml` Verify 단계의 `STAGING_SSH_KEY`를 `/home/runner/.ssh/deploy_key` 절대 경로로 변경
+
+3. 문서 동기화
+- `docs/changelog-dev.md` 업데이트
+
+### 검증
+- `bash -n infra/aws/verify-staging.sh`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,15 @@
 
 ## 2026-02-14
 
+### 스테이징 verify SSH 키 경로 hotfix(21차)
+- `infra/aws/verify-staging.sh` 경로 정규화 수정
+  - `~`/`~/...` 입력을 `HOME` 기준 절대 경로로 정확히 치환하도록 `expand_home_path` 로직 보정
+  - 치환 후 키 파일 존재 여부 확인 로직은 유지
+- `deploy-staging.yml` verify 단계 환경 변수 수정
+  - `STAGING_SSH_KEY`를 `~/.ssh/deploy_key` 대신 `/home/runner/.ssh/deploy_key`로 명시
+- 효과
+  - verify 단계가 SSH 키 경로를 오인식해 즉시 실패하던 회귀를 제거하고, 배포 검증 단계 안정성을 복구
+
 ### 스테이징 검증 스크립트 분리/하드닝(20차)
 - `deploy-staging.yml` 검증 단계 리팩토링
   - 인라인 verify 로직을 `infra/aws/verify-staging.sh`로 분리

--- a/infra/aws/verify-staging.sh
+++ b/infra/aws/verify-staging.sh
@@ -15,8 +15,12 @@ trim_text() {
 
 expand_home_path() {
   local path="$1"
+  if [[ "${path}" == "~" ]]; then
+    printf '%s' "${HOME}"
+    return 0
+  fi
   if [[ "${path}" == "~/"* ]]; then
-    printf '%s/%s' "${HOME}" "${path#~/}"
+    printf '%s/%s' "${HOME}" "${path:2}"
     return 0
   fi
   printf '%s' "${path}"


### PR DESCRIPTION
﻿## 요약
- PR #65 머지 후 staging deploy의 Verify 단계가 SSH 키 경로 해석 오류로 실패한 회귀를 수정했습니다.
- `verify-staging.sh`의 `~/` 경로 치환 로직을 보정하고, `~` 단일 경로도 처리하도록 보강했습니다.
- workflow에서 `STAGING_SSH_KEY`를 절대경로(`/home/runner/.ssh/deploy_key`)로 명시했습니다.
- 변경 이력 문서를 동기화했습니다.

## 검증
- `bash -n infra/aws/verify-staging.sh`
- 실패 로그 확인: `gh run view 22015805871 --log-failed`

## 리스크
- 검증 로직 경로 처리 수정만 포함된 핫픽스로 기능/인프라 동작 변경은 없습니다.
