### PR TITLE
Fix auth API 500s (better exception mapping + UTF-8)

### DIFF
--- a/apps/api/src/main/java/com/eunhyehymn/common/error/ApiAccessDeniedHandler.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/error/ApiAccessDeniedHandler.java
@@ -3,6 +3,7 @@ package com.eunhyehymn.common.error;
 import com.eunhyehymn.common.response.ApiResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
@@ -24,7 +25,8 @@ public class ApiAccessDeniedHandler implements AccessDeniedHandler {
         ErrorResponse error = ErrorResponse.of("forbidden", "접근 권한이 없습니다", null);
         ApiResponse<Object> body = ApiResponse.failure(error);
         response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        objectMapper.writeValue(response.getWriter(), body);
+        objectMapper.writeValue(response.getOutputStream(), body);
     }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/common/error/ApiAuthenticationEntryPoint.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/error/ApiAuthenticationEntryPoint.java
@@ -3,6 +3,7 @@ package com.eunhyehymn.common.error;
 import com.eunhyehymn.common.response.ApiResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
@@ -24,7 +25,8 @@ public class ApiAuthenticationEntryPoint implements AuthenticationEntryPoint {
         ErrorResponse error = ErrorResponse.of("unauthorized", "인증이 필요합니다", null);
         ApiResponse<Object> body = ApiResponse.failure(error);
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        objectMapper.writeValue(response.getWriter(), body);
+        objectMapper.writeValue(response.getOutputStream(), body);
     }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/common/error/GlobalExceptionHandler.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/error/GlobalExceptionHandler.java
@@ -1,17 +1,28 @@
 package com.eunhyehymn.common.error;
 
 import com.eunhyehymn.common.response.ApiResponse;
+import com.eunhyehymn.infrastructure.security.JwtValidationException;
 import jakarta.validation.ConstraintViolationException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
     @ExceptionHandler(ApiException.class)
     public ResponseEntity<ApiResponse<Object>> handleApiException(ApiException ex) {
         var error = ErrorResponse.of(ex.getCode(), ex.getMessage(), ex.getDetails());
@@ -45,8 +56,50 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.failure(error));
     }
 
+    @ExceptionHandler(JwtValidationException.class)
+    public ResponseEntity<ApiResponse<Object>> handleJwtValidation(JwtValidationException ex) {
+        // Used by refresh-token flows and other JWT parsing; treat as client-side auth failure.
+        var error = ErrorResponse.of("invalid_token", "토큰이 유효하지 않습니다", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure(error));
+    }
+
+    @ExceptionHandler({
+        NoHandlerFoundException.class,
+        NoResourceFoundException.class
+    })
+    public ResponseEntity<ApiResponse<Object>> handleNotFound(Exception ex) {
+        var error = ErrorResponse.of("not_found", "요청한 리소스를 찾을 수 없습니다", null);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.failure(error));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Object>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException ex) {
+        var error = ErrorResponse.of("method_not_allowed", "지원하지 않는 HTTP 메서드입니다", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(ApiResponse.failure(error));
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Object>> handleUnsupportedMediaType(HttpMediaTypeNotSupportedException ex) {
+        var error = ErrorResponse.of("unsupported_media_type", "지원하지 않는 Content-Type 입니다", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body(ApiResponse.failure(error));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Object>> handleMalformedJson(HttpMessageNotReadableException ex) {
+        var error = ErrorResponse.of("malformed_json", "요청 본문(JSON)을 파싱할 수 없습니다", null);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.failure(error));
+    }
+
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Object>> handleUnhandled(Exception ex) {
+    public ResponseEntity<ApiResponse<Object>> handleUnhandled(Exception ex, HttpServletRequest request) {
+        log.error(
+            "Unhandled exception: method={} uri={} message={}",
+            request.getMethod(),
+            request.getRequestURI(),
+            ex.getMessage(),
+            ex
+        );
+
         // Keep a stable envelope so clients can recover safely.
         var error = ErrorResponse.of("internal_error", "Unexpected server error", null);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ApiResponse.failure(error));

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -14,6 +14,7 @@
 - `docs/staging-smoke-checklist.md`
 - `docs/staging-rehearsal-log.md`
 - `docs/deployment-readiness-audit.md`
+- `docs/staging-admin-login.md`
 - `infra/aws/README.md`
 - `docs/SECRETS_MANAGEMENT.md`
 

--- a/docs/staging-admin-login.md
+++ b/docs/staging-admin-login.md
@@ -1,0 +1,23 @@
+# Staging Admin Login (Kakao)
+
+Staging URL:
+- `http://13.209.200.12/`
+
+## What To Enter On Admin Login Page
+
+- **Kakao Access Token**: Kakao OAuth *access token* string (starts with `Bearer` 없이 토큰 값만).
+- **Invite Code**: 신규 사용자(처음 로그인)일 때만 필요. 기존 사용자면 비워도 됨.
+
+현재 스테이징 DB에 생성해둔 초대코드:
+- `STAGE-BHG8VM`
+
+## How To Get A Kakao Access Token
+
+1) Kakao Developers 콘솔에서 해당 앱으로 이동
+2) **카카오 로그인** 활성화 + (필요하면) **동의항목**에서 `프로필`, `이메일` 권한 설정
+3) Kakao Developers의 **도구**에서 토큰을 발급받아 **Access Token** 값을 복사
+
+주의:
+- **ID Token이 아니라 Access Token** 입니다.
+- 토큰 앞에 `Bearer `는 붙이지 말고, 토큰 문자열만 입력합니다.
+


### PR DESCRIPTION
- Add explicit exception mapping (404/405/415/400 malformed JSON, 401 invalid_token) so /auth endpoints stop surfacing as 500\n- Log unhandled exceptions with method/uri + stacktrace for staging debugging\n- Force UTF-8 for security entrypoints (avoid ISO-8859-1 garbling)\n- Add staging admin login doc (Kakao access token + invite code)