### PR TITLE
ci: unify api gradle cache strategy with setup-java

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -24,8 +24,10 @@ jobs:
         with:
           distribution: temurin
           java-version: "17"
-      - name: Gradle 캐시 설정
-        uses: gradle/actions/setup-gradle@v3
+          cache: gradle
+          cache-dependency-path: |
+            apps/api/**/*.gradle*
+            apps/api/**/gradle-wrapper.properties
       - name: Gradle Wrapper 실행 권한 부여
         run: chmod +x gradlew
       - name: 테스트 실행

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -60,7 +60,10 @@ jobs:
         with:
           distribution: temurin
           java-version: "17"
-      - uses: gradle/actions/setup-gradle@v3
+          cache: gradle
+          cache-dependency-path: |
+            apps/api/**/*.gradle*
+            apps/api/**/gradle-wrapper.properties
       - run: chmod +x gradlew
       - run: ./gradlew test --no-daemon --stacktrace
 

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -714,3 +714,28 @@
 
 ### 검증
 - `bash -n infra/aws/verify-staging.sh`
+
+## 25. 이번 사이클 기록 (2026-02-14, 22차)
+
+### 목표
+- API 테스트 캐시 안정화: Gradle 캐시 restore 400 경고 노이즈를 줄이고 워크플로우 간 캐시 설정 일관성 확보
+
+### 범위
+- 포함: `deploy-staging.yml`/`api-ci.yml`의 API 테스트 캐시 설정 통일, 문서 동기화
+- 제외: 애플리케이션 기능 코드 변경, 테스트 시나리오 변경
+
+### 수행 작업
+1. 배포 파이프라인 캐시 전략 변경
+- `deploy-staging.yml`의 `test-api` job에서 `gradle/actions/setup-gradle@v3` 제거
+- `actions/setup-java@v4`에 `cache: gradle` + `cache-dependency-path` 설정 추가
+
+2. API CI 캐시 전략 통일
+- `api-ci.yml`도 동일한 `setup-java` 내장 Gradle 캐시 방식으로 변경
+- `cache-dependency-path`를 `apps/api` Gradle 파일/Wrapper 기준으로 명시
+
+3. 변경 이력 문서 동기화
+- `docs/changelog-dev.md` 업데이트
+
+### 검증
+- `gh workflow view api-ci.yml --yaml`
+- `gh workflow view deploy-staging.yml --yaml`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,16 @@
 
 ## 2026-02-14
 
+### API Gradle 캐시 안정화(22차)
+- `deploy-staging.yml`의 API 테스트 단계 캐시 전략 변경
+  - `gradle/actions/setup-gradle@v3` 대신 `actions/setup-java@v4`의 `cache: gradle` 사용
+  - `cache-dependency-path`를 `apps/api` Gradle 파일/Wrapper 기준으로 명시
+- `api-ci.yml`의 API CI 테스트 단계 캐시 전략 동일화
+  - 배포 파이프라인과 동일하게 `setup-java` 내장 Gradle 캐시로 통일
+- 효과
+  - `setup-gradle` restore 시 간헐적으로 발생하던 캐시 400 경고 노이즈를 줄이고,
+    API 테스트 캐시 설정을 두 워크플로우에서 동일하게 유지
+
 ### 스테이징 verify SSH 키 경로 hotfix(21차)
 - `infra/aws/verify-staging.sh` 경로 정규화 수정
   - `~`/`~/...` 입력을 `HOME` 기준 절대 경로로 정확히 치환하도록 `expand_home_path` 로직 보정


### PR DESCRIPTION
﻿## 요약
- API 테스트 캐시를 `gradle/actions/setup-gradle`에서 `actions/setup-java` 내장 Gradle 캐시로 전환했습니다.
- `deploy-staging.yml`과 `api-ci.yml`의 캐시 전략을 동일하게 맞췄습니다.
- `cache-dependency-path`를 `apps/api` Gradle 파일 및 wrapper 파일 기준으로 명시했습니다.
- 변경 이력 문서를 동기화했습니다.

## 변경 이유
- 최근 staging deploy에서 `setup-gradle` 캐시 restore 과정에 간헐적 400 경고가 반복되어 로그 노이즈가 발생했습니다.
- 캐시 방식 일원화로 설정 복잡도를 낮추고, 동일 경로 기준 키 생성으로 추적성을 높입니다.

## 검증
- PR CI: `Workflow Lint` (`actionlint`, `deploy-script-syntax`) 통과 확인 예정
- post-merge: `Deploy Staging`에서 API 테스트/배포 완료 및 캐시 경고 여부 확인 예정
