### PR TITLE
fix(admin): clarify Kakao token input and hide dev login on staging

### DIFF
--- a/apps/admin/src/pages/LoginPage.tsx
+++ b/apps/admin/src/pages/LoginPage.tsx
@@ -4,40 +4,49 @@ import { useAuth } from "../auth/AuthContext";
 
 type SocialProvider = "GOOGLE" | "KAKAO";
 
+function isLocalDevHost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1";
+}
+
 export default function LoginPage() {
   const { login, loginWithSocial } = useAuth();
   const navigate = useNavigate();
+  const showDevLogin = isLocalDevHost(window.location.hostname);
 
-  // Social login state
   const [socialProvider, setSocialProvider] = useState<SocialProvider | null>(null);
   const [socialToken, setSocialToken] = useState("");
   const [inviteCode, setInviteCode] = useState("");
   const [needsInviteCode, setNeedsInviteCode] = useState(false);
 
-  // Dev login state
-  const [showDevLogin, setShowDevLogin] = useState(false);
+  const [showDevLoginForm, setShowDevLoginForm] = useState(false);
   const [displayName, setDisplayName] = useState("");
 
-  // Shared state
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  const socialTokenLabel = socialProvider === "KAKAO" ? "Access Token" : "ID Token";
+  const socialTokenPlaceholder =
+    socialProvider === "KAKAO" ? "Paste Kakao Access Token (without Bearer)" : "Paste Google ID Token";
+  const socialTokenGuide =
+    socialProvider === "KAKAO"
+      ? "Kakao login requires an Access Token. Do not paste an ID Token."
+      : "Google login requires an ID Token.";
 
   const handleSocialLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!socialProvider || !socialToken.trim()) return;
+
     setError(null);
     setLoading(true);
     try {
       await loginWithSocial(socialProvider, socialToken.trim(), inviteCode.trim() || undefined);
       navigate("/hymns", { replace: true });
     } catch (err) {
-      const message = err instanceof Error ? err.message : "로그인에 실패했습니다.";
+      const message = err instanceof Error ? err.message : "Login failed.";
       if (message.includes("초대코드")) {
         setNeedsInviteCode(true);
-        setError(message);
-      } else {
-        setError(message);
       }
+      setError(message);
     } finally {
       setLoading(false);
     }
@@ -46,9 +55,10 @@ export default function LoginPage() {
   const handleDevLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!displayName.trim()) {
-      setError("이름을 입력해 주세요.");
+      setError("Display name is required.");
       return;
     }
+
     setError(null);
     setLoading(true);
     try {
@@ -59,7 +69,7 @@ export default function LoginPage() {
       });
       navigate("/hymns", { replace: true });
     } catch (err) {
-      setError(err instanceof Error ? err.message : "로그인에 실패했습니다.");
+      setError(err instanceof Error ? err.message : "Login failed.");
     } finally {
       setLoading(false);
     }
@@ -80,7 +90,6 @@ export default function LoginPage() {
 
         {error && <p className="text-sm text-red-600 mb-4">{error}</p>}
 
-        {/* Social login buttons or token form */}
         {!socialProvider ? (
           <div className="flex flex-col gap-3 mb-6">
             <button
@@ -89,7 +98,7 @@ export default function LoginPage() {
               className="w-full flex items-center justify-center gap-2 border border-gray-300 rounded py-2 font-medium hover:bg-gray-50"
             >
               <span className="text-lg">G</span>
-              Google 로그인
+              Google Login
             </button>
             <button
               type="button"
@@ -97,39 +106,40 @@ export default function LoginPage() {
               className="w-full flex items-center justify-center gap-2 bg-yellow-300 rounded py-2 font-medium hover:bg-yellow-400"
             >
               <span className="text-lg">K</span>
-              Kakao 로그인
+              Kakao Login
             </button>
           </div>
         ) : (
           <form onSubmit={handleSocialLogin} className="flex flex-col gap-3 mb-6">
             <h2 className="text-sm font-semibold text-gray-700">
-              {socialProvider === "GOOGLE" ? "Google" : "Kakao"} 로그인
+              {socialProvider === "GOOGLE" ? "Google" : "Kakao"} Login
             </h2>
             <div>
               <label htmlFor="socialToken" className="block text-sm font-medium text-gray-700 mb-1">
-                ID Token
+                {socialTokenLabel}
               </label>
               <input
                 id="socialToken"
                 type="text"
                 value={socialToken}
                 onChange={(e) => setSocialToken(e.target.value)}
-                placeholder="소셜 로그인 ID Token 입력"
+                placeholder={socialTokenPlaceholder}
                 required
                 className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
               />
+              <p className="mt-1 text-xs text-gray-500">{socialTokenGuide}</p>
             </div>
             {needsInviteCode && (
               <div>
                 <label htmlFor="inviteCode" className="block text-sm font-medium text-gray-700 mb-1">
-                  초대코드
+                  Invite Code
                 </label>
                 <input
                   id="inviteCode"
                   type="text"
                   value={inviteCode}
                   onChange={(e) => setInviteCode(e.target.value)}
-                  placeholder="초대코드를 입력하세요"
+                  placeholder="Enter invite code"
                   required
                   className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 />
@@ -141,61 +151,61 @@ export default function LoginPage() {
                 disabled={loading}
                 className="flex-1 bg-indigo-600 text-white rounded py-2 font-medium hover:bg-indigo-700 disabled:opacity-50"
               >
-                {loading ? "로그인 중..." : "로그인"}
+                {loading ? "Signing in..." : "Sign In"}
               </button>
               <button
                 type="button"
                 onClick={resetSocial}
                 className="border border-gray-300 rounded px-4 py-2 hover:bg-gray-50"
               >
-                취소
+                Cancel
               </button>
             </div>
           </form>
         )}
 
-        {/* Divider */}
-        <div className="flex items-center gap-3 mb-4">
-          <div className="flex-1 h-px bg-gray-300" />
-          <span className="text-xs text-gray-400">또는</span>
-          <div className="flex-1 h-px bg-gray-300" />
-        </div>
-
-        {/* Dev login (collapsible) */}
-        <button
-          type="button"
-          onClick={() => setShowDevLogin(!showDevLogin)}
-          className="w-full text-sm text-gray-500 hover:text-gray-700 mb-2"
-        >
-          {showDevLogin ? "▲ Dev 로그인 닫기" : "▼ Dev 로그인 (개발용)"}
-        </button>
-
         {showDevLogin && (
-          <form onSubmit={handleDevLogin} className="flex flex-col gap-3">
-            <div>
-              <label htmlFor="displayName" className="block text-sm font-medium text-gray-700 mb-1">
-                표시 이름
-              </label>
-              <input
-                id="displayName"
-                type="text"
-                value={displayName}
-                onChange={(e) => setDisplayName(e.target.value)}
-                placeholder="관리자"
-                className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-              />
+          <>
+            <div className="flex items-center gap-3 mb-4">
+              <div className="flex-1 h-px bg-gray-300" />
+              <span className="text-xs text-gray-400">or</span>
+              <div className="flex-1 h-px bg-gray-300" />
             </div>
-            <p className="text-xs text-gray-500">
-              Dev 프로필 전용. ADMIN 역할로 자동 로그인됩니다.
-            </p>
+
             <button
-              type="submit"
-              disabled={loading}
-              className="bg-gray-600 text-white rounded py-2 font-medium hover:bg-gray-700 disabled:opacity-50"
+              type="button"
+              onClick={() => setShowDevLoginForm((v) => !v)}
+              className="w-full text-sm text-gray-500 hover:text-gray-700 mb-2"
             >
-              {loading ? "로그인 중..." : "Dev 로그인"}
+              {showDevLoginForm ? "Hide Dev Login" : "Dev Login (local only)"}
             </button>
-          </form>
+
+            {showDevLoginForm && (
+              <form onSubmit={handleDevLogin} className="flex flex-col gap-3">
+                <div>
+                  <label htmlFor="displayName" className="block text-sm font-medium text-gray-700 mb-1">
+                    Display Name
+                  </label>
+                  <input
+                    id="displayName"
+                    type="text"
+                    value={displayName}
+                    onChange={(e) => setDisplayName(e.target.value)}
+                    placeholder="Admin"
+                    className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  />
+                </div>
+                <p className="text-xs text-gray-500">Dev login is enabled only on localhost.</p>
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="bg-gray-600 text-white rounded py-2 font-medium hover:bg-gray-700 disabled:opacity-50"
+                >
+                  {loading ? "Signing in..." : "Dev Sign In"}
+                </button>
+              </form>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -870,3 +870,29 @@
 - `powershell -File scripts/staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Event push -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 120 -AsJson`
 - `powershell -File scripts/staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Event push -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 120 -AsMarkdown`
 - `powershell -File scripts/staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Event push -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 1 -AsJson` (expected non-zero exit)
+
+## 31. Cycle record (2026-02-14, login guidance patch)
+
+### Goal
+- Remove staging login confusion by clarifying token input semantics for social login.
+
+### Scope
+- Included: Admin login UI label/help updates for Google/Kakao token types, hide dev login on non-localhost.
+- Excluded: auth API logic changes, deployment workflow changes.
+
+### Work
+1. Token input clarification
+- `apps/admin/src/pages/LoginPage.tsx`
+- Provider-specific token label/help:
+  - Google -> `ID Token`
+  - Kakao -> `Access Token` (without `Bearer ` prefix)
+
+2. Dev login visibility guard
+- `apps/admin/src/pages/LoginPage.tsx`
+- Dev login section is rendered only for `localhost` and `127.0.0.1`.
+
+3. Documentation sync
+- `docs/changelog-dev.md` updated.
+
+### Validation
+- `cd apps/admin && npm ci && npx tsc --noEmit && npm run build`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,14 @@
 
 ## 2026-02-14
 
+### Login token input clarification for staging
+- `apps/admin/src/pages/LoginPage.tsx`
+  - Login token label is now provider-specific:
+    - Google: `ID Token`
+    - Kakao: `Access Token`
+  - Added token guidance text to prevent Kakao ID-token misuse.
+  - Dev login section is now shown only on localhost (`localhost`, `127.0.0.1`) to avoid staging confusion.
+
 ### 스테이징 상태 조회 스크립트 게이트 강화(27차)
 - `scripts/staging-latest-status.ps1` 옵션 확장
   - `-RequireDeploySuccess` 추가: `deploy` job 결론이 `success`가 아니면 실패 처리


### PR DESCRIPTION
## Summary
- Clarify social token input semantics in Admin login UI:
  - Google -> ID Token
  - Kakao -> Access Token (without `Bearer ` prefix)
- Add provider-specific helper text under token input to prevent misuse.
- Hide Dev login section outside localhost (`localhost`, `127.0.0.1`) to avoid staging confusion.
- Sync docs:
  - `docs/changelog-dev.md`
  - `docs/WORK_CYCLE.md`

## Validation
- `cd apps/admin && npx tsc --noEmit`
- `cd apps/admin && npm run build`

## Risk
- UI-only change (Admin login screen). No auth backend logic or infra workflow changes.