### PR TITLE
feat(admin): prevent self-lockout from user management UI

### DIFF
--- a/apps/admin/src/pages/HelpPage.tsx
+++ b/apps/admin/src/pages/HelpPage.tsx
@@ -25,6 +25,15 @@ export default function HelpPage() {
       </section>
 
       <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">사용자 관리 잠금 정책</h2>
+        <div className="mt-2 space-y-1 text-sm text-slate-600">
+          <div>- 현재 로그인한 운영자 계정은 역할/상태 변경이 잠깁니다.</div>
+          <div>- 마지막 활성 관리자 계정은 USER 변경/비활성화가 잠깁니다.</div>
+          <div>- 목적: 단일 운영자 환경에서 관리자 계정 잠금(셀프 락아웃) 방지</div>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
         <h2 className="text-lg font-semibold text-slate-900">자주 보이는 API 에러 코드</h2>
         <div className="mt-2 space-y-1 text-sm text-slate-600">
           <div>- `admin_login_disabled`: 서버에 관리자 ID/PW가 비어 있음</div>

--- a/apps/admin/src/pages/UserListPage.tsx
+++ b/apps/admin/src/pages/UserListPage.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 import { listUsers, updateUser, type UserResponse } from "../api/adminUsers";
+import { useAuth } from "../auth/AuthContext";
 
 type RoleFilter = "all" | "ADMIN" | "USER";
 type StatusFilter = "all" | "ACTIVE" | "DISABLED";
 
 export default function UserListPage() {
+  const { user: currentUser } = useAuth();
   const [users, setUsers] = useState<UserResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -42,7 +44,46 @@ export default function UserListPage() {
     });
   }, [users, search, roleFilter, statusFilter]);
 
+  const activeAdminCount = useMemo(
+    () => users.filter((u) => u.role === "ADMIN" && u.status === "ACTIVE").length,
+    [users],
+  );
+
+  const isCurrentOperator = (targetUser: UserResponse): boolean => currentUser?.userId === targetUser.id;
+
+  const isLastActiveAdmin = (targetUser: UserResponse): boolean =>
+    targetUser.role === "ADMIN" && targetUser.status === "ACTIVE" && activeAdminCount <= 1;
+
+  const getRoleLockReason = (targetUser: UserResponse): string | null => {
+    if (isCurrentOperator(targetUser)) {
+      return "현재 로그인한 운영자 계정은 역할 변경이 잠겨 있습니다.";
+    }
+    if (isLastActiveAdmin(targetUser)) {
+      return "마지막 활성 관리자 계정은 일반 사용자로 변경할 수 없습니다.";
+    }
+    return null;
+  };
+
+  const getStatusLockReason = (targetUser: UserResponse): string | null => {
+    if (isCurrentOperator(targetUser)) {
+      return "현재 로그인한 운영자 계정은 상태 변경이 잠겨 있습니다.";
+    }
+    if (isLastActiveAdmin(targetUser)) {
+      return "마지막 활성 관리자 계정은 비활성화할 수 없습니다.";
+    }
+    return null;
+  };
+
   const handleRoleChange = async (user: UserResponse, newRole: string) => {
+    if (newRole === user.role) {
+      return;
+    }
+    const lockReason = getRoleLockReason(user);
+    if (lockReason) {
+      setMutationError(lockReason);
+      return;
+    }
+
     setMutationError(null);
     setUpdatingIds((prev) => new Set(prev).add(user.id));
     try {
@@ -60,6 +101,12 @@ export default function UserListPage() {
   };
 
   const handleStatusToggle = async (user: UserResponse) => {
+    const lockReason = getStatusLockReason(user);
+    if (lockReason) {
+      setMutationError(lockReason);
+      return;
+    }
+
     const newStatus = user.status === "ACTIVE" ? "DISABLED" : "ACTIVE";
     setMutationError(null);
     setUpdatingIds((prev) => new Set(prev).add(user.id));
@@ -84,6 +131,9 @@ export default function UserListPage() {
         <p className="mt-1 text-sm text-slate-600">
           단일 운영자 환경에서는 관리자 계정을 최소 1개 유지해야 합니다.
         </p>
+        <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+          현재 로그인한 운영자 계정과 마지막 활성 관리자 계정은 실수 방지를 위해 역할/상태 변경이 잠깁니다.
+        </div>
         <div className="mt-4 flex flex-col gap-3 md:flex-row">
           <input
             type="text"
@@ -141,40 +191,56 @@ export default function UserListPage() {
                   </td>
                 </tr>
               )}
-              {filteredUsers.map((u) => (
-                <tr key={u.id} className="border-b border-slate-100 last:border-b-0 hover:bg-slate-50">
-                  <td className="px-4 py-3 font-medium">{u.displayName}</td>
-                  <td className="px-4 py-3">
-                    <select
-                      value={u.role}
-                      onChange={(e) => handleRoleChange(u, e.target.value)}
-                      disabled={updatingIds.has(u.id)}
-                      className="rounded border border-gray-300 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
-                    >
-                      <option value="USER">일반</option>
-                      <option value="ADMIN">관리자</option>
-                    </select>
-                  </td>
-                  <td className="px-4 py-3">
-                    <button
-                      type="button"
-                      onClick={() => handleStatusToggle(u)}
-                      disabled={updatingIds.has(u.id)}
-                      className={`inline-block rounded-full px-2.5 py-1 text-xs font-semibold transition-colors disabled:opacity-50 ${
-                        u.status === "ACTIVE"
-                          ? "bg-green-100 text-green-700 hover:bg-green-200"
-                          : "bg-red-100 text-red-700 hover:bg-red-200"
-                      }`}
-                    >
-                      {updatingIds.has(u.id) ? "..." : u.status === "ACTIVE" ? "활성" : "비활성"}
-                    </button>
-                  </td>
-                  <td className="px-4 py-3 text-sm text-gray-500">{new Date(u.createdAt).toLocaleDateString("ko-KR")}</td>
-                  <td className="px-4 py-3 text-sm text-gray-500">
-                    {u.lastLoginAt ? new Date(u.lastLoginAt).toLocaleDateString("ko-KR") : "-"}
-                  </td>
-                </tr>
-              ))}
+              {filteredUsers.map((u) => {
+                const roleLockReason = getRoleLockReason(u);
+                const statusLockReason = getStatusLockReason(u);
+
+                return (
+                  <tr key={u.id} className="border-b border-slate-100 last:border-b-0 hover:bg-slate-50">
+                    <td className="px-4 py-3 font-medium">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span>{u.displayName}</span>
+                        {isCurrentOperator(u) && (
+                          <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-semibold text-indigo-700">
+                            현재 운영자
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <select
+                        value={u.role}
+                        onChange={(e) => handleRoleChange(u, e.target.value)}
+                        disabled={updatingIds.has(u.id) || roleLockReason !== null}
+                        title={roleLockReason ?? ""}
+                        className="rounded border border-gray-300 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
+                      >
+                        <option value="USER">일반</option>
+                        <option value="ADMIN">관리자</option>
+                      </select>
+                    </td>
+                    <td className="px-4 py-3">
+                      <button
+                        type="button"
+                        onClick={() => handleStatusToggle(u)}
+                        disabled={updatingIds.has(u.id) || statusLockReason !== null}
+                        title={statusLockReason ?? ""}
+                        className={`inline-block rounded-full px-2.5 py-1 text-xs font-semibold transition-colors disabled:opacity-50 ${
+                          u.status === "ACTIVE"
+                            ? "bg-green-100 text-green-700 hover:bg-green-200"
+                            : "bg-red-100 text-red-700 hover:bg-red-200"
+                        }`}
+                      >
+                        {updatingIds.has(u.id) ? "..." : u.status === "ACTIVE" ? "활성" : "비활성"}
+                      </button>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-500">{new Date(u.createdAt).toLocaleDateString("ko-KR")}</td>
+                    <td className="px-4 py-3 text-sm text-gray-500">
+                      {u.lastLoginAt ? new Date(u.lastLoginAt).toLocaleDateString("ko-KR") : "-"}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </section>


### PR DESCRIPTION
﻿## Why
- In single-operator mode, user-role/status edits can accidentally lock out the only admin account.
- Backend already protects some cases, but UI should prevent risky actions earlier.

## What changed
- Added lock rules in User Management UI:
  - current logged-in operator account cannot change role/status
  - last active admin account cannot be downgraded or disabled
- Added explicit badge for current operator row.
- Added inline warning banner explaining lock behavior.
- Documented lock policy in Help page.

## Validation
- npx tsc --noEmit (apps/admin)
- npm run build (apps/admin)
