### PR TITLE
feat: add branch and event filters to staging status script

### DIFF
--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -791,3 +791,28 @@
 
 ### 검증
 - `powershell -File scripts/staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Workflow deploy-staging.yml -AsJson -RequireSuccess`
+
+## 28. 이번 사이클 기록 (2026-02-14, 25차)
+
+### 목표
+- 스테이징 상태 조회 정확도 향상: 배포(push)와 리허설(workflow_dispatch) run을 필터링 조회 가능하도록 스크립트 확장
+
+### 범위
+- 포함: `staging-latest-status.ps1` 옵션 확장(`-Branch`, `-Event`), 운영 문서 안내 보강
+- 제외: 배포 workflow 로직 변경, 애플리케이션 기능 코드 변경
+
+### 수행 작업
+1. 조회 옵션 확장
+- `scripts/staging-latest-status.ps1`에 `-Branch`(기본 `develop`) 옵션 추가
+- `scripts/staging-latest-status.ps1`에 `-Event` 옵션 추가
+- 내부 `gh run list` 호출 시 branch/event 필터를 선택적으로 적용하도록 개선
+
+2. 운영 문서 동기화
+- `docs/runbook.md`에 브랜치/이벤트 필터 옵션 안내 추가
+- `infra/aws/README.md`에 리허설 run 확인 시 `-Branch`, `-Event` 사용 가이드 추가
+
+3. 변경 이력 문서 동기화
+- `docs/changelog-dev.md` 업데이트
+
+### 검증
+- `powershell -File scripts/staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess -AsJson`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,17 @@
 
 ## 2026-02-14
 
+### 스테이징 상태 조회 스크립트 필터 확장(25차)
+- `scripts/staging-latest-status.ps1` 옵션 확장
+  - `-Branch`(기본 `develop`) 추가: 대상 브랜치 기준 최신 run 조회
+  - `-Event` 추가: `push`/`workflow_dispatch` 등 이벤트 유형 필터링 조회 지원
+- 운영 문서 반영
+  - `docs/runbook.md`: 브랜치/이벤트 필터 옵션 안내 추가
+  - `infra/aws/README.md`: 리허설 run 확인 시 `-Branch`, `-Event` 사용 가이드 추가
+- 효과
+  - 자동 배포(push)와 리허설(workflow_dispatch) run을 목적별로 분리 조회할 수 있어,
+    스테이징 상태 확인 결과의 맥락 혼동을 줄임
+
 ### 스테이징 최신 상태 조회 스크립트 추가(24차)
 - 신규 스크립트: `scripts/staging-latest-status.ps1`
   - 최신 `deploy-staging.yml` run의 상태/결론/커밋/URL 출력

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -31,6 +31,7 @@
   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `ECR_REGISTRY`, `EC2_HOST`, `EC2_SSH_KEY`, `DEPLOY_ENV_FILE`
 - [ ] GitHub Actions 배포 워크플로 최신 성공 이력 확인
   - `.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess`
+  - 리허설 run 확인이 필요하면 `-Branch <브랜치>` 또는 `-Event workflow_dispatch` 옵션 사용
 - [ ] 스모크 테스트 담당자/기기(Android/iOS/웹) 배정
 
 ## 5. 배포 절차

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -160,6 +160,7 @@ Terraform 적용 후 아래 스크립트로 필수 Secrets를 한 번에 동기�
 ```
 
 JSON 출력이 필요하면 `-AsJson` 옵션을 사용한다.
+리허설/수동 실행 내역 확인 시에는 `-Branch <branch>` 또는 `-Event workflow_dispatch` 옵션을 함께 사용한다.
 
 주의:
 - `-Ref`에는 branch/tag만 사용할 수 있다 (`workflow_dispatch` 제약).

--- a/scripts/staging-latest-status.ps1
+++ b/scripts/staging-latest-status.ps1
@@ -1,6 +1,8 @@
 param(
   [string]$Repo = "V4N1LLA/Eunhye_Hymn",
   [string]$Workflow = "deploy-staging.yml",
+  [string]$Branch = "develop",
+  [string]$Event = "",
   [int]$Limit = 1,
   [switch]$Wait,
   [int]$WatchIntervalSeconds = 10,
@@ -78,7 +80,7 @@ if ($Limit -lt 1) {
   throw "Limit must be >= 1"
 }
 
-$runs = Invoke-GhJson -Args @(
+$runListArgs = @(
   "run", "list",
   "--repo", $Repo,
   "--workflow", $Workflow,
@@ -86,8 +88,18 @@ $runs = Invoke-GhJson -Args @(
   "--json", "databaseId,workflowName,event,status,conclusion,createdAt,updatedAt,headBranch,headSha,url"
 )
 
+if (-not [string]::IsNullOrWhiteSpace($Branch)) {
+  $runListArgs += @("--branch", $Branch)
+}
+
+if (-not [string]::IsNullOrWhiteSpace($Event)) {
+  $runListArgs += @("--event", $Event)
+}
+
+$runs = Invoke-GhJson -Args $runListArgs
+
 if ($null -eq $runs -or $runs.Count -eq 0) {
-  throw "No workflow runs found for $Repo / $Workflow"
+  throw "No workflow runs found for $Repo / $Workflow (branch='$Branch', event='$Event')"
 }
 
 $selectedRun = $runs[0]


### PR DESCRIPTION
﻿## 요약
- `scripts/staging-latest-status.ps1`에 run 필터 옵션을 추가했습니다.
  - `-Branch` (기본: `develop`)
  - `-Event` (`push`, `workflow_dispatch` 등)
- 스크립트 내부 `gh run list` 호출에 선택적 branch/event 필터를 적용했습니다.
- runbook/infra 가이드 문서에 필터 옵션 사용법을 반영했습니다.

## 검증
- `powershell -File scripts/staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Event push -RequireSuccess`
- `powershell -File scripts/staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Event workflow_dispatch -AsJson`

## 기대 효과
- 자동 배포(push) run과 리허설(workflow_dispatch) run을 구분 조회할 수 있어 스테이징 상태 판단의 정확도가 높아집니다.
