### PR TITLE
feat(admin): single-operator UX overhaul and clearer auth recovery

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -19,7 +19,7 @@ export default function App() {
       <AuthProvider>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
-          <Route path="/help" element={<HelpPage />} />
+          <Route path="/login/help" element={<HelpPage />} />
           <Route element={<ProtectedRoute />}>
             <Route element={<Layout />}>
               <Route path="/" element={<DashboardPage />} />
@@ -30,6 +30,7 @@ export default function App() {
               <Route path="/users" element={<UserListPage />} />
               <Route path="/invite-codes" element={<InviteCodePage />} />
               <Route path="/events" element={<AdminEventPage />} />
+              <Route path="/help" element={<HelpPage />} />
             </Route>
           </Route>
         </Routes>

--- a/apps/admin/src/api/client.ts
+++ b/apps/admin/src/api/client.ts
@@ -94,6 +94,10 @@ async function handleResponse<T>(response: Response, unauthorized: UnauthorizedM
     throw new Error(resolveErrorMessage(payload, "인증에 실패했습니다."));
   }
 
+  if (response.status === 403) {
+    throw new Error(resolveErrorMessage(payload, "관리자 권한이 없습니다. 세션 초기화 후 관리자 계정으로 다시 로그인해 주세요."));
+  }
+
   if (!response.ok || payload?.success === false) {
     throw new Error(resolveErrorMessage(payload, "요청 처리 중 오류가 발생했습니다."));
   }

--- a/apps/admin/src/auth/AuthContext.tsx
+++ b/apps/admin/src/auth/AuthContext.tsx
@@ -54,9 +54,14 @@ function loadUser(): User | null {
   if (!token) return null;
   const payload = parseJwtPayload(token);
   if (!payload) return null;
+  const userId = payload.sub ?? payload.userId;
+  const role = payload.role ?? "USER";
+  if (typeof userId !== "string" || typeof role !== "string") {
+    return null;
+  }
   return {
-    userId: (payload.sub ?? payload.userId) as string,
-    role: (payload.role ?? "USER") as string,
+    userId,
+    role,
   };
 }
 
@@ -68,9 +73,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const setTokensAndUser = useCallback((accessToken: string, refreshToken: string, fallbackUser?: User) => {
     setTokens(accessToken, refreshToken);
     const parsed = parseJwtPayload(accessToken);
+    const userId = parsed?.sub ?? parsed?.userId;
+    const role = parsed?.role ?? "USER";
     setUser(
-      parsed
-        ? { userId: (parsed.sub ?? parsed.userId) as string, role: (parsed.role ?? "USER") as string }
+      parsed && typeof userId === "string" && typeof role === "string"
+        ? { userId, role }
         : fallbackUser ?? null,
     );
   }, []);
@@ -82,6 +89,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const loginWithAdminPassword = useCallback(async (loginId: string, password: string) => {
     const result = await apiAdminPasswordLogin({ loginId, password });
+    const payload = parseJwtPayload(result.accessToken);
+    const role = payload?.role;
+    if (role !== "ADMIN") {
+      clearTokens();
+      setUser(null);
+      throw new Error("관리자 권한 토큰이 아닙니다. 세션을 초기화한 뒤 관리자 계정으로 다시 로그인해 주세요.");
+    }
     setTokensAndUser(result.accessToken, result.refreshToken);
     return { newUser: result.newUser };
   }, [setTokensAndUser]);

--- a/apps/admin/src/auth/ProtectedRoute.tsx
+++ b/apps/admin/src/auth/ProtectedRoute.tsx
@@ -9,7 +9,7 @@ export default function ProtectedRoute() {
     return <Navigate to="/login" replace />;
   }
 
-  if (user?.role && user.role !== "ADMIN") {
+  if (user?.role !== "ADMIN") {
     return <NotAuthorizedPage />;
   }
 

--- a/apps/admin/src/components/Layout.tsx
+++ b/apps/admin/src/components/Layout.tsx
@@ -1,83 +1,144 @@
-import { NavLink, Outlet, useNavigate } from "react-router-dom";
+import { NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 
 type NavItem = {
   to: string;
   label: string;
   description: string;
+  matchPrefix?: string;
 };
 
 const NAV_ITEMS: NavItem[] = [
-  { to: "/", label: "홈", description: "대시보드" },
-  { to: "/hymns", label: "찬양 관리", description: "목록/편집/상태" },
-  { to: "/assets/upload", label: "에셋 업로드", description: "이미지/악보/음원" },
-  { to: "/invite-codes", label: "초대코드", description: "생성/비활성화" },
-  { to: "/users", label: "사용자", description: "역할/상태" },
-  { to: "/events", label: "감사 로그/분석", description: "조회/내보내기" },
-  { to: "/help", label: "도움말", description: "로그인/권한" },
+  { to: "/", label: "홈", description: "운영 상태 한눈에 보기" },
+  { to: "/hymns", label: "찬양 관리", description: "찬양 목록/편집/상태", matchPrefix: "/hymns" },
+  { to: "/assets/upload", label: "에셋 업로드", description: "이미지/악보/음원 등록", matchPrefix: "/assets" },
+  { to: "/invite-codes", label: "초대코드 관리", description: "생성/사용량/비활성화", matchPrefix: "/invite-codes" },
+  { to: "/users", label: "사용자 관리", description: "역할/상태 관리", matchPrefix: "/users" },
+  { to: "/events", label: "감사 로그/분석", description: "조회/내보내기/지표", matchPrefix: "/events" },
+  { to: "/help", label: "도움말", description: "로그인/권한 문제 해결", matchPrefix: "/help" },
 ];
+
+function resolveCurrentSection(pathname: string): NavItem {
+  if (pathname === "/") {
+    return NAV_ITEMS[0];
+  }
+
+  const matched = NAV_ITEMS.find((item) => item.matchPrefix && pathname.startsWith(item.matchPrefix));
+  return matched ?? NAV_ITEMS[0];
+}
 
 export default function Layout() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const host = window.location.host;
+  const currentSection = resolveCurrentSection(location.pathname);
+  const isAdmin = user?.role === "ADMIN";
 
   const handleLogout = async () => {
     await logout();
-    navigate("/login");
+    navigate("/login", { replace: true });
   };
 
-  const linkClass = ({ isActive }: { isActive: boolean }) => {
-    const base = "block rounded-lg px-3 py-2 transition";
+  const sidebarLinkClass = ({ isActive }: { isActive: boolean }) => {
+    const base = "block rounded-xl border px-3 py-3 transition";
     if (isActive) {
-      return `${base} bg-white text-indigo-900 shadow-sm`;
+      return `${base} border-indigo-300 bg-white text-indigo-900 shadow-sm`;
     }
-    return `${base} text-indigo-100 hover:bg-indigo-700/60`;
+    return `${base} border-transparent text-indigo-100 hover:border-indigo-500 hover:bg-indigo-700/70`;
+  };
+
+  const mobileLinkClass = ({ isActive }: { isActive: boolean }) => {
+    const base = "rounded-lg px-3 py-1.5 text-xs font-semibold whitespace-nowrap transition";
+    if (isActive) {
+      return `${base} bg-indigo-600 text-white`;
+    }
+    return `${base} bg-slate-100 text-slate-700 hover:bg-slate-200`;
   };
 
   return (
-    <div className="flex min-h-screen bg-slate-50">
-      {/* Sidebar */}
-      <aside className="w-72 bg-indigo-900 text-white flex flex-col">
-        <div className="px-4 pt-5 pb-4">
-          <NavLink to="/" className="block rounded-lg px-2 py-2 hover:bg-indigo-800/60">
-            <div className="text-lg font-bold tracking-wide">Eunhye Admin</div>
-            <div className="mt-1 text-xs text-indigo-200 font-mono">{host}</div>
-          </NavLink>
-        </div>
-
-        <nav className="flex-1 flex flex-col gap-1 px-3">
-          {NAV_ITEMS.map((item) => (
-            <NavLink key={item.to} to={item.to} className={linkClass} end={item.to === "/"}>
-              <div className="flex items-center justify-between gap-2">
-                <div className="font-medium">{item.label}</div>
-              </div>
-              <div className="mt-0.5 text-xs text-indigo-200/80">{item.description}</div>
+    <div className="min-h-screen bg-slate-100 text-slate-900">
+      <div className="flex min-h-screen">
+        <aside className="hidden w-80 shrink-0 flex-col bg-indigo-900 text-white lg:flex">
+          <div className="border-b border-indigo-800 px-5 py-5">
+            <NavLink to="/" className="block rounded-xl border border-indigo-700/70 bg-indigo-800/60 px-3 py-3 hover:bg-indigo-700/70">
+              <div className="text-lg font-bold tracking-wide">Eunhye Admin</div>
+              <div className="mt-1 text-xs text-indigo-100/80">클릭하면 홈으로 이동</div>
+              <div className="mt-2 text-xs font-mono text-indigo-200">{host}</div>
             </NavLink>
-          ))}
-        </nav>
-
-        <div className="px-4 py-4 border-t border-indigo-800 text-sm space-y-2">
-          <div className="flex items-center justify-between">
-            <div className="text-indigo-200">Role</div>
-            <div className="rounded-full bg-indigo-800 px-2 py-0.5 text-xs font-semibold">
-              {user?.role ?? "-"}
-            </div>
           </div>
-          <button
-            type="button"
-            onClick={handleLogout}
-            className="w-full rounded-lg border border-indigo-700 px-3 py-2 text-left text-indigo-100 hover:bg-indigo-800/60"
-          >
-            로그아웃
-          </button>
-        </div>
-      </aside>
 
-      {/* Main content */}
-      <main className="flex-1 overflow-auto p-6">
-        <Outlet />
-      </main>
+          <nav className="flex-1 space-y-2 px-4 py-4">
+            {NAV_ITEMS.map((item) => (
+              <NavLink key={item.to} to={item.to} className={sidebarLinkClass} end={item.to === "/"}>
+                <div className="text-sm font-semibold">{item.label}</div>
+                <div className="mt-1 text-xs text-indigo-200">{item.description}</div>
+              </NavLink>
+            ))}
+          </nav>
+
+          <div className="space-y-3 border-t border-indigo-800 px-5 py-4 text-sm">
+            <div className="rounded-xl border border-indigo-700 bg-indigo-800/60 px-3 py-2">
+              <div className="text-xs text-indigo-200">운영 모드</div>
+              <div className="mt-1 font-semibold">단일 운영자 모드</div>
+            </div>
+            <div className="rounded-xl border border-indigo-700 bg-indigo-800/60 px-3 py-2">
+              <div className="flex items-center justify-between text-xs text-indigo-200">
+                <span>권한</span>
+                <span className={`rounded-full px-2 py-0.5 font-semibold ${isAdmin ? "bg-emerald-500/20 text-emerald-100" : "bg-amber-500/20 text-amber-100"}`}>
+                  {user?.role ?? "-"}
+                </span>
+              </div>
+              <div className="mt-1 truncate text-xs text-indigo-100">{user?.userId ?? "세션 없음"}</div>
+            </div>
+            <button
+              type="button"
+              onClick={handleLogout}
+              className="w-full rounded-xl border border-indigo-600 px-3 py-2 text-left font-semibold text-indigo-100 hover:bg-indigo-800/80"
+            >
+              로그아웃
+            </button>
+          </div>
+        </aside>
+
+        <div className="flex min-h-screen flex-1 flex-col">
+          <header className="sticky top-0 z-20 border-b border-slate-200 bg-white/95 backdrop-blur">
+            <div className="flex items-start justify-between gap-4 px-4 py-3 md:px-6">
+              <div>
+                <div className="text-xs font-semibold text-indigo-600">ADMIN</div>
+                <h1 className="text-lg font-bold text-slate-900 md:text-xl">{currentSection.label}</h1>
+                <p className="mt-0.5 text-xs text-slate-500 md:text-sm">{currentSection.description}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <NavLink
+                  to="/"
+                  className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-50"
+                >
+                  홈
+                </NavLink>
+                <button
+                  type="button"
+                  onClick={handleLogout}
+                  className="rounded-lg bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-800 lg:hidden"
+                >
+                  로그아웃
+                </button>
+              </div>
+            </div>
+            <nav className="flex gap-2 overflow-x-auto border-t border-slate-200 px-4 py-2 lg:hidden">
+              {NAV_ITEMS.map((item) => (
+                <NavLink key={item.to} to={item.to} className={mobileLinkClass} end={item.to === "/"}>
+                  {item.label}
+                </NavLink>
+              ))}
+            </nav>
+          </header>
+
+          <main className="flex-1 p-4 md:p-6">
+            <Outlet />
+          </main>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/admin/src/pages/AdminAssetUploadPage.tsx
+++ b/apps/admin/src/pages/AdminAssetUploadPage.tsx
@@ -17,6 +17,14 @@ interface Props {
   onConfirmed?: () => void;
 }
 
+function toUploadStateLabel(uploadState: UploadState, isPresigning: boolean): string {
+  if (isPresigning) return "프리사인 요청 중";
+  if (uploadState === "idle") return "대기";
+  if (uploadState === "presigned") return "프리사인 완료";
+  if (uploadState === "uploaded") return "업로드 완료";
+  return "확정 완료";
+}
+
 export default function AdminAssetUploadPage({ hymnId: hymnIdProp, onConfirmed }: Props) {
   const params = useParams<{ hymnId?: string }>();
   const initialHymnId = hymnIdProp ?? params.hymnId ?? "";
@@ -111,178 +119,171 @@ export default function AdminAssetUploadPage({ hymnId: hymnIdProp, onConfirmed }
   const showHymnIdField = !hymnIdProp;
 
   return (
-    <div className="max-w-2xl">
-      {showHymnIdField && <h1 className="text-2xl font-bold mb-6">에셋 업로드</h1>}
-
-      <div className="flex flex-col gap-4">
-        {showHymnIdField && (
-          <div>
-            <label htmlFor="hymnId" className="block text-sm font-medium text-gray-700 mb-1">
-              찬송가 ID (UUID)
-            </label>
-            <input
-              id="hymnId"
-              type="text"
-              value={hymnId}
-              onChange={(e) => setHymnId(e.target.value)}
-              placeholder="hymnId UUID"
-              className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-            />
-          </div>
-        )}
-
+    <div className="max-w-3xl space-y-4">
+      {showHymnIdField && (
         <div>
-          <label htmlFor="assetType" className="block text-sm font-medium text-gray-700 mb-1">
-            에셋 타입
-          </label>
-          <select
-            id="assetType"
-            value={assetType}
-            onChange={(e) => {
-              const newType = e.target.value as AssetType;
-              setAssetType(newType);
-              if (newType === "PNG") setPart("ALL");
-            }}
-            className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          >
-            <option value="PNG">PNG</option>
-            <option value="MIDI">MIDI</option>
-          </select>
-        </div>
-
-        <div>
-          <label htmlFor="partType" className="block text-sm font-medium text-gray-700 mb-1">
-            파트 (선택)
-          </label>
-          <select
-            id="partType"
-            value={assetType === "PNG" ? "ALL" : part}
-            onChange={(e) => setPart(e.target.value as PartType | "")}
-            disabled={assetType === "PNG"}
-            className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:bg-gray-100 disabled:text-gray-500"
-          >
-            <option value="">(없음)</option>
-            <option value="ALL">ALL</option>
-            <option value="S">S</option>
-            <option value="A">A</option>
-            <option value="T">T</option>
-            <option value="B">B</option>
-          </select>
-        </div>
-
-        <div>
-          <label htmlFor="file" className="block text-sm font-medium text-gray-700 mb-1">
-            파일 선택
-          </label>
-          <input
-            id="file"
-            type="file"
-            onChange={(e) => {
-              const selectedFile = e.target.files?.[0] ?? null;
-              setFile(selectedFile);
-              if (selectedFile) handlePresign(selectedFile);
-            }}
-            className="w-full text-sm"
-          />
-        </div>
-      </div>
-
-      {/* Action buttons */}
-      <div className="mt-4 flex gap-2">
-        <button
-          type="button"
-          onClick={() => file && handlePresign(file)}
-          disabled={!hymnId || !file || isPresigning}
-          className="bg-gray-600 text-white px-4 py-2 rounded hover:bg-gray-700 disabled:opacity-50 text-sm"
-        >
-          {isPresigning ? "처리 중..." : "Presign"}
-        </button>
-        <button
-          type="button"
-          onClick={handleUpload}
-          disabled={!presignResult || !file || isUploading}
-          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50 text-sm"
-        >
-          {isUploading ? "업로드 중..." : "Upload"}
-        </button>
-        <button
-          type="button"
-          onClick={handleConfirm}
-          disabled={!presignResult || uploadState !== "uploaded"}
-          className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 disabled:opacity-50 text-sm"
-        >
-          Confirm
-        </button>
-      </div>
-
-      {/* Presign result */}
-      <div className="mt-6 p-4 bg-gray-50 rounded text-sm">
-        <h2 className="font-semibold mb-2">프리사인 결과</h2>
-        <div className="space-y-1 text-gray-600">
-          <div>uploadUrl: {presignResult?.uploadUrl ?? "-"}</div>
-          <div>publicUrl: {presignResult?.publicUrl ?? "-"}</div>
-          <div>objectKey: {presignResult?.objectKey ?? "-"}</div>
-        </div>
-        <p className="mt-2 text-xs text-gray-400">
-          objectKey는 서버 규칙에 따라 hymns/&#123;hymnId&#125;/&#123;type&#125;/&#123;part&#125;/ 로 시작해야 합니다.
-          part가 없으면 ALL로 처리됩니다.
-        </p>
-      </div>
-
-      {/* Confirm options */}
-      <div className="mt-4 flex gap-4">
-        <div className="flex-1">
-          <label htmlFor="checksum" className="block text-sm font-medium text-gray-700 mb-1">
-            checksum
-          </label>
-          <input
-            id="checksum"
-            type="text"
-            value={checksum}
-            onChange={(e) => setChecksum(e.target.value)}
-            placeholder="선택"
-            className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          />
-        </div>
-        <div className="flex-1">
-          <label htmlFor="version" className="block text-sm font-medium text-gray-700 mb-1">
-            version
-          </label>
-          <input
-            id="version"
-            type="text"
-            value={version}
-            onChange={(e) => setVersion(e.target.value)}
-            placeholder="선택"
-            className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-          />
-        </div>
-      </div>
-
-      {/* Confirm result */}
-      {confirmResult && (
-        <div className="mt-4 p-4 bg-green-50 rounded text-sm">
-          <h2 className="font-semibold mb-2">확인 결과</h2>
-          <pre className="text-xs">{JSON.stringify(confirmResult, null, 2)}</pre>
+          <h1 className="text-2xl font-bold text-slate-900">에셋 업로드</h1>
+          <p className="mt-1 text-sm text-slate-600">파일 선택 후 `프리사인 → 업로드 → 확정` 순서로 진행합니다.</p>
         </div>
       )}
 
-      {/* Status */}
-      <div className="mt-4 text-sm">
-        <span className="text-gray-500">상태: </span>
-        <span className="font-medium">
-          {isPresigning
-            ? "프리사인 중"
-            : uploadState === "idle"
-              ? "대기"
-              : uploadState === "presigned"
-                ? "프리사인 완료"
-                : uploadState === "uploaded"
-                  ? "업로드 완료"
-                  : "확인 완료"}
-        </span>
-        {lastError && <span className="ml-3 text-red-600">오류: {lastError}</span>}
-      </div>
+      <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="grid gap-4 md:grid-cols-2">
+          {showHymnIdField && (
+            <div className="md:col-span-2">
+              <label htmlFor="hymnId" className="mb-1 block text-sm font-medium text-gray-700">
+                찬양 ID (UUID)
+              </label>
+              <input
+                id="hymnId"
+                type="text"
+                value={hymnId}
+                onChange={(e) => setHymnId(e.target.value)}
+                placeholder="hymnId UUID"
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+            </div>
+          )}
+
+          <div>
+            <label htmlFor="assetType" className="mb-1 block text-sm font-medium text-gray-700">
+              에셋 타입
+            </label>
+            <select
+              id="assetType"
+              value={assetType}
+              onChange={(e) => {
+                const newType = e.target.value as AssetType;
+                setAssetType(newType);
+                if (newType === "PNG") setPart("ALL");
+              }}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            >
+              <option value="PNG">PNG</option>
+              <option value="MIDI">MIDI</option>
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="partType" className="mb-1 block text-sm font-medium text-gray-700">
+              파트 (선택)
+            </label>
+            <select
+              id="partType"
+              value={assetType === "PNG" ? "ALL" : part}
+              onChange={(e) => setPart(e.target.value as PartType | "")}
+              disabled={assetType === "PNG"}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:bg-gray-100 disabled:text-gray-500"
+            >
+              <option value="">(없음)</option>
+              <option value="ALL">ALL</option>
+              <option value="S">S</option>
+              <option value="A">A</option>
+              <option value="T">T</option>
+              <option value="B">B</option>
+            </select>
+          </div>
+
+          <div className="md:col-span-2">
+            <label htmlFor="file" className="mb-1 block text-sm font-medium text-gray-700">
+              파일 선택
+            </label>
+            <input
+              id="file"
+              type="file"
+              onChange={(e) => {
+                const selectedFile = e.target.files?.[0] ?? null;
+                setFile(selectedFile);
+                if (selectedFile) handlePresign(selectedFile);
+              }}
+              className="w-full text-sm"
+            />
+            {file && <p className="mt-1 text-xs text-slate-500">선택됨: {file.name}</p>}
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => file && handlePresign(file)}
+            disabled={!hymnId || !file || isPresigning}
+            className="rounded-lg bg-slate-700 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-800 disabled:opacity-50"
+          >
+            {isPresigning ? "프리사인 중..." : "1) 프리사인"}
+          </button>
+          <button
+            type="button"
+            onClick={handleUpload}
+            disabled={!presignResult || !file || isUploading}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {isUploading ? "업로드 중..." : "2) 업로드"}
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!presignResult || uploadState !== "uploaded"}
+            className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:opacity-50"
+          >
+            3) 확정
+          </button>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <h2 className="text-base font-semibold text-slate-900">프리사인 결과</h2>
+        <div className="mt-2 space-y-1 text-xs text-gray-600">
+          <div className="break-all">uploadUrl: {presignResult?.uploadUrl ?? "-"}</div>
+          <div className="break-all">publicUrl: {presignResult?.publicUrl ?? "-"}</div>
+          <div className="break-all">objectKey: {presignResult?.objectKey ?? "-"}</div>
+        </div>
+        <p className="mt-2 text-xs text-gray-500">
+          objectKey는 hymns/&lt;hymnId&gt;/&lt;type&gt;/&lt;part&gt; 규칙으로 저장됩니다.
+        </p>
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <h2 className="text-base font-semibold text-slate-900">옵션 메타데이터</h2>
+        <div className="mt-3 grid gap-3 md:grid-cols-2">
+          <div>
+            <label htmlFor="checksum" className="mb-1 block text-sm font-medium text-gray-700">
+              checksum (선택)
+            </label>
+            <input
+              id="checksum"
+              type="text"
+              value={checksum}
+              onChange={(e) => setChecksum(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+          <div>
+            <label htmlFor="version" className="mb-1 block text-sm font-medium text-gray-700">
+              version (선택)
+            </label>
+            <input
+              id="version"
+              type="text"
+              value={version}
+              onChange={(e) => setVersion(e.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+        </div>
+      </section>
+
+      {confirmResult && (
+        <section className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4 shadow-sm">
+          <h2 className="text-base font-semibold text-emerald-900">확정 결과</h2>
+          <pre className="mt-2 overflow-x-auto text-xs text-emerald-900">{JSON.stringify(confirmResult, null, 2)}</pre>
+        </section>
+      )}
+
+      <section className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm">
+        <span className="text-slate-500">상태:</span>{" "}
+        <span className="font-semibold text-slate-900">{toUploadStateLabel(uploadState, isPresigning)}</span>
+        {lastError && <span className="ml-2 text-red-600">오류: {lastError}</span>}
+      </section>
     </div>
   );
 }

--- a/apps/admin/src/pages/AdminEventPage.tsx
+++ b/apps/admin/src/pages/AdminEventPage.tsx
@@ -258,13 +258,18 @@ export default function AdminEventPage() {
   };
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-6">감사 로그/분석</h1>
+    <div className="space-y-4">
+      <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <h1 className="text-2xl font-bold text-slate-900">감사 로그/분석</h1>
+        <p className="mt-1 text-sm text-slate-600">
+          사용자 이벤트 조회, 기간 집계, CSV 내보내기(동기/비동기)까지 한 화면에서 처리합니다.
+        </p>
+      </section>
 
-      <div className="bg-white rounded-lg shadow p-4 mb-4 border border-indigo-100">
+      <div className="bg-white rounded-2xl border border-indigo-100 p-4 shadow-sm">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <h2 className="text-base font-semibold text-gray-900">Async Export Ops Metrics</h2>
+            <h2 className="text-base font-semibold text-gray-900">비동기 내보내기 운영 지표</h2>
             {opsMetrics && (
               <p className="text-xs text-gray-500 mt-1">
                 {formatDateTime(opsMetrics.fromInclusive)} ~ {formatDateTime(opsMetrics.toExclusive)}
@@ -289,12 +294,12 @@ export default function AdminEventPage() {
           </div>
         </div>
 
-        {opsMetricsLoading && <p className="text-sm text-gray-500 mt-3">Loading metrics...</p>}
+        {opsMetricsLoading && <p className="text-sm text-gray-500 mt-3">지표 로딩 중...</p>}
 
         {!opsMetricsLoading && opsMetrics && (
           <div className="grid grid-cols-1 md:grid-cols-4 gap-3 mt-3">
             <div className="rounded border border-gray-200 px-3 py-2">
-              <p className="text-xs text-gray-500">Total Jobs</p>
+              <p className="text-xs text-gray-500">총 작업 수</p>
               <p className="text-xl font-semibold text-gray-900">{opsMetrics.jobs.total.toLocaleString("ko-KR")}</p>
               <p className="text-xs text-gray-500 mt-1">
                 completed {opsMetrics.jobs.completed.toLocaleString("ko-KR")} / failed{" "}
@@ -302,7 +307,7 @@ export default function AdminEventPage() {
               </p>
             </div>
             <div className="rounded border border-gray-200 px-3 py-2">
-              <p className="text-xs text-gray-500">Failure Rate</p>
+              <p className="text-xs text-gray-500">실패율</p>
               <p className="text-xl font-semibold text-rose-600">{opsMetrics.jobs.failureRatePercent.toFixed(2)}%</p>
               <p className="text-xs text-gray-500 mt-1">
                 queued {opsMetrics.jobs.queued.toLocaleString("ko-KR")} / running{" "}
@@ -310,7 +315,7 @@ export default function AdminEventPage() {
               </p>
             </div>
             <div className="rounded border border-gray-200 px-3 py-2">
-              <p className="text-xs text-gray-500">Processing Time</p>
+              <p className="text-xs text-gray-500">처리 시간</p>
               <p className="text-xl font-semibold text-gray-900">{formatSeconds(opsMetrics.processing.averageSeconds)}</p>
               <p className="text-xs text-gray-500 mt-1">
                 p95 {formatSeconds(opsMetrics.processing.p95Seconds)} / sample{" "}
@@ -318,7 +323,7 @@ export default function AdminEventPage() {
               </p>
             </div>
             <div className="rounded border border-gray-200 px-3 py-2">
-              <p className="text-xs text-gray-500">Cleanup Volume</p>
+              <p className="text-xs text-gray-500">정리 건수</p>
               <p className="text-xl font-semibold text-emerald-700">
                 {opsMetrics.cleanup.deletedJobs.toLocaleString("ko-KR")}
               </p>

--- a/apps/admin/src/pages/DashboardPage.tsx
+++ b/apps/admin/src/pages/DashboardPage.tsx
@@ -1,22 +1,30 @@
 import { Link } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 
-function Item({
-  title,
-  description,
-  to,
-}: {
+type QuickAction = {
   title: string;
   description: string;
   to: string;
-}) {
+};
+
+const QUICK_ACTIONS: QuickAction[] = [
+  { title: "찬양 관리", description: "목록/검색/활성화/삭제", to: "/hymns" },
+  { title: "에셋 업로드", description: "찬양별 이미지/악보/음원 등록", to: "/assets/upload" },
+  { title: "초대코드 관리", description: "앱 사용자 초대코드 생성 및 비활성화", to: "/invite-codes" },
+  { title: "사용자 관리", description: "역할/상태 점검 및 수정", to: "/users" },
+  { title: "감사 로그/분석", description: "이벤트 조회/CSV 내보내기", to: "/events" },
+  { title: "도움말", description: "로그인/권한 문제 빠른 해결", to: "/help" },
+];
+
+function QuickActionCard({ title, description, to }: QuickAction) {
   return (
     <Link
       to={to}
-      className="block rounded-xl border border-slate-200 bg-white p-4 shadow-sm hover:border-indigo-300 hover:shadow transition"
+      className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-indigo-300 hover:shadow"
     >
-      <div className="font-semibold text-slate-900">{title}</div>
+      <div className="text-base font-semibold text-slate-900">{title}</div>
       <div className="mt-1 text-sm text-slate-600">{description}</div>
+      <div className="mt-3 text-xs font-semibold text-indigo-600">바로 가기</div>
     </Link>
   );
 }
@@ -24,32 +32,45 @@ function Item({
 export default function DashboardPage() {
   const { user } = useAuth();
   const host = window.location.host;
+  const isAdmin = user?.role === "ADMIN";
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold text-slate-900">홈</h1>
-          <p className="mt-1 text-sm text-slate-600">
-            운영자 전용 Admin 콘솔입니다. (host: <span className="font-mono">{host}</span>)
-          </p>
-        </div>
-        <div className="text-right">
-          <div className="text-sm text-slate-600">Role</div>
-          <div className="mt-1 inline-flex items-center rounded-full bg-indigo-50 px-3 py-1 text-sm font-semibold text-indigo-700">
-            {user?.role ?? "-"}
+    <div className="space-y-5">
+      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h2 className="text-2xl font-bold text-slate-900">운영 대시보드</h2>
+            <p className="mt-1 text-sm text-slate-600">
+              단일 운영자 기준 어드민 콘솔입니다. 현재 호스트: <span className="font-mono">{host}</span>
+            </p>
+          </div>
+          <div className="grid grid-cols-2 gap-2 text-right text-sm">
+            <div className="rounded-lg bg-slate-100 px-3 py-2">
+              <div className="text-xs text-slate-500">권한</div>
+              <div className="font-semibold text-slate-900">{user?.role ?? "-"}</div>
+            </div>
+            <div className={`rounded-lg px-3 py-2 ${isAdmin ? "bg-emerald-50" : "bg-amber-50"}`}>
+              <div className={`text-xs ${isAdmin ? "text-emerald-700" : "text-amber-700"}`}>접근 상태</div>
+              <div className={`font-semibold ${isAdmin ? "text-emerald-800" : "text-amber-800"}`}>
+                {isAdmin ? "정상" : "권한 점검 필요"}
+              </div>
+            </div>
           </div>
         </div>
-      </div>
+        <div className="mt-4 rounded-xl border border-indigo-100 bg-indigo-50 px-4 py-3 text-sm text-indigo-900">
+          로그인 후 각 메뉴에서 "권한 없음"이 보이면, 먼저 <Link className="font-semibold underline" to="/help">도움말</Link>의
+          "세션 초기화 후 재로그인" 절차를 진행하세요.
+        </div>
+      </section>
 
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-        <Item title="찬양 관리" description="목록/검색/활성화/삭제, 편집/추가" to="/hymns" />
-        <Item title="에셋 업로드" description="이미지/악보/음원 업로드" to="/assets/upload" />
-        <Item title="초대코드 관리" description="초대코드 생성/비활성화/사용량 확인" to="/invite-codes" />
-        <Item title="사용자 관리" description="사용자 역할/상태 관리" to="/users" />
-        <Item title="감사 로그/분석" description="이벤트 검색/요약/CSV 내보내기" to="/events" />
-        <Item title="도움말" description="로그인/토큰/권한 문제 해결" to="/help" />
-      </div>
+      <section>
+        <h3 className="mb-3 text-base font-semibold text-slate-800">자주 쓰는 작업</h3>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {QUICK_ACTIONS.map((item) => (
+            <QuickActionCard key={item.to} {...item} />
+          ))}
+        </div>
+      </section>
     </div>
   );
 }

--- a/apps/admin/src/pages/HelpPage.tsx
+++ b/apps/admin/src/pages/HelpPage.tsx
@@ -1,39 +1,38 @@
 export default function HelpPage() {
   return (
     <div className="space-y-4">
-      <div>
+      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
         <h1 className="text-2xl font-bold text-slate-900">도움말</h1>
-        <p className="mt-1 text-sm text-slate-600">
-          운영자 1인 기준으로, Admin 로그인/권한 이슈 해결 가이드입니다.
-        </p>
-      </div>
+        <p className="mt-1 text-sm text-slate-600">운영자 1인 기준 로그인/권한 문제를 빠르게 해결하는 가이드입니다.</p>
+      </section>
 
-      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm space-y-2">
-        <h2 className="text-lg font-semibold text-slate-900">로그인 방식</h2>
-        <div className="text-sm text-slate-600 space-y-1">
-          <div>- Admin 웹은 ID/PW 로그인(`auth/admin/login`)을 사용합니다.</div>
-          <div>- 서버에 `ADMIN_LOGIN_ID`, `ADMIN_LOGIN_PASSWORD`가 설정되어 있어야 로그인됩니다.</div>
+      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">로그인 규칙 (중요)</h2>
+        <div className="mt-2 space-y-1 text-sm text-slate-600">
+          <div>- Admin 웹은 OAuth가 아니라 관리자 ID/PW 로그인만 사용합니다.</div>
+          <div>- 필요한 서버 환경변수: `ADMIN_LOGIN_ID`, `ADMIN_LOGIN_PASSWORD`</div>
+          <div>- 초대코드(`stage-...`)는 앱 사용자 가입용이며, Admin 로그인 ID가 아닙니다.</div>
         </div>
-      </div>
+      </section>
 
-      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm space-y-2">
-        <h2 className="text-lg font-semibold text-slate-900">권한이 없다고 나올 때</h2>
-        <div className="text-sm text-slate-600 space-y-1">
-          <div>- 현재 토큰 role이 `USER`이면 Admin API는 403입니다.</div>
-          <div>- 로그아웃 후 재로그인하세요.</div>
-          <div>- 계속 실패하면 브라우저 `sessionStorage`의 `accessToken`, `refreshToken`을 지우고 다시 로그인하세요.</div>
+      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">권한 없음(403) 해결 순서</h2>
+        <div className="mt-2 space-y-1 text-sm text-slate-600">
+          <div>1) 로그인 화면에서 "세션 초기화 후 다시 로그인" 버튼 실행</div>
+          <div>2) 관리자 ID/PW로 다시 로그인</div>
+          <div>3) 여전히 실패하면 서버 환경변수와 배포 반영 여부 확인</div>
         </div>
-      </div>
+      </section>
 
-      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm space-y-2">
-        <h2 className="text-lg font-semibold text-slate-900">API 에러 코드</h2>
-        <div className="text-sm text-slate-600 space-y-1">
-          <div>- `admin_login_disabled`: 서버에 ID/PW 설정이 없음</div>
+      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">자주 보이는 API 에러 코드</h2>
+        <div className="mt-2 space-y-1 text-sm text-slate-600">
+          <div>- `admin_login_disabled`: 서버에 관리자 ID/PW가 비어 있음</div>
           <div>- `admin_login_failed`: 아이디 또는 비밀번호 불일치</div>
-          <div>- `unauthorized`: 로그인 토큰 없음/만료</div>
-          <div>- `forbidden`: USER 토큰으로 admin endpoint 접근</div>
+          <div>- `unauthorized`: 토큰 만료/누락</div>
+          <div>- `forbidden`: ADMIN이 아닌 토큰으로 Admin API 호출</div>
         </div>
-      </div>
+      </section>
     </div>
   );
 }

--- a/apps/admin/src/pages/HymnListPage.tsx
+++ b/apps/admin/src/pages/HymnListPage.tsx
@@ -87,45 +87,51 @@ export default function HymnListPage() {
   };
 
   return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">찬양 관리</h1>
-        <Link
-          to="/hymns/new"
-          className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700"
-        >
-          새 찬양 추가
-        </Link>
-      </div>
+    <div className="space-y-4">
+      <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-xl font-bold text-slate-900">찬양 관리</h2>
+            <p className="mt-1 text-sm text-slate-600">제목/태그 검색, 활성화 토글, 수정/삭제를 수행합니다.</p>
+          </div>
+          <Link
+            to="/hymns/new"
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
+          >
+            새 찬양 추가
+          </Link>
+        </div>
 
-      {/* Search & Filter Bar */}
-      <div className="flex items-center gap-3 mb-4">
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="제목, 번호, 태그 검색..."
-          className="flex-1 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-        />
-        <select
-          value={enabledFilter}
-          onChange={(e) => setEnabledFilter(e.target.value as EnabledFilter)}
-          className="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-        >
-          <option value="all">전체</option>
-          <option value="enabled">활성만</option>
-          <option value="disabled">비활성만</option>
-        </select>
-      </div>
+        <div className="mt-4 flex flex-col gap-3 md:flex-row">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="제목, 번호, 태그 검색..."
+            className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+          <select
+            value={enabledFilter}
+            onChange={(e) => setEnabledFilter(e.target.value as EnabledFilter)}
+            className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            <option value="all">전체</option>
+            <option value="enabled">활성만</option>
+            <option value="disabled">비활성만</option>
+          </select>
+        </div>
+      </section>
 
-      {loading && <p className="text-gray-500">로딩 중...</p>}
-      {error && <p className="text-red-600 mb-4">{error}</p>}
-      {actionError && <p className="text-red-600 mb-4">{actionError}</p>}
+      {loading && <p className="text-sm text-gray-500">로딩 중...</p>}
+      {error && <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
+      {actionError && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{actionError}</div>
+      )}
 
       {!loading && !error && (
-        <div className="bg-white rounded-lg shadow overflow-hidden">
+        <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
           <table className="w-full text-left">
-            <thead className="bg-gray-50 border-b">
+            <thead className="bg-slate-50 border-b border-slate-200">
               <tr>
                 <th className="px-4 py-3 text-sm font-semibold text-gray-600">번호</th>
                 <th className="px-4 py-3 text-sm font-semibold text-gray-600">제목</th>
@@ -137,18 +143,16 @@ export default function HymnListPage() {
             <tbody>
               {filteredHymns.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="px-4 py-8 text-center text-gray-400">
-                    {search || enabledFilter !== "all"
-                      ? "검색 결과가 없습니다."
-                      : "등록된 찬양이 없습니다."}
+                  <td colSpan={5} className="px-4 py-10 text-center text-gray-400">
+                    {search || enabledFilter !== "all" ? "검색 결과가 없습니다." : "등록된 찬양이 없습니다."}
                   </td>
                 </tr>
               )}
               {filteredHymns.map((h) => (
-                <tr key={h.id} className="border-b last:border-b-0 hover:bg-gray-50">
+                <tr key={h.id} className="border-b border-slate-100 last:border-b-0 hover:bg-slate-50">
                   <td className="px-4 py-3 text-sm">{h.number ?? "-"}</td>
                   <td className="px-4 py-3">
-                    <Link to={`/hymns/${h.id}/edit`} className="text-indigo-600 hover:underline">
+                    <Link to={`/hymns/${h.id}/edit`} className="font-medium text-indigo-600 hover:underline">
                       {h.title}
                     </Link>
                   </td>
@@ -158,7 +162,7 @@ export default function HymnListPage() {
                       type="button"
                       onClick={() => handleToggleEnabled(h)}
                       disabled={togglingIds.has(h.id)}
-                      className={`inline-block px-2 py-0.5 rounded text-xs font-medium cursor-pointer transition-colors disabled:opacity-50 ${
+                      className={`inline-block rounded-full px-2.5 py-1 text-xs font-semibold transition-colors disabled:opacity-50 ${
                         h.enabled
                           ? "bg-green-100 text-green-700 hover:bg-green-200"
                           : "bg-gray-100 text-gray-500 hover:bg-gray-200"
@@ -172,7 +176,7 @@ export default function HymnListPage() {
                       type="button"
                       onClick={() => handleDelete(h)}
                       disabled={deletingIds.has(h.id)}
-                      className="text-red-600 hover:text-red-800 text-sm font-medium disabled:opacity-50"
+                      className="text-sm font-medium text-red-600 hover:text-red-800 disabled:opacity-50"
                     >
                       {deletingIds.has(h.id) ? "삭제 중..." : "삭제"}
                     </button>
@@ -181,14 +185,11 @@ export default function HymnListPage() {
               ))}
             </tbody>
           </table>
-        </div>
+        </section>
       )}
 
-      {/* Result count */}
       {!loading && !error && (search || enabledFilter !== "all") && (
-        <p className="mt-3 text-sm text-gray-500">
-          {filteredHymns.length}건 / 전체 {hymns.length}건
-        </p>
+        <p className="text-sm text-gray-500">{filteredHymns.length}건 / 전체 {hymns.length}건</p>
       )}
     </div>
   );

--- a/apps/admin/src/pages/InviteCodePage.tsx
+++ b/apps/admin/src/pages/InviteCodePage.tsx
@@ -95,80 +95,87 @@ export default function InviteCodePage() {
   };
 
   return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">초대코드 관리</h1>
-        <button
-          type="button"
-          onClick={handleToggleForm}
-          className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700"
-        >
-          {showForm ? "취소" : "새 초대코드"}
-        </button>
-      </div>
+    <div className="space-y-4">
+      <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-xl font-bold text-slate-900">초대코드 관리</h2>
+            <p className="mt-1 text-sm text-slate-600">앱 사용자 등록용 코드 생성/비활성화/사용량 조회를 수행합니다.</p>
+          </div>
+          <button
+            type="button"
+            onClick={handleToggleForm}
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
+          >
+            {showForm ? "취소" : "새 초대코드"}
+          </button>
+        </div>
+      </section>
 
-      {mutationError && <p className="text-red-600 mb-4">{mutationError}</p>}
+      {mutationError && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{mutationError}</div>
+      )}
 
       {showForm && (
-        <form onSubmit={handleCreate} className="bg-white rounded-lg shadow p-4 mb-6 space-y-3">
+        <form onSubmit={handleCreate} className="space-y-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">코드</label>
+            <label className="mb-1 block text-sm font-medium text-gray-700">코드</label>
             <input
               type="text"
               value={newCode}
               onChange={(e) => setNewCode(e.target.value)}
               required
-              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
               placeholder="예: EUNHYE-2026"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">설명 (선택)</label>
+            <label className="mb-1 block text-sm font-medium text-gray-700">설명 (선택)</label>
             <input
               type="text"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
               placeholder="예: 2026년 새가족용"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">최대 사용 횟수 (선택)</label>
+            <label className="mb-1 block text-sm font-medium text-gray-700">최대 사용 횟수 (선택)</label>
             <input
               type="number"
               value={maxUses}
               onChange={(e) => setMaxUses(e.target.value)}
               min="1"
-              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
               placeholder="비워두면 무제한"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">만료일 (선택)</label>
+            <label className="mb-1 block text-sm font-medium text-gray-700">만료일 (선택)</label>
             <input
               type="datetime-local"
               value={expiresAt}
               onChange={(e) => setExpiresAt(e.target.value)}
-              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
             />
           </div>
           <button
             type="submit"
             disabled={creating || !newCode.trim()}
-            className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700 disabled:opacity-50"
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-50"
           >
             {creating ? "생성 중..." : "생성"}
           </button>
         </form>
       )}
 
-      {loading && <p className="text-gray-500">로딩 중...</p>}
-      {loadError && <p className="text-red-600 mb-4">{loadError}</p>}
+      {loading && <p className="text-sm text-gray-500">로딩 중...</p>}
+      {loadError && <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{loadError}</div>}
 
       {!loading && !loadError && (
-        <div className="bg-white rounded-lg shadow overflow-hidden">
+        <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
           <table className="w-full text-left">
-            <thead className="bg-gray-50 border-b">
+            <thead className="bg-slate-50 border-b border-slate-200">
               <tr>
                 <th className="px-4 py-3 text-sm font-semibold text-gray-600">코드</th>
                 <th className="px-4 py-3 text-sm font-semibold text-gray-600">설명</th>
@@ -182,24 +189,23 @@ export default function InviteCodePage() {
             <tbody>
               {codes.length === 0 && (
                 <tr>
-                  <td colSpan={7} className="px-4 py-8 text-center text-gray-400">
+                  <td colSpan={7} className="px-4 py-10 text-center text-gray-400">
                     등록된 초대코드가 없습니다.
                   </td>
                 </tr>
               )}
               {codes.map((c) => (
-                <tr key={c.code} className="border-b last:border-b-0 hover:bg-gray-50">
+                <tr key={c.code} className="border-b border-slate-100 last:border-b-0 hover:bg-slate-50">
                   <td className="px-4 py-3 font-mono text-sm">{c.code}</td>
                   <td className="px-4 py-3 text-sm text-gray-500">{c.description ?? "-"}</td>
                   <td className="px-4 py-3 text-sm">
-                    {c.usedCount}{c.maxUses != null ? ` / ${c.maxUses}` : ""}
+                    {c.usedCount}
+                    {c.maxUses != null ? ` / ${c.maxUses}` : ""}
                   </td>
                   <td className="px-4 py-3">
                     <span
-                      className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${
-                        c.enabled
-                          ? "bg-green-100 text-green-700"
-                          : "bg-gray-100 text-gray-500"
+                      className={`inline-block rounded-full px-2.5 py-1 text-xs font-semibold ${
+                        c.enabled ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-500"
                       }`}
                     >
                       {c.enabled ? "활성" : "비활성"}
@@ -215,16 +221,14 @@ export default function InviteCodePage() {
                       <span className="text-gray-400">-</span>
                     )}
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-500">
-                    {new Date(c.createdAt).toLocaleDateString("ko-KR")}
-                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500">{new Date(c.createdAt).toLocaleDateString("ko-KR")}</td>
                   <td className="px-4 py-3">
                     {c.enabled && (
                       <button
                         type="button"
                         onClick={() => handleRevoke(c.code)}
                         disabled={revokingCodes.has(c.code)}
-                        className="text-red-600 hover:text-red-800 text-sm disabled:opacity-50"
+                        className="text-sm font-medium text-red-600 hover:text-red-800 disabled:opacity-50"
                       >
                         {revokingCodes.has(c.code) ? "..." : "비활성화"}
                       </button>
@@ -234,7 +238,7 @@ export default function InviteCodePage() {
               ))}
             </tbody>
           </table>
-        </div>
+        </section>
       )}
     </div>
   );

--- a/apps/admin/src/pages/LoginPage.tsx
+++ b/apps/admin/src/pages/LoginPage.tsx
@@ -7,7 +7,7 @@ function isLocalDevHost(hostname: string): boolean {
 }
 
 export default function LoginPage() {
-  const { loginWithAdminPassword, login } = useAuth();
+  const { loginWithAdminPassword, login, logout } = useAuth();
   const navigate = useNavigate();
   const host = window.location.host;
   const showDevLogin = isLocalDevHost(window.location.hostname);
@@ -16,6 +16,7 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
 
   const [showDevLoginForm, setShowDevLoginForm] = useState(false);
   const [displayName, setDisplayName] = useState("");
@@ -27,6 +28,7 @@ export default function LoginPage() {
       return;
     }
 
+    setNotice(null);
     setError(null);
     setLoading(true);
     try {
@@ -46,6 +48,7 @@ export default function LoginPage() {
       return;
     }
 
+    setNotice(null);
     setError(null);
     setLoading(true);
     try {
@@ -62,86 +65,131 @@ export default function LoginPage() {
     }
   };
 
+  const handleResetSession = async () => {
+    setError(null);
+    setNotice(null);
+    setLoading(true);
+    try {
+      await logout();
+      setNotice("이 브라우저의 기존 토큰을 초기화했습니다. 이제 관리자 계정으로 다시 로그인하세요.");
+    } catch {
+      setNotice("세션을 초기화했습니다. 다시 로그인해 주세요.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-50 px-4 py-10">
-      <div className="bg-white rounded-xl shadow-sm border border-slate-200 w-full max-w-md p-8">
-        <div className="mb-6">
-          <h1 className="text-2xl font-bold text-center text-slate-900">Eunhye Admin</h1>
-          <p className="mt-2 text-center text-sm text-slate-600">
-            운영자 전용 로그인 (host: <span className="font-mono">{host}</span>)
+    <div className="min-h-screen bg-slate-100 px-4 py-8 md:py-12">
+      <div className="mx-auto grid w-full max-w-5xl gap-4 lg:grid-cols-[1.1fr_0.9fr]">
+        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="inline-flex rounded-full bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700">
+            Single Operator Mode
+          </div>
+          <h1 className="mt-3 text-2xl font-bold text-slate-900">Eunhye Admin 로그인</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            운영자 1인 전용 관리 콘솔입니다. 서버에 설정된 관리자 ID/PW로만 로그인됩니다.
           </p>
-        </div>
+          <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+            <div className="font-semibold text-slate-900">접속 정보</div>
+            <div className="mt-1">host: <span className="font-mono">{host}</span></div>
+            <div className="mt-3 space-y-1 text-slate-600">
+              <div>1) 관리자 ID/PW 입력</div>
+              <div>2) 로그인 후 상단/좌측 메뉴로 바로 이동</div>
+              <div>3) 권한 오류 시 세션 초기화 후 재로그인</div>
+            </div>
+          </div>
+        </section>
 
-        {error && (
-          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-            {error}
+        <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="mb-5">
+            <h2 className="text-lg font-semibold text-slate-900">관리자 인증</h2>
+            <p className="mt-1 text-sm text-slate-600">OAuth 없이 ID/PW만 사용합니다.</p>
           </div>
-        )}
 
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <div>
-            <label htmlFor="loginId" className="block text-sm font-medium text-slate-700 mb-1">
-              아이디
-            </label>
-            <input
-              id="loginId"
-              type="text"
-              value={loginId}
-              onChange={(e) => setLoginId(e.target.value)}
-              placeholder="admin id"
-              autoComplete="username"
-              required
-              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-            />
-          </div>
-          <div>
-            <label htmlFor="password" className="block text-sm font-medium text-slate-700 mb-1">
-              비밀번호
-            </label>
-            <input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder="password"
-              autoComplete="current-password"
-              required
-              className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-            />
-          </div>
+          {notice && (
+            <div className="mb-4 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+              {notice}
+            </div>
+          )}
+
+          {error && (
+            <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <div>
+              <label htmlFor="loginId" className="mb-1 block text-sm font-medium text-slate-700">
+                아이디
+              </label>
+              <input
+                id="loginId"
+                type="text"
+                value={loginId}
+                onChange={(e) => setLoginId(e.target.value)}
+                placeholder="운영자 아이디"
+                autoComplete="username"
+                required
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+            </div>
+            <div>
+              <label htmlFor="password" className="mb-1 block text-sm font-medium text-slate-700">
+                비밀번호
+              </label>
+              <input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="운영자 비밀번호"
+                autoComplete="current-password"
+                required
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full rounded-lg bg-indigo-600 py-2 font-semibold text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {loading ? "로그인 중..." : "로그인"}
+            </button>
+          </form>
+
           <button
-            type="submit"
+            type="button"
+            onClick={handleResetSession}
             disabled={loading}
-            className="w-full bg-indigo-600 text-white rounded-lg py-2 font-semibold hover:bg-indigo-700 disabled:opacity-50"
+            className="mt-3 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50 disabled:opacity-50"
           >
-            {loading ? "Signing in..." : "Sign In"}
+            세션 초기화 후 다시 로그인
           </button>
-        </form>
 
-        <div className="mt-4 text-xs text-slate-500">
-          로그인 문제가 있으면 <Link to="/help" className="underline">도움말</Link>을 확인하세요.
-        </div>
+          <div className="mt-4 text-xs text-slate-500">
+            로그인 문제가 있으면 <Link to="/login/help" className="font-semibold underline">도움말</Link>을 확인하세요.
+          </div>
+        </section>
 
         {showDevLogin && (
-          <>
-            <div className="flex items-center gap-3 my-4">
-              <div className="flex-1 h-px bg-gray-300" />
-              <span className="text-xs text-gray-400">or</span>
-              <div className="flex-1 h-px bg-gray-300" />
-            </div>
+          <section className="rounded-2xl border border-amber-200 bg-amber-50 p-6 shadow-sm">
+            <div className="text-sm font-semibold text-amber-800">로컬 개발용 로그인</div>
+            <p className="mt-1 text-xs text-amber-700">localhost에서만 사용됩니다. 스테이징/운영에서는 사용하지 마세요.</p>
 
             <button
               type="button"
               onClick={() => setShowDevLoginForm((v) => !v)}
-              className="w-full text-sm text-gray-500 hover:text-gray-700 mb-2"
+              className="mt-3 rounded-lg border border-amber-300 px-3 py-2 text-sm font-semibold text-amber-800 hover:bg-amber-100"
             >
-              {showDevLoginForm ? "Hide Dev Login" : "Dev Login (local only)"}
+              {showDevLoginForm ? "개발 로그인 닫기" : "개발 로그인 열기"}
             </button>
 
             {showDevLoginForm && (
-              <form onSubmit={handleDevLogin} className="flex flex-col gap-3">
+              <form onSubmit={handleDevLogin} className="mt-3 flex flex-col gap-3">
                 <div>
-                  <label htmlFor="displayName" className="block text-sm font-medium text-gray-700 mb-1">
+                  <label htmlFor="displayName" className="mb-1 block text-sm font-medium text-amber-900">
                     Display Name
                   </label>
                   <input
@@ -150,20 +198,19 @@ export default function LoginPage() {
                     value={displayName}
                     onChange={(e) => setDisplayName(e.target.value)}
                     placeholder="Admin"
-                    className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    className="w-full rounded-lg border border-amber-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
                   />
                 </div>
-                <p className="text-xs text-gray-500">Dev login is enabled only on localhost.</p>
                 <button
                   type="submit"
                   disabled={loading}
-                  className="bg-gray-600 text-white rounded py-2 font-medium hover:bg-gray-700 disabled:opacity-50"
+                  className="rounded-lg bg-amber-600 py-2 font-semibold text-white hover:bg-amber-700 disabled:opacity-50"
                 >
-                  {loading ? "Signing in..." : "Dev Sign In"}
+                  {loading ? "처리 중..." : "Dev Login"}
                 </button>
               </form>
             )}
-          </>
+          </section>
         )}
       </div>
     </div>

--- a/apps/admin/src/pages/NotAuthorizedPage.tsx
+++ b/apps/admin/src/pages/NotAuthorizedPage.tsx
@@ -11,36 +11,40 @@ export default function NotAuthorizedPage() {
   };
 
   return (
-    <div className="min-h-[70vh] flex items-center justify-center">
-      <div className="w-full max-w-lg rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-        <h1 className="text-xl font-bold text-slate-900">관리자 권한이 없습니다</h1>
+    <div className="flex min-h-[75vh] items-center justify-center">
+      <div className="w-full max-w-2xl rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="inline-flex rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
+          접근 제한
+        </div>
+        <h1 className="mt-3 text-2xl font-bold text-slate-900">관리자 권한이 확인되지 않았습니다</h1>
         <p className="mt-2 text-sm text-slate-600">
-          현재 로그인된 계정의 role이 <span className="font-mono">{user?.role ?? "UNKNOWN"}</span> 입니다.
-          Admin 기능은 <span className="font-mono">ADMIN</span> role이 필요합니다.
+          현재 세션 role: <span className="font-mono font-semibold">{user?.role ?? "UNKNOWN"}</span> (필수 role:{" "}
+          <span className="font-mono font-semibold">ADMIN</span>)
         </p>
 
-        <div className="mt-4 rounded-lg bg-slate-50 p-3 text-sm text-slate-700">
-          <div className="font-semibold">해결 방법</div>
-          <div className="mt-1 space-y-1 text-slate-600">
-            <div>- 로그아웃 후 다시 로그인하세요.</div>
-            <div>- 서버의 Admin ID/PW 설정(`ADMIN_LOGIN_ID`, `ADMIN_LOGIN_PASSWORD`)을 확인하세요.</div>
+        <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+          <div className="font-semibold text-slate-900">빠른 복구 순서</div>
+          <div className="mt-2 space-y-1 text-slate-600">
+            <div>1) "세션 초기화 후 재로그인"을 눌러 토큰을 지웁니다.</div>
+            <div>2) 관리자 ID/PW로 다시 로그인합니다.</div>
+            <div>3) 계속 실패하면 서버 설정값(`ADMIN_LOGIN_ID`, `ADMIN_LOGIN_PASSWORD`)을 확인합니다.</div>
           </div>
         </div>
 
-        <div className="mt-5 flex gap-2">
+        <div className="mt-5 flex flex-wrap gap-2">
           <button
             type="button"
             onClick={handleLogout}
             className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
           >
-            로그아웃
+            세션 초기화 후 재로그인
           </button>
           <button
             type="button"
             onClick={() => navigate("/help")}
             className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"
           >
-            도움말
+            도움말 열기
           </button>
         </div>
       </div>

--- a/apps/admin/src/pages/UserListPage.tsx
+++ b/apps/admin/src/pages/UserListPage.tsx
@@ -78,46 +78,51 @@ export default function UserListPage() {
   };
 
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-6">사용자 관리</h1>
+    <div className="space-y-4">
+      <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <h2 className="text-xl font-bold text-slate-900">사용자 관리</h2>
+        <p className="mt-1 text-sm text-slate-600">
+          단일 운영자 환경에서는 관리자 계정을 최소 1개 유지해야 합니다.
+        </p>
+        <div className="mt-4 flex flex-col gap-3 md:flex-row">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="이름 검색..."
+            className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+          <select
+            value={roleFilter}
+            onChange={(e) => setRoleFilter(e.target.value as RoleFilter)}
+            className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            <option value="all">전체 역할</option>
+            <option value="ADMIN">관리자</option>
+            <option value="USER">일반</option>
+          </select>
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+            className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            <option value="all">전체 상태</option>
+            <option value="ACTIVE">활성</option>
+            <option value="DISABLED">비활성</option>
+          </select>
+        </div>
+      </section>
 
-      {/* Search & Filter Bar */}
-      <div className="flex items-center gap-3 mb-4">
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="이름 검색..."
-          className="flex-1 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-        />
-        <select
-          value={roleFilter}
-          onChange={(e) => setRoleFilter(e.target.value as RoleFilter)}
-          className="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-        >
-          <option value="all">전체 역할</option>
-          <option value="ADMIN">관리자</option>
-          <option value="USER">일반</option>
-        </select>
-        <select
-          value={statusFilter}
-          onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
-          className="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-        >
-          <option value="all">전체 상태</option>
-          <option value="ACTIVE">활성</option>
-          <option value="DISABLED">비활성</option>
-        </select>
-      </div>
-
-      {loading && <p className="text-gray-500">로딩 중...</p>}
-      {loadError && <p className="text-red-600 mb-4">{loadError}</p>}
-      {mutationError && <p className="text-red-600 mb-4">{mutationError}</p>}
+      {loading && <p className="text-sm text-gray-500">로딩 중...</p>}
+      {loadError && <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{loadError}</div>}
+      {mutationError && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{mutationError}</div>
+      )}
 
       {!loading && !loadError && (
-        <div className="bg-white rounded-lg shadow overflow-hidden">
+        <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
           <table className="w-full text-left">
-            <thead className="bg-gray-50 border-b">
+            <thead className="bg-slate-50 border-b border-slate-200">
               <tr>
                 <th className="px-4 py-3 text-sm font-semibold text-gray-600">이름</th>
                 <th className="px-4 py-3 text-sm font-semibold text-gray-600">역할</th>
@@ -129,7 +134,7 @@ export default function UserListPage() {
             <tbody>
               {filteredUsers.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="px-4 py-8 text-center text-gray-400">
+                  <td colSpan={5} className="px-4 py-10 text-center text-gray-400">
                     {search || roleFilter !== "all" || statusFilter !== "all"
                       ? "검색 결과가 없습니다."
                       : "등록된 사용자가 없습니다."}
@@ -137,14 +142,14 @@ export default function UserListPage() {
                 </tr>
               )}
               {filteredUsers.map((u) => (
-                <tr key={u.id} className="border-b last:border-b-0 hover:bg-gray-50">
+                <tr key={u.id} className="border-b border-slate-100 last:border-b-0 hover:bg-slate-50">
                   <td className="px-4 py-3 font-medium">{u.displayName}</td>
                   <td className="px-4 py-3">
                     <select
                       value={u.role}
                       onChange={(e) => handleRoleChange(u, e.target.value)}
                       disabled={updatingIds.has(u.id)}
-                      className="border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
+                      className="rounded border border-gray-300 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
                     >
                       <option value="USER">일반</option>
                       <option value="ADMIN">관리자</option>
@@ -155,7 +160,7 @@ export default function UserListPage() {
                       type="button"
                       onClick={() => handleStatusToggle(u)}
                       disabled={updatingIds.has(u.id)}
-                      className={`inline-block px-2 py-0.5 rounded text-xs font-medium cursor-pointer transition-colors disabled:opacity-50 ${
+                      className={`inline-block rounded-full px-2.5 py-1 text-xs font-semibold transition-colors disabled:opacity-50 ${
                         u.status === "ACTIVE"
                           ? "bg-green-100 text-green-700 hover:bg-green-200"
                           : "bg-red-100 text-red-700 hover:bg-red-200"
@@ -164,9 +169,7 @@ export default function UserListPage() {
                       {updatingIds.has(u.id) ? "..." : u.status === "ACTIVE" ? "활성" : "비활성"}
                     </button>
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-500">
-                    {new Date(u.createdAt).toLocaleDateString("ko-KR")}
-                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500">{new Date(u.createdAt).toLocaleDateString("ko-KR")}</td>
                   <td className="px-4 py-3 text-sm text-gray-500">
                     {u.lastLoginAt ? new Date(u.lastLoginAt).toLocaleDateString("ko-KR") : "-"}
                   </td>
@@ -174,13 +177,11 @@ export default function UserListPage() {
               ))}
             </tbody>
           </table>
-        </div>
+        </section>
       )}
 
       {!loading && !loadError && (search || roleFilter !== "all" || statusFilter !== "all") && (
-        <p className="mt-3 text-sm text-gray-500">
-          {filteredUsers.length}명 / 전체 {users.length}명
-        </p>
+        <p className="text-sm text-gray-500">{filteredUsers.length}명 / 전체 {users.length}명</p>
       )}
     </div>
   );

--- a/docs/staging-admin-login.md
+++ b/docs/staging-admin-login.md
@@ -9,6 +9,10 @@ Admin login can use dedicated credentials configured by environment variables:
 - `ADMIN_LOGIN_ID`
 - `ADMIN_LOGIN_PASSWORD`
 
+Important:
+- Invite codes (for example `stage-xxxxxx`) are for app user onboarding.
+- Invite codes are **not** admin login IDs.
+
 API endpoint:
 - `POST /api/v1/auth/admin/login`
 
@@ -38,4 +42,5 @@ This mode is optional and can be disabled once ID/PW login is fully adopted.
   - ID or password mismatch.
 - `forbidden` on admin pages after login:
   - clear browser `sessionStorage` tokens and log in again.
+  - ensure you used `ADMIN_LOGIN_ID` / `ADMIN_LOGIN_PASSWORD`, not an invite code.
 


### PR DESCRIPTION
﻿## Why
- Admin is operated by a single owner, so the console should prioritize clarity and fail-safe recovery over multi-operator complexity.
- Users were seeing section-level "forbidden" confusion after stale/non-admin tokens.

## What changed
- Redesigned admin shell/navigation with clearer home behavior and contextual section header.
- Reworked login UX for ID/PW-only operator flow, including explicit session reset action.
- Tightened auth gating so non-ADMIN users are blocked before entering admin pages.
- Added ADMIN-role validation on password login token parsing.
- Improved 403 error message guidance in API client.
- Reworked help and not-authorized pages around practical recovery steps.
- Refreshed key admin pages (hymns/users/invite/assets/events) for more consistent UX.
- Updated staging login doc to explicitly distinguish invite codes from admin credentials.

## Validation
- npx tsc --noEmit (apps/admin)
- npm run build (apps/admin)
