### PR TITLE
feat: add staging latest deploy status checker script

### DIFF
--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -763,3 +763,31 @@
 
 ### 검증
 - `gh workflow view api-ci.yml --yaml`
+
+## 27. 이번 사이클 기록 (2026-02-14, 24차)
+
+### 목표
+- 스테이징 수동 검수 진입 판단 단순화: 최신 배포 run의 핵심 상태를 한 번에 확인하는 조회 스크립트 제공
+
+### 범위
+- 포함: `staging-latest-status.ps1` 신규, runbook/체크리스트/인프라 가이드 문서 반영
+- 제외: 배포 로직/애플리케이션 기능 코드 변경
+
+### 수행 작업
+1. 최신 배포 상태 조회 스크립트 추가
+- `scripts/staging-latest-status.ps1` 신규 추가
+- 최신 `deploy-staging.yml` run의 상태/결론/커밋/URL 및 job 요약 출력
+- `deploy` job의 `Verify deployment` step 결과를 별도 필드로 노출
+- `-RequireSuccess` 옵션으로 최신 run이 성공이 아니면 비정상 종료
+- `-AsJson` 옵션으로 자동화 소비 가능한 JSON 출력 지원
+
+2. 운영 문서 동기화
+- `docs/runbook.md` 배포 체크리스트/절차에 상태 확인 명령 추가
+- `docs/staging-smoke-checklist.md` 실행 전 준비 항목에 상태 확인 명령 추가
+- `infra/aws/README.md` 리허설 가이드 섹션에 상태 확인 명령 추가
+
+3. 변경 이력 문서 동기화
+- `docs/changelog-dev.md` 업데이트
+
+### 검증
+- `powershell -File scripts/staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Workflow deploy-staging.yml -AsJson -RequireSuccess`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,20 @@
 
 ## 2026-02-14
 
+### 스테이징 최신 상태 조회 스크립트 추가(24차)
+- 신규 스크립트: `scripts/staging-latest-status.ps1`
+  - 최신 `deploy-staging.yml` run의 상태/결론/커밋/URL 출력
+  - `deploy` job과 `Verify deployment` step 결론을 함께 요약
+  - `-RequireSuccess` 옵션으로 최신 run 성공 여부를 종료코드로 강제
+  - `-AsJson` 옵션으로 자동화 파이프라인에서 소비 가능한 JSON 출력 지원
+- 운영 문서 반영
+  - `docs/runbook.md`: 배포 체크리스트/절차에 상태 조회 명령 추가
+  - `docs/staging-smoke-checklist.md`: 실행 전 준비 항목에 상태 조회 명령 추가
+  - `infra/aws/README.md`: 리허설 가이드 섹션에 상태 조회 스크립트 추가
+- 효과
+  - 스모크 테스트 시작 전에 최신 배포의 성공 여부와 verify 통과 여부를 빠르게 확인할 수 있어
+    스테이징 수동 검수 진입 판단이 단순해짐
+
 ### API CI 트리거/동시성 정비(23차)
 - `api-ci.yml` 트리거 보강
   - `apps/api/**` 변경 외에 `.github/workflows/api-ci.yml` 변경 시에도 API CI가 실행되도록 path 추가

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -30,6 +30,7 @@
 - [ ] GitHub Actions 필수 Secrets 등록 확인
   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `ECR_REGISTRY`, `EC2_HOST`, `EC2_SSH_KEY`, `DEPLOY_ENV_FILE`
 - [ ] GitHub Actions 배포 워크플로 최신 성공 이력 확인
+  - `.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess`
 - [ ] 스모크 테스트 담당자/기기(Android/iOS/웹) 배정
 
 ## 5. 배포 절차
@@ -38,6 +39,7 @@
    - 운영 반영: `develop` push 트리거
    - 리허설/선검증: `Deploy Staging` workflow_dispatch (`enable_awslogs=false` 권장)
    - 자동화 경로: `.\scripts\staging-rehearsal.ps1` 실행 시 preflight + workflow_dispatch + run 완료 대기 + 로그 기록을 일괄 수행
+   - 최신 배포 상태 확인: `.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess`
 3. EC2에서 컨테이너 상태 확인
    - `docker ps`
    - `docker logs <api_container> --tail 200`

--- a/docs/staging-smoke-checklist.md
+++ b/docs/staging-smoke-checklist.md
@@ -7,6 +7,7 @@
 ## 1. 실행 전 준비
 
 - [ ] GitHub Actions 배포 워크플로가 정상 완료되었는지 확인
+  - `.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess`
 - [ ] 점검 대상 커밋 SHA/배포 시각/담당자 확정
 - [ ] 자동 리허설 로그(`docs/staging-rehearsal-log.md`) 최신 행 확인
 - [ ] 관리자 계정 및 모바일 테스트 계정 준비

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -153,6 +153,14 @@ Terraform 적용 후 아래 스크립트로 필수 Secrets를 한 번에 동기�
 
 로컬 문법/파라미터 검증만 필요하면 `-DryRun` 옵션을 사용한다.
 
+최신 배포 run 상태(특히 deploy/verify 성공 여부) 확인:
+
+```powershell
+.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess
+```
+
+JSON 출력이 필요하면 `-AsJson` 옵션을 사용한다.
+
 주의:
 - `-Ref`에는 branch/tag만 사용할 수 있다 (`workflow_dispatch` 제약).
 - 특정 커밋 SHA 기준 리허설이 필요하면 임시 브랜치를 만든 뒤 해당 브랜치명을 `-Ref`로 전달한다.

--- a/scripts/staging-latest-status.ps1
+++ b/scripts/staging-latest-status.ps1
@@ -1,0 +1,153 @@
+param(
+  [string]$Repo = "V4N1LLA/Eunhye_Hymn",
+  [string]$Workflow = "deploy-staging.yml",
+  [int]$Limit = 1,
+  [switch]$Wait,
+  [int]$WatchIntervalSeconds = 10,
+  [switch]$RequireSuccess,
+  [switch]$AsJson
+)
+
+$ErrorActionPreference = "Stop"
+
+function Test-CommandExists {
+  param([string]$Name)
+  return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Invoke-GhJson {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$Args
+  )
+
+  $output = & gh @Args
+  if ($LASTEXITCODE -ne 0) {
+    throw "gh command failed: gh $($Args -join ' ')"
+  }
+
+  if ([string]::IsNullOrWhiteSpace($output)) {
+    return $null
+  }
+
+  return ($output | ConvertFrom-Json)
+}
+
+function Get-DurationSeconds {
+  param(
+    [string]$StartedAt,
+    [string]$CompletedAt
+  )
+
+  if ([string]::IsNullOrWhiteSpace($StartedAt) -or [string]::IsNullOrWhiteSpace($CompletedAt)) {
+    return $null
+  }
+
+  $start = ([DateTime]$StartedAt).ToUniversalTime()
+  $end = ([DateTime]$CompletedAt).ToUniversalTime()
+  return [math]::Round(($end - $start).TotalSeconds, 1)
+}
+
+function Get-StepConclusion {
+  param(
+    [object]$Job,
+    [string]$StepName
+  )
+
+  if ($null -eq $Job -or $null -eq $Job.steps) {
+    return "-"
+  }
+
+  $step = $Job.steps | Where-Object { $_.name -eq $StepName } | Select-Object -First 1
+  if ($null -eq $step) {
+    return "-"
+  }
+
+  if ([string]::IsNullOrWhiteSpace($step.conclusion)) {
+    return $step.status
+  }
+
+  return $step.conclusion
+}
+
+if (-not (Test-CommandExists "gh")) {
+  throw "gh CLI is required."
+}
+
+if ($Limit -lt 1) {
+  throw "Limit must be >= 1"
+}
+
+$runs = Invoke-GhJson -Args @(
+  "run", "list",
+  "--repo", $Repo,
+  "--workflow", $Workflow,
+  "--limit", "$Limit",
+  "--json", "databaseId,workflowName,event,status,conclusion,createdAt,updatedAt,headBranch,headSha,url"
+)
+
+if ($null -eq $runs -or $runs.Count -eq 0) {
+  throw "No workflow runs found for $Repo / $Workflow"
+}
+
+$selectedRun = $runs[0]
+$runId = "$($selectedRun.databaseId)"
+
+if ($Wait -and $selectedRun.status -ne "completed") {
+  & gh run watch $runId --repo $Repo --interval $WatchIntervalSeconds --exit-status
+}
+
+$runView = Invoke-GhJson -Args @(
+  "run", "view", $runId,
+  "--repo", $Repo,
+  "--json", "databaseId,workflowName,event,status,conclusion,createdAt,updatedAt,headBranch,headSha,url,jobs"
+)
+
+$jobs = @($runView.jobs)
+$deployJob = $jobs | Where-Object { $_.name -eq "deploy" } | Select-Object -First 1
+$verifyStepConclusion = Get-StepConclusion -Job $deployJob -StepName "Verify deployment"
+$runDeployConclusion = if ($null -eq $deployJob) { "-" } else { $deployJob.conclusion }
+
+$jobTable = $jobs | ForEach-Object {
+  [PSCustomObject]@{
+    Job = $_.name
+    Status = $_.status
+    Conclusion = $_.conclusion
+    DurationSec = Get-DurationSeconds -StartedAt $_.startedAt -CompletedAt $_.completedAt
+  }
+}
+
+$summary = [PSCustomObject]@{
+  Repo = $Repo
+  Workflow = $runView.workflowName
+  RunId = $runView.databaseId
+  Event = $runView.event
+  Branch = $runView.headBranch
+  HeadSha = $runView.headSha
+  Status = $runView.status
+  Conclusion = $runView.conclusion
+  DeployJobConclusion = $runDeployConclusion
+  VerifyStepConclusion = $verifyStepConclusion
+  CreatedAtUtc = ([DateTime]$runView.createdAt).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+  UpdatedAtUtc = ([DateTime]$runView.updatedAt).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+  Url = $runView.url
+}
+
+if ($AsJson) {
+  [PSCustomObject]@{
+    summary = $summary
+    jobs = $jobTable
+  } | ConvertTo-Json -Depth 6
+} else {
+  Write-Host "== Latest Staging Deploy Run =="
+  $summary | Format-List
+  Write-Host ""
+  Write-Host "== Jobs =="
+  $jobTable | Format-Table -AutoSize
+}
+
+if ($RequireSuccess -and $runView.conclusion -ne "success") {
+  throw "Latest run is not successful (run_id=$runId, conclusion=$($runView.conclusion))"
+}
+
+exit 0


### PR DESCRIPTION
﻿## 요약
- 최신 `Deploy Staging` run 상태를 즉시 확인할 수 있는 스크립트 `scripts/staging-latest-status.ps1`를 추가했습니다.
- 스크립트는 run 요약(결론/커밋/URL)과 job별 상태, `Verify deployment` step 결과를 함께 출력합니다.
- `-RequireSuccess`(성공 강제), `-AsJson`(자동화용 JSON 출력), `-Wait`(진행 중 run 대기) 옵션을 지원합니다.
- runbook/smoke checklist/infra 가이드 문서에 새 스크립트 사용 절차를 반영했습니다.

## 검증
- `powershell -File scripts/staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Workflow deploy-staging.yml -AsJson -RequireSuccess`
- `rg -n "<<<<<<<|>>>>>>>" docs infra/aws scripts -S`

## 기대 효과
- 스테이징 수동 검수 시작 전에 최신 배포 run의 성공 여부와 verify 통과 여부를 한 번에 확인할 수 있어 운영 판단 속도가 빨라집니다.
