### PR TITLE
feat: add markdown table output to staging status script

### DIFF
--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -816,3 +816,29 @@
 
 ### 검증
 - `powershell -File scripts/staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess -AsJson`
+
+## 29. 이번 사이클 기록 (2026-02-14, 26차)
+
+### 목표
+- 스테이징 점검 기록 작성 효율화: 최신 배포 상태를 문서/티켓에 바로 붙여넣을 수 있는 Markdown 출력 지원
+
+### 범위
+- 포함: `staging-latest-status.ps1`의 `-AsMarkdown` 출력 추가, 관련 운영 문서 옵션 안내 동기화
+- 제외: 배포 workflow 로직 변경, 애플리케이션 기능 변경
+
+### 수행 작업
+1. Markdown 출력 모드 추가
+- `scripts/staging-latest-status.ps1`에 `-AsMarkdown` 옵션 추가
+- run 요약 + job 상태를 Markdown 테이블로 출력하도록 구현
+- `-AsJson`/`-AsMarkdown` 동시 사용 시 충돌 에러 처리 추가
+
+2. 운영 문서 동기화
+- `docs/runbook.md`에 `-AsMarkdown` 사용 안내 추가
+- `docs/staging-smoke-checklist.md`에 기록용 표 출력 안내 추가
+- `infra/aws/README.md`에 Markdown 출력 옵션 안내 추가
+
+3. 변경 이력 문서 동기화
+- `docs/changelog-dev.md` 업데이트
+
+### 검증
+- `powershell -File scripts/staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Event push -RequireSuccess -AsMarkdown`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,18 @@
 
 ## 2026-02-14
 
+### 스테이징 상태 조회 스크립트 Markdown 출력 추가(26차)
+- `scripts/staging-latest-status.ps1` 옵션 확장
+  - `-AsMarkdown` 추가: run 요약 + job 상태를 Markdown 테이블 형태로 출력
+  - `-AsJson`과 동시 사용 시 오류 처리(출력 모드 충돌 방지)
+- 운영 문서 반영
+  - `docs/runbook.md`: `-AsMarkdown` 옵션 안내 추가
+  - `docs/staging-smoke-checklist.md`: 실행 전 준비 항목에 Markdown 출력 옵션 안내 추가
+  - `infra/aws/README.md`: 리허설 가이드에 Markdown 출력 옵션 안내 추가
+- 효과
+  - 스테이징 점검 결과를 문서/티켓에 붙여 넣을 때 형식 정리가 쉬워져
+    검수 기록 작성 시간을 줄임
+
 ### 스테이징 상태 조회 스크립트 필터 확장(25차)
 - `scripts/staging-latest-status.ps1` 옵션 확장
   - `-Branch`(기본 `develop`) 추가: 대상 브랜치 기준 최신 run 조회

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -32,6 +32,7 @@
 - [ ] GitHub Actions 배포 워크플로 최신 성공 이력 확인
   - `.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess`
   - 리허설 run 확인이 필요하면 `-Branch <브랜치>` 또는 `-Event workflow_dispatch` 옵션 사용
+  - 문서/티켓 기록용 표 출력은 `-AsMarkdown` 옵션 사용
 - [ ] 스모크 테스트 담당자/기기(Android/iOS/웹) 배정
 
 ## 5. 배포 절차

--- a/docs/staging-smoke-checklist.md
+++ b/docs/staging-smoke-checklist.md
@@ -8,6 +8,7 @@
 
 - [ ] GitHub Actions 배포 워크플로가 정상 완료되었는지 확인
   - `.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess`
+  - 기록용 표가 필요하면 `-AsMarkdown` 옵션 사용
 - [ ] 점검 대상 커밋 SHA/배포 시각/담당자 확정
 - [ ] 자동 리허설 로그(`docs/staging-rehearsal-log.md`) 최신 행 확인
 - [ ] 관리자 계정 및 모바일 테스트 계정 준비

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -161,6 +161,7 @@ Terraform 적용 후 아래 스크립트로 필수 Secrets를 한 번에 동기�
 
 JSON 출력이 필요하면 `-AsJson` 옵션을 사용한다.
 리허설/수동 실행 내역 확인 시에는 `-Branch <branch>` 또는 `-Event workflow_dispatch` 옵션을 함께 사용한다.
+문서/티켓 첨부용 표가 필요하면 `-AsMarkdown` 옵션을 사용한다.
 
 주의:
 - `-Ref`에는 branch/tag만 사용할 수 있다 (`workflow_dispatch` 제약).

--- a/scripts/staging-latest-status.ps1
+++ b/scripts/staging-latest-status.ps1
@@ -7,6 +7,7 @@ param(
   [switch]$Wait,
   [int]$WatchIntervalSeconds = 10,
   [switch]$RequireSuccess,
+  [switch]$AsMarkdown,
   [switch]$AsJson
 )
 
@@ -80,6 +81,13 @@ if ($Limit -lt 1) {
   throw "Limit must be >= 1"
 }
 
+$outputModeCount = 0
+if ($AsJson) { $outputModeCount++ }
+if ($AsMarkdown) { $outputModeCount++ }
+if ($outputModeCount -gt 1) {
+  throw "Use only one output mode: -AsJson or -AsMarkdown"
+}
+
 $runListArgs = @(
   "run", "list",
   "--repo", $Repo,
@@ -150,6 +158,16 @@ if ($AsJson) {
     summary = $summary
     jobs = $jobTable
   } | ConvertTo-Json -Depth 6
+} elseif ($AsMarkdown) {
+  Write-Output "| RunId | Event | Branch | HeadSha | Conclusion | Deploy | Verify | URL |"
+  Write-Output "|---|---|---|---|---|---|---|---|"
+  Write-Output "| $($summary.RunId) | $($summary.Event) | $($summary.Branch) | $($summary.HeadSha) | $($summary.Conclusion) | $($summary.DeployJobConclusion) | $($summary.VerifyStepConclusion) | $($summary.Url) |"
+  Write-Output ""
+  Write-Output "| Job | Status | Conclusion | DurationSec |"
+  Write-Output "|---|---|---|---|"
+  foreach ($job in $jobTable) {
+    Write-Output "| $($job.Job) | $($job.Status) | $($job.Conclusion) | $($job.DurationSec) |"
+  }
 } else {
   Write-Host "== Latest Staging Deploy Run =="
   $summary | Format-List


### PR DESCRIPTION
﻿## 요약
- `scripts/staging-latest-status.ps1`에 `-AsMarkdown` 옵션을 추가했습니다.
- 최신 run 요약과 job 상태를 Markdown 테이블로 출력해 문서/티켓에 바로 붙여넣기 가능하게 했습니다.
- 출력 모드 충돌 방지를 위해 `-AsJson`과 `-AsMarkdown` 동시 사용 시 에러 처리했습니다.
- runbook/smoke checklist/aws README에 새 옵션 안내를 반영했습니다.

## 검증
- `powershell -File scripts/staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Event push -RequireSuccess -AsMarkdown`
- `powershell -File scripts/staging-latest-status.ps1 -AsJson -AsMarkdown` (충돌 에러 확인)

## 기대 효과
- 스테이징 검수 결과 기록 정리 시간을 줄이고, 실행 증빙을 표준 형식으로 남기기 쉬워집니다.
