### PR TITLE
ci: run api-ci on workflow changes and add concurrency

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -4,11 +4,17 @@ on:
   pull_request:
     paths:
       - "apps/api/**"
+      - ".github/workflows/api-ci.yml"
   push:
     branches:
       - develop
     paths:
       - "apps/api/**"
+      - ".github/workflows/api-ci.yml"
+
+concurrency:
+  group: api-ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -739,3 +739,27 @@
 ### 검증
 - `gh workflow view api-ci.yml --yaml`
 - `gh workflow view deploy-staging.yml --yaml`
+
+## 26. 이번 사이클 기록 (2026-02-14, 23차)
+
+### 목표
+- API CI 누락/중복 실행 최소화: 워크플로우 파일 변경 시 검증 누락을 막고 동일 브랜치 중복 실행을 제어
+
+### 범위
+- 포함: `api-ci.yml` path 트리거 보강, workflow-level concurrency 추가, 문서 동기화
+- 제외: API 테스트 명령/빌드 설정 변경
+
+### 수행 작업
+1. API CI 트리거 보강
+- `pull_request`/`push` path에 `.github/workflows/api-ci.yml` 추가
+- API CI 워크플로우 자체 수정 시에도 자동 검증되도록 보강
+
+2. API CI 동시성 제어 추가
+- `concurrency.group`을 `api-ci-${{ github.ref }}`로 설정
+- `cancel-in-progress: true`를 적용해 동일 브랜치의 이전 실행을 자동 취소
+
+3. 변경 이력 문서 동기화
+- `docs/changelog-dev.md` 업데이트
+
+### 검증
+- `gh workflow view api-ci.yml --yaml`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,16 @@
 
 ## 2026-02-14
 
+### API CI 트리거/동시성 정비(23차)
+- `api-ci.yml` 트리거 보강
+  - `apps/api/**` 변경 외에 `.github/workflows/api-ci.yml` 변경 시에도 API CI가 실행되도록 path 추가
+- `api-ci.yml` 동시성 제어 추가
+  - `concurrency.group: api-ci-${{ github.ref }}`
+  - `cancel-in-progress: true`로 동일 브랜치의 이전 API CI를 자동 취소
+- 효과
+  - API CI 워크플로우 자체 수정이 검증에서 누락되는 케이스를 차단하고,
+    연속 push 시 불필요한 중복 실행을 줄여 피드백 시간을 단축
+
 ### API Gradle 캐시 안정화(22차)
 - `deploy-staging.yml`의 API 테스트 단계 캐시 전략 변경
   - `gradle/actions/setup-gradle@v3` 대신 `actions/setup-java@v4`의 `cache: gradle` 사용


### PR DESCRIPTION
﻿## 요약
- `api-ci.yml`가 변경될 때도 API CI가 자동 실행되도록 path 트리거를 보강했습니다.
- API CI에 workflow-level `concurrency`를 추가해 동일 브랜치의 중복 실행을 자동 취소하도록 했습니다.
- 변경 이력 문서를 동기화했습니다.

## 기대 효과
- API CI 워크플로우 수정 PR에서도 실제 API 테스트가 함께 실행되어 검증 누락을 줄입니다.
- 연속 push 상황에서 오래된 API CI를 취소해 피드백 지연을 줄입니다.

## 검증
- PR CI: `Workflow Lint` 통과 확인
- PR CI: `API CI`가 워크플로우 파일 변경만으로도 실행되는지 확인
