### PR TITLE
feat: harden staging status gate checks

### DIFF
--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -842,3 +842,31 @@
 
 ### 검증
 - `powershell -File scripts/staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Event push -RequireSuccess -AsMarkdown`
+
+## 30. 이번 사이클 기록 (2026-02-14, 27차)
+
+### 목표
+- 스테이징 수동 검수 진입 기준 강화: 최신 배포 run의 성공 여부뿐 아니라 deploy/verify 단계 성공과 실행 신선도까지 자동 게이트화
+
+### 범위
+- 포함: `staging-latest-status.ps1` 옵션 확장(`-RequireDeploySuccess`, `-RequireVerifySuccess`, `-MaxAgeMinutes`), 운영 문서 동기화
+- 제외: 배포 workflow 로직 변경, 애플리케이션 기능 코드 변경
+
+### 수행 작업
+1. 상태 확인 게이트 확장
+- `scripts/staging-latest-status.ps1`에 `-RequireDeploySuccess` 추가
+- `scripts/staging-latest-status.ps1`에 `-RequireVerifySuccess` 추가
+- `scripts/staging-latest-status.ps1`에 `-MaxAgeMinutes` 추가
+- run 요약에 `RunAgeMinutes` 필드 추가, Markdown 출력 테이블에 `AgeMin` 컬럼 추가
+
+2. 운영 문서 동기화
+- `docs/runbook.md`, `docs/staging-smoke-checklist.md`, `infra/aws/README.md`의 상태 확인 명령을 강화 옵션 기준으로 갱신
+- `-MaxAgeMinutes` 신선도 기준 사용 가이드 추가
+
+3. 변경 이력 문서 동기화
+- `docs/changelog-dev.md` 업데이트
+
+### 검증
+- `powershell -File scripts/staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Event push -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 120 -AsJson`
+- `powershell -File scripts/staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Event push -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 120 -AsMarkdown`
+- `powershell -File scripts/staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Event push -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 1 -AsJson` (expected non-zero exit)

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,18 @@
 
 ## 2026-02-14
 
+### 스테이징 상태 조회 스크립트 게이트 강화(27차)
+- `scripts/staging-latest-status.ps1` 옵션 확장
+  - `-RequireDeploySuccess` 추가: `deploy` job 결론이 `success`가 아니면 실패 처리
+  - `-RequireVerifySuccess` 추가: `Verify deployment` step 결론이 `success`가 아니면 실패 처리
+  - `-MaxAgeMinutes` 추가: 최신 run이 허용 시간보다 오래된 경우 실패 처리
+  - run 요약에 `RunAgeMinutes` 추가, Markdown 출력에 `AgeMin` 컬럼 추가
+- 운영 문서 반영
+  - `docs/runbook.md`, `docs/staging-smoke-checklist.md`, `infra/aws/README.md`에 강화된 상태 확인 명령 반영
+- 효과
+  - 스모크 테스트 진입 전에 "성공 여부 + 검증 단계 성공 + 실행 신선도"를 종료코드 기반으로 강제 가능
+  - 오래된 성공 run을 최신 상태로 오인해 검수를 진행하는 리스크 감소
+
 ### 스테이징 상태 조회 스크립트 Markdown 출력 추가(26차)
 - `scripts/staging-latest-status.ps1` 옵션 확장
   - `-AsMarkdown` 추가: run 요약 + job 상태를 Markdown 테이블 형태로 출력

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -30,7 +30,7 @@
 - [ ] GitHub Actions 필수 Secrets 등록 확인
   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `ECR_REGISTRY`, `EC2_HOST`, `EC2_SSH_KEY`, `DEPLOY_ENV_FILE`
 - [ ] GitHub Actions 배포 워크플로 최신 성공 이력 확인
-  - `.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess`
+  - `.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 120`
   - 리허설 run 확인이 필요하면 `-Branch <브랜치>` 또는 `-Event workflow_dispatch` 옵션 사용
   - 문서/티켓 기록용 표 출력은 `-AsMarkdown` 옵션 사용
 - [ ] 스모크 테스트 담당자/기기(Android/iOS/웹) 배정
@@ -41,7 +41,7 @@
    - 운영 반영: `develop` push 트리거
    - 리허설/선검증: `Deploy Staging` workflow_dispatch (`enable_awslogs=false` 권장)
    - 자동화 경로: `.\scripts\staging-rehearsal.ps1` 실행 시 preflight + workflow_dispatch + run 완료 대기 + 로그 기록을 일괄 수행
-   - 최신 배포 상태 확인: `.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess`
+   - 최신 배포 상태 확인: `.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 120`
 3. EC2에서 컨테이너 상태 확인
    - `docker ps`
    - `docker logs <api_container> --tail 200`

--- a/docs/staging-smoke-checklist.md
+++ b/docs/staging-smoke-checklist.md
@@ -7,7 +7,7 @@
 ## 1. 실행 전 준비
 
 - [ ] GitHub Actions 배포 워크플로가 정상 완료되었는지 확인
-  - `.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess`
+  - `.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 120`
   - 기록용 표가 필요하면 `-AsMarkdown` 옵션 사용
 - [ ] 점검 대상 커밋 SHA/배포 시각/담당자 확정
 - [ ] 자동 리허설 로그(`docs/staging-rehearsal-log.md`) 최신 행 확인

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -156,12 +156,13 @@ Terraform 적용 후 아래 스크립트로 필수 Secrets를 한 번에 동기�
 최신 배포 run 상태(특히 deploy/verify 성공 여부) 확인:
 
 ```powershell
-.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess
+.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 120
 ```
 
 JSON 출력이 필요하면 `-AsJson` 옵션을 사용한다.
 리허설/수동 실행 내역 확인 시에는 `-Branch <branch>` 또는 `-Event workflow_dispatch` 옵션을 함께 사용한다.
 문서/티켓 첨부용 표가 필요하면 `-AsMarkdown` 옵션을 사용한다.
+최신 성공 run이 오래되면 `-MaxAgeMinutes <minutes>` 값으로 스모크 진입 전 신선도 기준을 강제한다.
 
 주의:
 - `-Ref`에는 branch/tag만 사용할 수 있다 (`workflow_dispatch` 제약).

--- a/scripts/staging-latest-status.ps1
+++ b/scripts/staging-latest-status.ps1
@@ -6,7 +6,10 @@ param(
   [int]$Limit = 1,
   [switch]$Wait,
   [int]$WatchIntervalSeconds = 10,
+  [int]$MaxAgeMinutes = 0,
   [switch]$RequireSuccess,
+  [switch]$RequireDeploySuccess,
+  [switch]$RequireVerifySuccess,
   [switch]$AsMarkdown,
   [switch]$AsJson
 )
@@ -81,6 +84,10 @@ if ($Limit -lt 1) {
   throw "Limit must be >= 1"
 }
 
+if ($MaxAgeMinutes -lt 0) {
+  throw "MaxAgeMinutes must be >= 0"
+}
+
 $outputModeCount = 0
 if ($AsJson) { $outputModeCount++ }
 if ($AsMarkdown) { $outputModeCount++ }
@@ -127,6 +134,9 @@ $jobs = @($runView.jobs)
 $deployJob = $jobs | Where-Object { $_.name -eq "deploy" } | Select-Object -First 1
 $verifyStepConclusion = Get-StepConclusion -Job $deployJob -StepName "Verify deployment"
 $runDeployConclusion = if ($null -eq $deployJob) { "-" } else { $deployJob.conclusion }
+$createdAtUtc = ([DateTime]$runView.createdAt).ToUniversalTime()
+$updatedAtUtc = ([DateTime]$runView.updatedAt).ToUniversalTime()
+$runAgeMinutes = [math]::Round(((Get-Date).ToUniversalTime() - $createdAtUtc).TotalMinutes, 1)
 
 $jobTable = $jobs | ForEach-Object {
   [PSCustomObject]@{
@@ -148,8 +158,9 @@ $summary = [PSCustomObject]@{
   Conclusion = $runView.conclusion
   DeployJobConclusion = $runDeployConclusion
   VerifyStepConclusion = $verifyStepConclusion
-  CreatedAtUtc = ([DateTime]$runView.createdAt).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-  UpdatedAtUtc = ([DateTime]$runView.updatedAt).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+  RunAgeMinutes = $runAgeMinutes
+  CreatedAtUtc = $createdAtUtc.ToString("yyyy-MM-ddTHH:mm:ssZ")
+  UpdatedAtUtc = $updatedAtUtc.ToString("yyyy-MM-ddTHH:mm:ssZ")
   Url = $runView.url
 }
 
@@ -159,9 +170,9 @@ if ($AsJson) {
     jobs = $jobTable
   } | ConvertTo-Json -Depth 6
 } elseif ($AsMarkdown) {
-  Write-Output "| RunId | Event | Branch | HeadSha | Conclusion | Deploy | Verify | URL |"
-  Write-Output "|---|---|---|---|---|---|---|---|"
-  Write-Output "| $($summary.RunId) | $($summary.Event) | $($summary.Branch) | $($summary.HeadSha) | $($summary.Conclusion) | $($summary.DeployJobConclusion) | $($summary.VerifyStepConclusion) | $($summary.Url) |"
+  Write-Output "| RunId | Event | Branch | HeadSha | Conclusion | Deploy | Verify | AgeMin | URL |"
+  Write-Output "|---|---|---|---|---|---|---|---|---|"
+  Write-Output "| $($summary.RunId) | $($summary.Event) | $($summary.Branch) | $($summary.HeadSha) | $($summary.Conclusion) | $($summary.DeployJobConclusion) | $($summary.VerifyStepConclusion) | $($summary.RunAgeMinutes) | $($summary.Url) |"
   Write-Output ""
   Write-Output "| Job | Status | Conclusion | DurationSec |"
   Write-Output "|---|---|---|---|"
@@ -178,6 +189,18 @@ if ($AsJson) {
 
 if ($RequireSuccess -and $runView.conclusion -ne "success") {
   throw "Latest run is not successful (run_id=$runId, conclusion=$($runView.conclusion))"
+}
+
+if ($RequireDeploySuccess -and $runDeployConclusion -ne "success") {
+  throw "Deploy job did not succeed (run_id=$runId, deploy_conclusion=$runDeployConclusion)"
+}
+
+if ($RequireVerifySuccess -and $verifyStepConclusion -ne "success") {
+  throw "Verify deployment step did not succeed (run_id=$runId, verify_conclusion=$verifyStepConclusion)"
+}
+
+if ($MaxAgeMinutes -gt 0 -and $runAgeMinutes -gt $MaxAgeMinutes) {
+  throw "Latest run is too old (run_id=$runId, age_minutes=$runAgeMinutes, max_age_minutes=$MaxAgeMinutes)"
 }
 
 exit 0


### PR DESCRIPTION
## 요약
- `scripts/staging-latest-status.ps1`에 스테이징 진입 게이트를 확장했습니다.
  - `-RequireDeploySuccess`: deploy job 성공 강제
  - `-RequireVerifySuccess`: `Verify deployment` step 성공 강제
  - `-MaxAgeMinutes`: 최신 run 신선도(허용 최대 경과 시간) 강제
- 출력 요약에 `RunAgeMinutes`를 추가하고, Markdown 출력에 `AgeMin` 컬럼을 추가했습니다.
- 운영 문서의 상태 확인 명령을 강화 옵션 기준으로 동기화했습니다.
  - `docs/runbook.md`
  - `docs/staging-smoke-checklist.md`
  - `infra/aws/README.md`
  - `docs/changelog-dev.md`, `docs/WORK_CYCLE.md`

## 검증
- `powershell -NoProfile -File .\\scripts\\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Event push -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 120 -AsJson`
- `powershell -NoProfile -File .\\scripts\\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Event push -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 120 -AsMarkdown`
- `powershell -NoProfile -File .\\scripts\\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Event push -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 1 -AsJson` (expected non-zero exit)

## 리스크/롤백
- 변경 범위는 스크립트/문서만이며 배포 워크플로우 자체 로직은 변경하지 않았습니다.
- 이슈 시 `scripts/staging-latest-status.ps1`의 신규 옵션 미사용으로 기존 동작(`-RequireSuccess`)으로 즉시 우회 가능합니다.