### PR TITLE
feat(admin): add full CRUD actions to user management

### DIFF
--- a/apps/admin/src/api/adminUsers.ts
+++ b/apps/admin/src/api/adminUsers.ts
@@ -1,4 +1,4 @@
-import { apiGet, apiPatch } from "./client";
+import { apiDelete, apiGet, apiPatch, apiPost } from "./client";
 
 export interface UserResponse {
   id: string;
@@ -14,10 +14,24 @@ export interface UpdateUserRequest {
   status?: string;
 }
 
+export interface CreateUserRequest {
+  displayName: string;
+  role?: string;
+  status?: string;
+}
+
 export function listUsers(): Promise<UserResponse[]> {
   return apiGet<UserResponse[]>("/admin/users");
 }
 
+export function createUser(req: CreateUserRequest): Promise<UserResponse> {
+  return apiPost<UserResponse>("/admin/users", req);
+}
+
 export function updateUser(id: string, req: UpdateUserRequest): Promise<UserResponse> {
   return apiPatch<UserResponse>(`/admin/users/${id}`, req);
+}
+
+export function deleteUser(id: string): Promise<UserResponse> {
+  return apiDelete<UserResponse>(`/admin/users/${id}`);
 }

--- a/apps/admin/src/pages/HelpPage.tsx
+++ b/apps/admin/src/pages/HelpPage.tsx
@@ -27,8 +27,10 @@ export default function HelpPage() {
       <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
         <h2 className="text-lg font-semibold text-slate-900">사용자 관리 잠금 정책</h2>
         <div className="mt-2 space-y-1 text-sm text-slate-600">
+          <div>- 사용자 관리에서 생성/조회/수정/삭제(비활성)가 가능합니다.</div>
           <div>- 현재 로그인한 운영자 계정은 역할/상태 변경이 잠깁니다.</div>
           <div>- 마지막 활성 관리자 계정은 USER 변경/비활성화가 잠깁니다.</div>
+          <div>- 사용자 삭제는 소프트 삭제이며 `DISABLED` 상태로 처리됩니다.</div>
           <div>- 목적: 단일 운영자 환경에서 관리자 계정 잠금(셀프 락아웃) 방지</div>
         </div>
       </section>

--- a/apps/admin/src/pages/UserListPage.tsx
+++ b/apps/admin/src/pages/UserListPage.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
-import { listUsers, updateUser, type UserResponse } from "../api/adminUsers";
+import { createUser, deleteUser, listUsers, updateUser, type UserResponse } from "../api/adminUsers";
 import { useAuth } from "../auth/AuthContext";
 
 type RoleFilter = "all" | "ADMIN" | "USER";
 type StatusFilter = "all" | "ACTIVE" | "DISABLED";
+type EditableRole = "ADMIN" | "USER";
+type EditableStatus = "ACTIVE" | "DISABLED";
 
 export default function UserListPage() {
   const { user: currentUser } = useAuth();
@@ -11,10 +13,19 @@ export default function UserListPage() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [mutationError, setMutationError] = useState<string | null>(null);
+
   const [search, setSearch] = useState("");
   const [roleFilter, setRoleFilter] = useState<RoleFilter>("all");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+
   const [updatingIds, setUpdatingIds] = useState<Set<string>>(new Set());
+  const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set());
+
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [newDisplayName, setNewDisplayName] = useState("");
+  const [newRole, setNewRole] = useState<EditableRole>("USER");
+  const [newStatus, setNewStatus] = useState<EditableStatus>("ACTIVE");
+  const [creating, setCreating] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -29,6 +40,7 @@ export default function UserListPage() {
       .finally(() => {
         if (!cancelled) setLoading(false);
       });
+
     return () => {
       cancelled = true;
     };
@@ -74,10 +86,24 @@ export default function UserListPage() {
     return null;
   };
 
-  const handleRoleChange = async (user: UserResponse, newRole: string) => {
-    if (newRole === user.role) {
+  const getDeleteLockReason = (targetUser: UserResponse): string | null => {
+    if (isCurrentOperator(targetUser)) {
+      return "현재 로그인한 운영자 계정은 삭제할 수 없습니다.";
+    }
+    if (isLastActiveAdmin(targetUser)) {
+      return "마지막 활성 관리자 계정은 삭제할 수 없습니다.";
+    }
+    if (targetUser.status === "DISABLED") {
+      return "이미 삭제(비활성) 처리된 계정입니다.";
+    }
+    return null;
+  };
+
+  const handleRoleChange = async (user: UserResponse, newRoleValue: string) => {
+    if (newRoleValue === user.role) {
       return;
     }
+
     const lockReason = getRoleLockReason(user);
     if (lockReason) {
       setMutationError(lockReason);
@@ -87,7 +113,7 @@ export default function UserListPage() {
     setMutationError(null);
     setUpdatingIds((prev) => new Set(prev).add(user.id));
     try {
-      const updated = await updateUser(user.id, { role: newRole });
+      const updated = await updateUser(user.id, { role: newRoleValue });
       setUsers((prev) => prev.map((u) => (u.id === user.id ? updated : u)));
     } catch (err) {
       setMutationError(err instanceof Error ? err.message : "역할 변경에 실패했습니다.");
@@ -107,11 +133,11 @@ export default function UserListPage() {
       return;
     }
 
-    const newStatus = user.status === "ACTIVE" ? "DISABLED" : "ACTIVE";
+    const newStatusValue = user.status === "ACTIVE" ? "DISABLED" : "ACTIVE";
     setMutationError(null);
     setUpdatingIds((prev) => new Set(prev).add(user.id));
     try {
-      const updated = await updateUser(user.id, { status: newStatus });
+      const updated = await updateUser(user.id, { status: newStatusValue });
       setUsers((prev) => prev.map((u) => (u.id === user.id ? updated : u)));
     } catch (err) {
       setMutationError(err instanceof Error ? err.message : "상태 변경에 실패했습니다.");
@@ -124,16 +150,90 @@ export default function UserListPage() {
     }
   };
 
+  const handleDeleteUser = async (targetUser: UserResponse) => {
+    const lockReason = getDeleteLockReason(targetUser);
+    if (lockReason) {
+      setMutationError(lockReason);
+      return;
+    }
+
+    const confirmed = window.confirm(`"${targetUser.displayName}" 사용자를 삭제(비활성) 처리하시겠습니까?`);
+    if (!confirmed) return;
+
+    setMutationError(null);
+    setDeletingIds((prev) => new Set(prev).add(targetUser.id));
+    try {
+      const deleted = await deleteUser(targetUser.id);
+      setUsers((prev) => prev.map((u) => (u.id === targetUser.id ? deleted : u)));
+    } catch (err) {
+      setMutationError(err instanceof Error ? err.message : "삭제에 실패했습니다.");
+    } finally {
+      setDeletingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(targetUser.id);
+        return next;
+      });
+    }
+  };
+
+  const resetCreateForm = () => {
+    setNewDisplayName("");
+    setNewRole("USER");
+    setNewStatus("ACTIVE");
+  };
+
+  const handleCreateUser = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newDisplayName.trim()) {
+      setMutationError("이름을 입력해 주세요.");
+      return;
+    }
+
+    setMutationError(null);
+    setCreating(true);
+    try {
+      const created = await createUser({
+        displayName: newDisplayName.trim(),
+        role: newRole,
+        status: newStatus,
+      });
+      setUsers((prev) => [created, ...prev]);
+      resetCreateForm();
+      setShowCreateForm(false);
+    } catch (err) {
+      setMutationError(err instanceof Error ? err.message : "사용자 생성에 실패했습니다.");
+    } finally {
+      setCreating(false);
+    }
+  };
+
   return (
     <div className="space-y-4">
       <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-        <h2 className="text-xl font-bold text-slate-900">사용자 관리</h2>
-        <p className="mt-1 text-sm text-slate-600">
-          단일 운영자 환경에서는 관리자 계정을 최소 1개 유지해야 합니다.
-        </p>
-        <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
-          현재 로그인한 운영자 계정과 마지막 활성 관리자 계정은 실수 방지를 위해 역할/상태 변경이 잠깁니다.
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-xl font-bold text-slate-900">사용자 관리</h2>
+            <p className="mt-1 text-sm text-slate-600">생성/조회/수정/삭제(비활성) 작업을 수행합니다.</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              if (showCreateForm) {
+                resetCreateForm();
+              }
+              setShowCreateForm((prev) => !prev);
+            }}
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
+          >
+            {showCreateForm ? "생성 취소" : "새 사용자 생성"}
+          </button>
         </div>
+
+        <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+          현재 로그인한 운영자 계정과 마지막 활성 관리자 계정은 실수 방지를 위해 수정/삭제가 잠깁니다. 삭제는 soft-delete로
+          `DISABLED` 처리됩니다.
+        </div>
+
         <div className="mt-4 flex flex-col gap-3 md:flex-row">
           <input
             type="text"
@@ -161,6 +261,54 @@ export default function UserListPage() {
             <option value="DISABLED">비활성</option>
           </select>
         </div>
+
+        {showCreateForm && (
+          <form onSubmit={handleCreateUser} className="mt-4 grid grid-cols-1 gap-3 rounded-xl border border-slate-200 bg-slate-50 p-3 md:grid-cols-4">
+            <input
+              type="text"
+              value={newDisplayName}
+              onChange={(e) => setNewDisplayName(e.target.value)}
+              placeholder="사용자 이름"
+              className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 md:col-span-2"
+              required
+            />
+            <select
+              value={newRole}
+              onChange={(e) => setNewRole(e.target.value as EditableRole)}
+              className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            >
+              <option value="USER">일반</option>
+              <option value="ADMIN">관리자</option>
+            </select>
+            <select
+              value={newStatus}
+              onChange={(e) => setNewStatus(e.target.value as EditableStatus)}
+              className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            >
+              <option value="ACTIVE">활성</option>
+              <option value="DISABLED">비활성</option>
+            </select>
+            <div className="flex items-center gap-2 md:col-span-4">
+              <button
+                type="submit"
+                disabled={creating || !newDisplayName.trim()}
+                className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-50"
+              >
+                {creating ? "생성 중..." : "사용자 생성"}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  resetCreateForm();
+                  setShowCreateForm(false);
+                }}
+                className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100"
+              >
+                취소
+              </button>
+            </div>
+          </form>
+        )}
       </section>
 
       {loading && <p className="text-sm text-gray-500">로딩 중...</p>}
@@ -172,19 +320,20 @@ export default function UserListPage() {
       {!loading && !loadError && (
         <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
           <table className="w-full text-left">
-            <thead className="bg-slate-50 border-b border-slate-200">
+            <thead className="border-b border-slate-200 bg-slate-50">
               <tr>
                 <th className="px-4 py-3 text-sm font-semibold text-gray-600">이름</th>
                 <th className="px-4 py-3 text-sm font-semibold text-gray-600">역할</th>
                 <th className="px-4 py-3 text-sm font-semibold text-gray-600">상태</th>
                 <th className="px-4 py-3 text-sm font-semibold text-gray-600">가입일</th>
                 <th className="px-4 py-3 text-sm font-semibold text-gray-600">최근 로그인</th>
+                <th className="px-4 py-3 text-sm font-semibold text-gray-600">작업</th>
               </tr>
             </thead>
             <tbody>
               {filteredUsers.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="px-4 py-10 text-center text-gray-400">
+                  <td colSpan={6} className="px-4 py-10 text-center text-gray-400">
                     {search || roleFilter !== "all" || statusFilter !== "all"
                       ? "검색 결과가 없습니다."
                       : "등록된 사용자가 없습니다."}
@@ -194,6 +343,8 @@ export default function UserListPage() {
               {filteredUsers.map((u) => {
                 const roleLockReason = getRoleLockReason(u);
                 const statusLockReason = getStatusLockReason(u);
+                const deleteLockReason = getDeleteLockReason(u);
+                const inProgress = updatingIds.has(u.id) || deletingIds.has(u.id);
 
                 return (
                   <tr key={u.id} className="border-b border-slate-100 last:border-b-0 hover:bg-slate-50">
@@ -211,7 +362,7 @@ export default function UserListPage() {
                       <select
                         value={u.role}
                         onChange={(e) => handleRoleChange(u, e.target.value)}
-                        disabled={updatingIds.has(u.id) || roleLockReason !== null}
+                        disabled={inProgress || roleLockReason !== null}
                         title={roleLockReason ?? ""}
                         className="rounded border border-gray-300 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
                       >
@@ -223,7 +374,7 @@ export default function UserListPage() {
                       <button
                         type="button"
                         onClick={() => handleStatusToggle(u)}
-                        disabled={updatingIds.has(u.id) || statusLockReason !== null}
+                        disabled={inProgress || statusLockReason !== null}
                         title={statusLockReason ?? ""}
                         className={`inline-block rounded-full px-2.5 py-1 text-xs font-semibold transition-colors disabled:opacity-50 ${
                           u.status === "ACTIVE"
@@ -231,12 +382,23 @@ export default function UserListPage() {
                             : "bg-red-100 text-red-700 hover:bg-red-200"
                         }`}
                       >
-                        {updatingIds.has(u.id) ? "..." : u.status === "ACTIVE" ? "활성" : "비활성"}
+                        {inProgress ? "..." : u.status === "ACTIVE" ? "활성" : "비활성"}
                       </button>
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-500">{new Date(u.createdAt).toLocaleDateString("ko-KR")}</td>
                     <td className="px-4 py-3 text-sm text-gray-500">
                       {u.lastLoginAt ? new Date(u.lastLoginAt).toLocaleDateString("ko-KR") : "-"}
+                    </td>
+                    <td className="px-4 py-3">
+                      <button
+                        type="button"
+                        onClick={() => handleDeleteUser(u)}
+                        disabled={inProgress || deleteLockReason !== null}
+                        title={deleteLockReason ?? ""}
+                        className="text-sm font-semibold text-red-600 hover:text-red-800 disabled:opacity-40"
+                      >
+                        {deletingIds.has(u.id) ? "삭제 중..." : "삭제"}
+                      </button>
                     </td>
                   </tr>
                 );

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminCreateUserUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminCreateUserUseCase.java
@@ -1,0 +1,39 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.common.error.ApiException;
+import com.eunhyehymn.domain.model.Role;
+import com.eunhyehymn.domain.model.User;
+import com.eunhyehymn.domain.model.UserStatus;
+import com.eunhyehymn.domain.repository.UserRepository;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+
+public class AdminCreateUserUseCase {
+    private final UserRepository userRepository;
+
+    public AdminCreateUserUseCase(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public User create(String displayName, Role role, UserStatus status) {
+        String resolvedDisplayName = displayName == null ? "" : displayName.trim();
+        if (resolvedDisplayName.isBlank()) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "validation_error", "displayName은 비워둘 수 없습니다", null);
+        }
+
+        Role resolvedRole = role != null ? role : Role.USER;
+        UserStatus resolvedStatus = status != null ? status : UserStatus.ACTIVE;
+        Instant now = Instant.now();
+
+        User user = new User(
+            UUID.randomUUID(),
+            resolvedDisplayName,
+            resolvedRole,
+            resolvedStatus,
+            now,
+            null
+        );
+        return userRepository.save(user);
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminDeleteUserUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminDeleteUserUseCase.java
@@ -1,0 +1,47 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.common.error.ApiException;
+import com.eunhyehymn.domain.model.Role;
+import com.eunhyehymn.domain.model.User;
+import com.eunhyehymn.domain.model.UserStatus;
+import com.eunhyehymn.domain.repository.UserRepository;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+
+public class AdminDeleteUserUseCase {
+    private final UserRepository userRepository;
+
+    public AdminDeleteUserUseCase(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public User delete(UUID requesterId, UUID targetUserId) {
+        User existing = userRepository.findById(targetUserId)
+            .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "user_not_found", "사용자를 찾을 수 없습니다", null));
+
+        if (requesterId.equals(targetUserId)) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "self_delete", "자신의 계정은 삭제할 수 없습니다", null);
+        }
+
+        if (existing.role() == Role.ADMIN && existing.status() == UserStatus.ACTIVE) {
+            long activeAdminCount = userRepository.countByRoleAndStatus(Role.ADMIN, UserStatus.ACTIVE);
+            if (activeAdminCount <= 1) {
+                throw new ApiException(HttpStatus.BAD_REQUEST, "last_admin", "마지막 활성 관리자를 삭제할 수 없습니다", null);
+            }
+        }
+
+        if (existing.status() == UserStatus.DISABLED) {
+            return existing;
+        }
+
+        User deleted = new User(
+            existing.id(),
+            existing.displayName(),
+            existing.role(),
+            UserStatus.DISABLED,
+            existing.createdAt(),
+            existing.lastLoginAt()
+        );
+        return userRepository.save(deleted);
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/UseCaseConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/UseCaseConfig.java
@@ -1,6 +1,8 @@
 package com.eunhyehymn.common.config;
 
 import com.eunhyehymn.application.usecases.AdminCreateHymnUseCase;
+import com.eunhyehymn.application.usecases.AdminCreateUserUseCase;
+import com.eunhyehymn.application.usecases.AdminDeleteUserUseCase;
 import com.eunhyehymn.application.usecases.AdminEventExportJobUseCase;
 import com.eunhyehymn.application.usecases.AdminListEventsUseCase;
 import com.eunhyehymn.application.usecases.AdminDeleteHymnUseCase;
@@ -139,5 +141,15 @@ public class UseCaseConfig {
     @Bean
     AdminUpdateUserUseCase adminUpdateUserUseCase(UserRepository userRepository) {
         return new AdminUpdateUserUseCase(userRepository);
+    }
+
+    @Bean
+    AdminCreateUserUseCase adminCreateUserUseCase(UserRepository userRepository) {
+        return new AdminCreateUserUseCase(userRepository);
+    }
+
+    @Bean
+    AdminDeleteUserUseCase adminDeleteUserUseCase(UserRepository userRepository) {
+        return new AdminDeleteUserUseCase(userRepository);
     }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminUserController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminUserController.java
@@ -1,5 +1,7 @@
 package com.eunhyehymn.presentation.controllers;
 
+import com.eunhyehymn.application.usecases.AdminCreateUserUseCase;
+import com.eunhyehymn.application.usecases.AdminDeleteUserUseCase;
 import com.eunhyehymn.application.usecases.AdminListUsersUseCase;
 import com.eunhyehymn.application.usecases.AdminUpdateUserUseCase;
 import com.eunhyehymn.common.error.ApiException;
@@ -7,13 +9,16 @@ import com.eunhyehymn.common.response.ApiResponse;
 import com.eunhyehymn.domain.model.Role;
 import com.eunhyehymn.domain.model.User;
 import com.eunhyehymn.domain.model.UserStatus;
+import jakarta.validation.constraints.NotBlank;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,13 +29,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/admin/users")
 @Validated
 public class AdminUserController {
+    private final AdminCreateUserUseCase adminCreateUserUseCase;
+    private final AdminDeleteUserUseCase adminDeleteUserUseCase;
     private final AdminListUsersUseCase adminListUsersUseCase;
     private final AdminUpdateUserUseCase adminUpdateUserUseCase;
 
     public AdminUserController(
+        AdminCreateUserUseCase adminCreateUserUseCase,
+        AdminDeleteUserUseCase adminDeleteUserUseCase,
         AdminListUsersUseCase adminListUsersUseCase,
         AdminUpdateUserUseCase adminUpdateUserUseCase
     ) {
+        this.adminCreateUserUseCase = adminCreateUserUseCase;
+        this.adminDeleteUserUseCase = adminDeleteUserUseCase;
         this.adminListUsersUseCase = adminListUsersUseCase;
         this.adminUpdateUserUseCase = adminUpdateUserUseCase;
     }
@@ -41,6 +52,14 @@ public class AdminUserController {
             .map(UserResponse::from)
             .toList();
         return ApiResponse.success(items);
+    }
+
+    @PostMapping
+    public ApiResponse<UserResponse> create(@RequestBody @Validated CreateUserRequest request) {
+        Role role = parseEnum(Role.class, request.role(), "role");
+        UserStatus status = parseEnum(UserStatus.class, request.status(), "status");
+        User user = adminCreateUserUseCase.create(request.displayName(), role, status);
+        return ApiResponse.success(UserResponse.from(user));
     }
 
     @PatchMapping("/{id}")
@@ -56,6 +75,13 @@ public class AdminUserController {
         return ApiResponse.success(UserResponse.from(user));
     }
 
+    @DeleteMapping("/{id}")
+    public ApiResponse<UserResponse> delete(@PathVariable UUID id, Authentication authentication) {
+        UUID requesterId = UUID.fromString(authentication.getName());
+        User user = adminDeleteUserUseCase.delete(requesterId, id);
+        return ApiResponse.success(UserResponse.from(user));
+    }
+
     private <E extends Enum<E>> E parseEnum(Class<E> enumClass, String value, String fieldName) {
         if (value == null) {
             return null;
@@ -66,6 +92,13 @@ public class AdminUserController {
             throw new ApiException(HttpStatus.BAD_REQUEST, "validation_error",
                 fieldName + " 값이 올바르지 않습니다: " + value, null);
         }
+    }
+
+    public record CreateUserRequest(
+        @NotBlank String displayName,
+        String role,
+        String status
+    ) {
     }
 
     public record UserResponse(

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminUserApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminUserApiTest.java
@@ -1,7 +1,9 @@
 package com.eunhyehymn.presentation.controllers;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -115,6 +117,54 @@ class AdminUserApiTest {
     }
 
     @Test
+    void adminCanCreateUser() throws Exception {
+        String payload = objectMapper.writeValueAsString(Map.of(
+            "displayName", "신규사용자",
+            "role", "USER",
+            "status", "ACTIVE"
+        ));
+
+        mockMvc.perform(post("/admin/users")
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.displayName").value("신규사용자"))
+            .andExpect(jsonPath("$.data.role").value("USER"))
+            .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+    }
+
+    @Test
+    void createUserWithInvalidRoleReturnsBadRequest() throws Exception {
+        String payload = objectMapper.writeValueAsString(Map.of(
+            "displayName", "신규사용자",
+            "role", "INVALID"
+        ));
+
+        mockMvc.perform(post("/admin/users")
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void adminCanDeleteUserSoftly() throws Exception {
+        mockMvc.perform(delete("/admin/users/" + userId)
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.status").value("DISABLED"));
+    }
+
+    @Test
+    void adminCannotDeleteSelf() throws Exception {
+        mockMvc.perform(delete("/admin/users/" + adminId)
+                .header("Authorization", "Bearer " + adminToken))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error.code").value("self_delete"));
+    }
+
+    @Test
     void invalidRoleReturnsBadRequest() throws Exception {
         String payload = objectMapper.writeValueAsString(Map.of("role", "INVALID"));
 
@@ -170,6 +220,23 @@ class AdminUserApiTest {
                 .header("Authorization", "Bearer " + adminToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(demotePayload))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error.code").value("last_admin"));
+    }
+
+    @Test
+    void cannotDeleteLastActiveAdmin() throws Exception {
+        UUID secondAdminId = UUID.randomUUID();
+        userJpaRepository.save(new UserEntity(secondAdminId, "두번째관리자", Role.ADMIN, UserStatus.ACTIVE, Instant.now(), Instant.now()));
+        String secondAdminToken = jwtService.issueAccessToken(secondAdminId.toString(), Role.ADMIN.name());
+
+        mockMvc.perform(delete("/admin/users/" + adminId)
+                .header("Authorization", "Bearer " + secondAdminToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.status").value("DISABLED"));
+
+        mockMvc.perform(delete("/admin/users/" + secondAdminId)
+                .header("Authorization", "Bearer " + adminToken))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.error.code").value("last_admin"));
     }


### PR DESCRIPTION
﻿## Why
- User management lacked explicit Create/Delete operations while hymn management already had full CRUD.
- Operator requested full CRUD coverage in admin management sections.

## What changed
### Backend
- Added `AdminCreateUserUseCase` and `AdminDeleteUserUseCase`.
- Added `POST /admin/users` to create users.
- Added `DELETE /admin/users/{id}` as soft-delete (sets `status=DISABLED`).
- Preserved lock safety:
  - cannot delete self (`self_delete`)
  - cannot delete last active admin (`last_admin`)
- Wired new use cases in `UseCaseConfig`.

### Frontend (Admin)
- Added user API methods: create/delete.
- Updated User Management UI:
  - user create form (name/role/status)
  - delete action per row
  - lock-aware controls for self/last-admin safety
  - clear note that delete is soft-delete (`DISABLED`)
- Updated help page with CRUD and soft-delete policy.

### Tests
- Expanded `AdminUserApiTest`:
  - create user success
  - create invalid role failure
  - delete user success (soft-delete)
  - self delete blocked
  - last active admin delete blocked

## Verification
- `./gradlew.bat test --no-daemon` (apps/api)
- `npx tsc --noEmit` (apps/admin)
- `npm run build` (apps/admin)
