### PR TITLE
refactor(admin): harden CRUD edge cases and improve UX

### DIFF
--- a/apps/admin/src/api/hymns.ts
+++ b/apps/admin/src/api/hymns.ts
@@ -3,7 +3,7 @@ import { apiDelete, apiGet, apiPatch, apiPost } from "./client";
 export interface HymnResponse {
   id: string;
   title: string;
-  number: number | null;
+  number: string | null;
   tags: string | null;
   enabled: boolean;
   createdAt: string;
@@ -12,7 +12,7 @@ export interface HymnResponse {
 export interface HymnDetailResponse {
   id: string;
   title: string;
-  number: number | null;
+  number: string | null;
   tags: string | null;
   enabled: boolean;
   createdAt: string;
@@ -30,14 +30,14 @@ export interface AssetResponse {
 
 export interface CreateHymnRequest {
   title: string;
-  number?: number | null;
+  number?: string | null;
   tags?: string | null;
   enabled?: boolean;
 }
 
 export interface UpdateHymnRequest {
   title?: string | null;
-  number?: number | null;
+  number?: string | null;
   tags?: string | null;
   enabled?: boolean | null;
 }

--- a/apps/admin/src/pages/HymnCreatePage.tsx
+++ b/apps/admin/src/pages/HymnCreatePage.tsx
@@ -2,6 +2,14 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { createHymn } from "../api/hymns";
 
+const TITLE_MAX_LENGTH = 120;
+const NUMBER_MAX_LENGTH = 20;
+
+function normalizeOptional(value: string): string | null {
+  const normalized = value.trim();
+  return normalized ? normalized : null;
+}
+
 export default function HymnCreatePage() {
   const navigate = useNavigate();
   const [title, setTitle] = useState("");
@@ -13,17 +21,29 @@ export default function HymnCreatePage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!title.trim()) {
+    const normalizedTitle = title.trim();
+    const normalizedNumber = number.trim();
+
+    if (!normalizedTitle) {
       setError("제목을 입력해 주세요.");
       return;
     }
+    if (normalizedTitle.length > TITLE_MAX_LENGTH) {
+      setError(`제목은 최대 ${TITLE_MAX_LENGTH}자까지 입력할 수 있습니다.`);
+      return;
+    }
+    if (normalizedNumber.length > NUMBER_MAX_LENGTH) {
+      setError(`번호는 최대 ${NUMBER_MAX_LENGTH}자까지 입력할 수 있습니다.`);
+      return;
+    }
+
     setError(null);
     setSaving(true);
     try {
       await createHymn({
-        title: title.trim(),
-        number: number ? parseInt(number, 10) : null,
-        tags: tags.trim() || null,
+        title: normalizedTitle,
+        number: normalizedNumber || null,
+        tags: normalizeOptional(tags),
         enabled,
       });
       navigate("/hymns", { replace: true });
@@ -36,10 +56,10 @@ export default function HymnCreatePage() {
 
   return (
     <div className="max-w-lg">
-      <h1 className="text-2xl font-bold mb-6">새 찬양 추가</h1>
-      <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow p-6 flex flex-col gap-4">
+      <h1 className="mb-6 text-2xl font-bold">새 찬양 추가</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4 rounded-lg bg-white p-6 shadow">
         <div>
-          <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-1">
+          <label htmlFor="title" className="mb-1 block text-sm font-medium text-gray-700">
             제목 *
           </label>
           <input
@@ -47,23 +67,32 @@ export default function HymnCreatePage() {
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            maxLength={TITLE_MAX_LENGTH}
+            className="w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
+          <div className="mt-1 text-right text-xs text-slate-500">
+            {title.trim().length}/{TITLE_MAX_LENGTH}
+          </div>
         </div>
+
         <div>
-          <label htmlFor="number" className="block text-sm font-medium text-gray-700 mb-1">
+          <label htmlFor="number" className="mb-1 block text-sm font-medium text-gray-700">
             번호
           </label>
           <input
             id="number"
-            type="number"
+            type="text"
             value={number}
             onChange={(e) => setNumber(e.target.value)}
-            className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            maxLength={NUMBER_MAX_LENGTH}
+            placeholder="예: 23, A-12"
+            className="w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
+          <div className="mt-1 text-xs text-slate-500">숫자/문자 모두 입력 가능합니다.</div>
         </div>
+
         <div>
-          <label htmlFor="tags" className="block text-sm font-medium text-gray-700 mb-1">
+          <label htmlFor="tags" className="mb-1 block text-sm font-medium text-gray-700">
             태그 (쉼표 구분)
           </label>
           <input
@@ -72,9 +101,10 @@ export default function HymnCreatePage() {
             value={tags}
             onChange={(e) => setTags(e.target.value)}
             placeholder="예: 찬양, 경배"
-            className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
         </div>
+
         <div className="flex items-center gap-2">
           <input
             id="enabled"
@@ -93,15 +123,15 @@ export default function HymnCreatePage() {
         <div className="flex gap-3">
           <button
             type="submit"
-            disabled={saving}
-            className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700 disabled:opacity-50"
+            disabled={saving || !title.trim()}
+            className="rounded bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700 disabled:opacity-50"
           >
             {saving ? "저장 중..." : "저장"}
           </button>
           <button
             type="button"
             onClick={() => navigate("/hymns")}
-            className="border border-gray-300 px-4 py-2 rounded hover:bg-gray-50"
+            className="rounded border border-gray-300 px-4 py-2 hover:bg-gray-50"
           >
             취소
           </button>

--- a/apps/admin/src/pages/HymnEditPage.tsx
+++ b/apps/admin/src/pages/HymnEditPage.tsx
@@ -1,8 +1,16 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { deleteAsset } from "../api/adminAssets";
 import { deleteHymn, getHymnDetail, updateHymn, type HymnDetailResponse } from "../api/hymns";
 import AdminAssetUploadPage from "./AdminAssetUploadPage";
+
+const TITLE_MAX_LENGTH = 120;
+const NUMBER_MAX_LENGTH = 20;
+
+function normalizeOptional(value: string): string | null {
+  const normalized = value.trim();
+  return normalized ? normalized : null;
+}
 
 export default function HymnEditPage() {
   const { id } = useParams<{ id: string }>();
@@ -16,46 +24,78 @@ export default function HymnEditPage() {
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [assetActionError, setAssetActionError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deletingAssetId, setDeletingAssetId] = useState<string | null>(null);
 
-  const loadHymn = useCallback(() => {
+  const loadHymn = useCallback(async () => {
     if (!id) {
       setLoading(false);
       return;
     }
     setLoading(true);
-    getHymnDetail(id)
-      .then((data) => {
-        setHymn(data);
-        setTitle(data.title);
-        setNumber(data.number != null ? String(data.number) : "");
-        setTags(data.tags ?? "");
-        setEnabled(data.enabled);
-      })
-      .catch((err) => {
-        setError(err instanceof Error ? err.message : "찬양을 불러올 수 없습니다.");
-      })
-      .finally(() => {
-        setLoading(false);
-      });
+    setError(null);
+    try {
+      const data = await getHymnDetail(id);
+      setHymn(data);
+      setTitle(data.title);
+      setNumber(data.number ?? "");
+      setTags(data.tags ?? "");
+      setEnabled(data.enabled);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "찬양을 불러올 수 없습니다.");
+    } finally {
+      setLoading(false);
+    }
   }, [id]);
 
   useEffect(() => {
-    loadHymn();
+    void loadHymn();
   }, [loadHymn]);
+
+  const normalizedTitle = title.trim();
+  const normalizedNumber = number.trim();
+  const normalizedTags = tags.trim();
+
+  const hasDirtyChanges = useMemo(() => {
+    if (!hymn) return false;
+    return (
+      normalizedTitle !== hymn.title
+      || (normalizedNumber || null) !== hymn.number
+      || (normalizedTags || null) !== hymn.tags
+      || enabled !== hymn.enabled
+    );
+  }, [enabled, hymn, normalizedNumber, normalizedTags, normalizedTitle]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!id) return;
+
+    if (!normalizedTitle) {
+      setError("제목을 입력해 주세요.");
+      return;
+    }
+    if (normalizedTitle.length > TITLE_MAX_LENGTH) {
+      setError(`제목은 최대 ${TITLE_MAX_LENGTH}자까지 입력할 수 있습니다.`);
+      return;
+    }
+    if (normalizedNumber.length > NUMBER_MAX_LENGTH) {
+      setError(`번호는 최대 ${NUMBER_MAX_LENGTH}자까지 입력할 수 있습니다.`);
+      return;
+    }
+    if (!hasDirtyChanges) {
+      setError("변경된 내용이 없습니다.");
+      return;
+    }
+
     setError(null);
     setSaving(true);
     try {
       await updateHymn(id, {
-        title: title.trim() || null,
-        number: number ? parseInt(number, 10) : null,
-        tags: tags.trim() || null,
+        title: normalizedTitle,
+        number: normalizedNumber || null,
+        tags: normalizeOptional(tags),
         enabled,
       });
       navigate("/hymns", { replace: true });
@@ -66,15 +106,15 @@ export default function HymnEditPage() {
     }
   };
 
-  const handleAssetUploaded = useCallback(() => {
+  const handleAssetUploaded = useCallback(async () => {
     if (!id) return;
-    getHymnDetail(id)
-      .then((data) => {
-        setHymn(data);
-      })
-      .catch(() => {
-        // silently ignore refresh errors
-      });
+    try {
+      const data = await getHymnDetail(id);
+      setHymn(data);
+      setAssetActionError(null);
+    } catch (err) {
+      setAssetActionError(err instanceof Error ? err.message : "에셋 목록을 새로고침하지 못했습니다.");
+    }
   }, [id]);
 
   const handleDeleteHymn = async () => {
@@ -95,50 +135,85 @@ export default function HymnEditPage() {
   const handleDeleteAsset = async (assetId: string) => {
     if (!window.confirm("이 에셋을 삭제하시겠습니까?")) return;
     setDeletingAssetId(assetId);
+    setAssetActionError(null);
     try {
       await deleteAsset(assetId);
-      handleAssetUploaded();
+      await handleAssetUploaded();
     } catch (err) {
-      alert(err instanceof Error ? err.message : "에셋 삭제에 실패했습니다.");
+      setAssetActionError(err instanceof Error ? err.message : "에셋 삭제에 실패했습니다.");
     } finally {
       setDeletingAssetId(null);
     }
   };
 
   if (loading) return <p className="text-gray-500">로딩 중...</p>;
-  if (!hymn && error) return <p className="text-red-600">{error}</p>;
+  if (!hymn && error) {
+    return (
+      <div className="space-y-3">
+        <p className="text-red-600">{error}</p>
+        <button
+          type="button"
+          onClick={() => void loadHymn()}
+          className="rounded border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-700 hover:bg-slate-100"
+        >
+          다시 시도
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div className="max-w-2xl">
-      <h1 className="text-2xl font-bold mb-6">찬양 수정</h1>
-
-      <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow p-6 flex flex-col gap-4 mb-8">
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-3">
         <div>
-          <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-1">
-            제목
+          <h1 className="text-2xl font-bold">찬양 수정</h1>
+          {hymn && <p className="mt-1 text-xs text-slate-500">ID: {hymn.id}</p>}
+        </div>
+        <button
+          type="button"
+          onClick={() => void loadHymn()}
+          className="rounded border border-slate-300 px-3 py-1.5 text-sm font-semibold text-slate-700 hover:bg-slate-100"
+        >
+          데이터 새로고침
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="mb-8 flex flex-col gap-4 rounded-lg bg-white p-6 shadow">
+        <div>
+          <label htmlFor="title" className="mb-1 block text-sm font-medium text-gray-700">
+            제목 *
           </label>
           <input
             id="title"
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            maxLength={TITLE_MAX_LENGTH}
+            className="w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
+          <div className="mt-1 text-right text-xs text-slate-500">
+            {normalizedTitle.length}/{TITLE_MAX_LENGTH}
+          </div>
         </div>
+
         <div>
-          <label htmlFor="number" className="block text-sm font-medium text-gray-700 mb-1">
+          <label htmlFor="number" className="mb-1 block text-sm font-medium text-gray-700">
             번호
           </label>
           <input
             id="number"
-            type="number"
+            type="text"
             value={number}
             onChange={(e) => setNumber(e.target.value)}
-            className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            maxLength={NUMBER_MAX_LENGTH}
+            placeholder="예: 23, A-12"
+            className="w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
+          <div className="mt-1 text-xs text-slate-500">숫자/문자 모두 입력 가능합니다.</div>
         </div>
+
         <div>
-          <label htmlFor="tags" className="block text-sm font-medium text-gray-700 mb-1">
+          <label htmlFor="tags" className="mb-1 block text-sm font-medium text-gray-700">
             태그 (쉼표 구분)
           </label>
           <input
@@ -146,9 +221,10 @@ export default function HymnEditPage() {
             type="text"
             value={tags}
             onChange={(e) => setTags(e.target.value)}
-            className="w-full border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
         </div>
+
         <div className="flex items-center gap-2">
           <input
             id="enabled"
@@ -162,20 +238,21 @@ export default function HymnEditPage() {
           </label>
         </div>
 
+        {!hasDirtyChanges && <p className="text-xs text-slate-500">변경한 항목이 없으면 저장되지 않습니다.</p>}
         {error && <p className="text-sm text-red-600">{error}</p>}
 
         <div className="flex gap-3">
           <button
             type="submit"
-            disabled={saving}
-            className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700 disabled:opacity-50"
+            disabled={saving || !normalizedTitle || !hasDirtyChanges}
+            className="rounded bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700 disabled:opacity-50"
           >
             {saving ? "저장 중..." : "저장"}
           </button>
           <button
             type="button"
             onClick={() => navigate("/hymns")}
-            className="border border-gray-300 px-4 py-2 rounded hover:bg-gray-50"
+            className="rounded border border-gray-300 px-4 py-2 hover:bg-gray-50"
           >
             취소
           </button>
@@ -183,68 +260,70 @@ export default function HymnEditPage() {
             type="button"
             onClick={handleDeleteHymn}
             disabled={deleting}
-            className="ml-auto bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 disabled:opacity-50"
+            className="ml-auto rounded bg-red-600 px-4 py-2 text-white hover:bg-red-700 disabled:opacity-50"
           >
             {deleting ? "삭제 중..." : "삭제"}
           </button>
         </div>
       </form>
 
-      {/* Asset section */}
       {hymn && (
         <>
           {hymn.assets.length > 0 && (
-            <div className="bg-white rounded-lg shadow p-6 mb-6">
-              <h2 className="text-lg font-semibold mb-3">등록된 에셋</h2>
-              <table className="w-full text-left text-sm">
-                <thead className="border-b">
-                  <tr>
-                    <th className="pb-2 font-medium text-gray-600">타입</th>
-                    <th className="pb-2 font-medium text-gray-600">파트</th>
-                    <th className="pb-2 font-medium text-gray-600">ObjectKey</th>
-                    <th className="pb-2 font-medium text-gray-600">URL</th>
-                    <th className="pb-2 font-medium text-gray-600"></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {hymn.assets.map((a) => (
-                    <tr key={a.id} className="border-b last:border-b-0">
-                      <td className="py-2">{a.type}</td>
-                      <td className="py-2">{a.part}</td>
-                      <td className="py-2 text-gray-500 truncate max-w-xs">{a.objectKey}</td>
-                      <td className="py-2">
-                        {/^https?:\/\//i.test(a.url) ? (
-                          <a
-                            href={a.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-indigo-600 hover:underline"
-                          >
-                            열기
-                          </a>
-                        ) : (
-                          <span className="text-gray-400">-</span>
-                        )}
-                      </td>
-                      <td className="py-2">
-                        <button
-                          type="button"
-                          onClick={() => handleDeleteAsset(a.id)}
-                          disabled={deletingAssetId === a.id}
-                          className="text-red-600 hover:text-red-800 disabled:opacity-50 text-sm font-medium"
-                        >
-                          {deletingAssetId === a.id ? "삭제 중..." : "삭제"}
-                        </button>
-                      </td>
+            <div className="mb-6 rounded-lg bg-white p-6 shadow">
+              <h2 className="mb-3 text-lg font-semibold">등록된 에셋</h2>
+              {assetActionError && <div className="mb-3 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{assetActionError}</div>}
+              <div className="overflow-x-auto">
+                <table className="min-w-[640px] w-full text-left text-sm">
+                  <thead className="border-b">
+                    <tr>
+                      <th className="pb-2 font-medium text-gray-600">타입</th>
+                      <th className="pb-2 font-medium text-gray-600">파트</th>
+                      <th className="pb-2 font-medium text-gray-600">ObjectKey</th>
+                      <th className="pb-2 font-medium text-gray-600">URL</th>
+                      <th className="pb-2 font-medium text-gray-600"></th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
+                  </thead>
+                  <tbody>
+                    {hymn.assets.map((asset) => (
+                      <tr key={asset.id} className="border-b last:border-b-0">
+                        <td className="py-2">{asset.type}</td>
+                        <td className="py-2">{asset.part}</td>
+                        <td className="max-w-xs truncate py-2 text-gray-500">{asset.objectKey}</td>
+                        <td className="py-2">
+                          {/^https?:\/\//i.test(asset.url) ? (
+                            <a
+                              href={asset.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-indigo-600 hover:underline"
+                            >
+                              열기
+                            </a>
+                          ) : (
+                            <span className="text-gray-400">-</span>
+                          )}
+                        </td>
+                        <td className="py-2">
+                          <button
+                            type="button"
+                            onClick={() => void handleDeleteAsset(asset.id)}
+                            disabled={deletingAssetId === asset.id}
+                            className="text-sm font-medium text-red-600 hover:text-red-800 disabled:opacity-50"
+                          >
+                            {deletingAssetId === asset.id ? "삭제 중..." : "삭제"}
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             </div>
           )}
 
-          <div className="bg-white rounded-lg shadow p-6">
-            <h2 className="text-lg font-semibold mb-3">에셋 업로드</h2>
+          <div className="rounded-lg bg-white p-6 shadow">
+            <h2 className="mb-3 text-lg font-semibold">에셋 업로드</h2>
             <AdminAssetUploadPage hymnId={id} onConfirmed={handleAssetUploaded} />
           </div>
         </>

--- a/apps/admin/src/pages/HymnListPage.tsx
+++ b/apps/admin/src/pages/HymnListPage.tsx
@@ -1,49 +1,62 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { deleteHymn, listHymns, updateHymn, type HymnResponse } from "../api/hymns";
 
 type EnabledFilter = "all" | "enabled" | "disabled";
 
+function StatCard({ title, value }: { title: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2">
+      <div className="text-xs text-slate-500">{title}</div>
+      <div className="mt-1 text-xl font-semibold text-slate-900">{value.toLocaleString("ko-KR")}</div>
+    </div>
+  );
+}
+
 export default function HymnListPage() {
   const [hymns, setHymns] = useState<HymnResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionSuccess, setActionSuccess] = useState<string | null>(null);
+
   const [search, setSearch] = useState("");
   const [enabledFilter, setEnabledFilter] = useState<EnabledFilter>("all");
   const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set());
   const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set());
-  const [actionError, setActionError] = useState<string | null>(null);
+
+  const loadHymns = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await listHymns();
+      setHymns(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "목록을 불러올 수 없습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    listHymns()
-      .then((data) => {
-        if (!cancelled) setHymns(data);
-      })
-      .catch((err) => {
-        if (!cancelled) setError(err instanceof Error ? err.message : "목록을 불러올 수 없습니다.");
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    void loadHymns();
+  }, [loadHymns]);
+
+  const clearActionFeedback = () => {
+    setActionError(null);
+    setActionSuccess(null);
+  };
 
   const filteredHymns = useMemo(() => {
     const query = search.trim().toLowerCase();
-    return hymns.filter((h) => {
-      // enabled filter
-      if (enabledFilter === "enabled" && !h.enabled) return false;
-      if (enabledFilter === "disabled" && h.enabled) return false;
+    return hymns.filter((hymn) => {
+      if (enabledFilter === "enabled" && !hymn.enabled) return false;
+      if (enabledFilter === "disabled" && hymn.enabled) return false;
 
-      // text search
       if (query) {
-        const titleMatch = h.title.toLowerCase().includes(query);
-        const numberMatch = h.number != null && String(h.number).includes(query);
-        const tagsMatch = h.tags != null && h.tags.toLowerCase().includes(query);
+        const titleMatch = hymn.title.toLowerCase().includes(query);
+        const numberMatch = hymn.number != null && hymn.number.toLowerCase().includes(query);
+        const tagsMatch = hymn.tags != null && hymn.tags.toLowerCase().includes(query);
         if (!titleMatch && !numberMatch && !tagsMatch) return false;
       }
 
@@ -51,12 +64,22 @@ export default function HymnListPage() {
     });
   }, [hymns, search, enabledFilter]);
 
+  const enabledCount = useMemo(() => hymns.filter((item) => item.enabled).length, [hymns]);
+  const disabledCount = hymns.length - enabledCount;
+  const hasActiveFilter = search.trim().length > 0 || enabledFilter !== "all";
+
+  const clearFilters = () => {
+    setSearch("");
+    setEnabledFilter("all");
+  };
+
   const handleToggleEnabled = async (hymn: HymnResponse) => {
+    clearActionFeedback();
     setTogglingIds((prev) => new Set(prev).add(hymn.id));
-    setActionError(null);
     try {
       const updated = await updateHymn(hymn.id, { enabled: !hymn.enabled });
-      setHymns((prev) => prev.map((h) => (h.id === hymn.id ? { ...h, enabled: updated.enabled } : h)));
+      setHymns((prev) => prev.map((item) => (item.id === hymn.id ? { ...item, enabled: updated.enabled } : item)));
+      setActionSuccess(`"${updated.title}" 찬양을 ${updated.enabled ? "활성" : "비활성"} 상태로 변경했습니다.`);
     } catch (err) {
       setActionError(err instanceof Error ? err.message : "상태 변경에 실패했습니다.");
     } finally {
@@ -70,11 +93,12 @@ export default function HymnListPage() {
 
   const handleDelete = async (hymn: HymnResponse) => {
     if (!window.confirm(`"${hymn.title}" 찬양을 삭제하시겠습니까? 관련된 에셋, 메모, 상태, 이벤트가 모두 삭제됩니다.`)) return;
+    clearActionFeedback();
     setDeletingIds((prev) => new Set(prev).add(hymn.id));
-    setActionError(null);
     try {
       await deleteHymn(hymn.id);
-      setHymns((prev) => prev.filter((h) => h.id !== hymn.id));
+      setHymns((prev) => prev.filter((item) => item.id !== hymn.id));
+      setActionSuccess(`"${hymn.title}" 찬양을 삭제했습니다.`);
     } catch (err) {
       setActionError(err instanceof Error ? err.message : "삭제에 실패했습니다.");
     } finally {
@@ -94,12 +118,28 @@ export default function HymnListPage() {
             <h2 className="text-xl font-bold text-slate-900">찬양 관리</h2>
             <p className="mt-1 text-sm text-slate-600">제목/태그 검색, 활성화 토글, 수정/삭제를 수행합니다.</p>
           </div>
-          <Link
-            to="/hymns/new"
-            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
-          >
-            새 찬양 추가
-          </Link>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void loadHymns()}
+              disabled={loading}
+              className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100 disabled:opacity-50"
+            >
+              {loading ? "새로고침 중..." : "목록 새로고침"}
+            </button>
+            <Link
+              to="/hymns/new"
+              className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
+            >
+              새 찬양 추가
+            </Link>
+          </div>
+        </div>
+
+        <div className="mt-4 grid grid-cols-3 gap-3">
+          <StatCard title="전체 찬양" value={hymns.length} />
+          <StatCard title="활성 찬양" value={enabledCount} />
+          <StatCard title="비활성 찬양" value={disabledCount} />
         </div>
 
         <div className="mt-4 flex flex-col gap-3 md:flex-row">
@@ -119,77 +159,116 @@ export default function HymnListPage() {
             <option value="enabled">활성만</option>
             <option value="disabled">비활성만</option>
           </select>
+          {hasActiveFilter && (
+            <button
+              type="button"
+              onClick={clearFilters}
+              className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100"
+            >
+              필터 초기화
+            </button>
+          )}
         </div>
       </section>
 
       {loading && <p className="text-sm text-gray-500">로딩 중...</p>}
-      {error && <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
+      {error && (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          <span>{error}</span>
+          <button
+            type="button"
+            onClick={() => void loadHymns()}
+            className="rounded border border-red-300 px-2.5 py-1 text-xs font-semibold text-red-700 hover:bg-red-100"
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+      {actionSuccess && (
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">{actionSuccess}</div>
+      )}
       {actionError && (
         <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{actionError}</div>
       )}
 
       {!loading && !error && (
         <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
-          <table className="w-full text-left">
-            <thead className="bg-slate-50 border-b border-slate-200">
-              <tr>
-                <th className="px-4 py-3 text-sm font-semibold text-gray-600">번호</th>
-                <th className="px-4 py-3 text-sm font-semibold text-gray-600">제목</th>
-                <th className="px-4 py-3 text-sm font-semibold text-gray-600">태그</th>
-                <th className="px-4 py-3 text-sm font-semibold text-gray-600">상태</th>
-                <th className="px-4 py-3 text-sm font-semibold text-gray-600">작업</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filteredHymns.length === 0 && (
+          <div className="overflow-x-auto">
+            <table className="min-w-[700px] w-full text-left">
+              <thead className="border-b border-slate-200 bg-slate-50">
                 <tr>
-                  <td colSpan={5} className="px-4 py-10 text-center text-gray-400">
-                    {search || enabledFilter !== "all" ? "검색 결과가 없습니다." : "등록된 찬양이 없습니다."}
-                  </td>
+                  <th className="px-4 py-3 text-sm font-semibold text-gray-600">번호</th>
+                  <th className="px-4 py-3 text-sm font-semibold text-gray-600">제목</th>
+                  <th className="px-4 py-3 text-sm font-semibold text-gray-600">태그</th>
+                  <th className="px-4 py-3 text-sm font-semibold text-gray-600">상태</th>
+                  <th className="px-4 py-3 text-sm font-semibold text-gray-600">작업</th>
                 </tr>
-              )}
-              {filteredHymns.map((h) => (
-                <tr key={h.id} className="border-b border-slate-100 last:border-b-0 hover:bg-slate-50">
-                  <td className="px-4 py-3 text-sm">{h.number ?? "-"}</td>
-                  <td className="px-4 py-3">
-                    <Link to={`/hymns/${h.id}/edit`} className="font-medium text-indigo-600 hover:underline">
-                      {h.title}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3 text-sm text-gray-500">{h.tags ?? "-"}</td>
-                  <td className="px-4 py-3">
-                    <button
-                      type="button"
-                      onClick={() => handleToggleEnabled(h)}
-                      disabled={togglingIds.has(h.id)}
-                      className={`inline-block rounded-full px-2.5 py-1 text-xs font-semibold transition-colors disabled:opacity-50 ${
-                        h.enabled
-                          ? "bg-green-100 text-green-700 hover:bg-green-200"
-                          : "bg-gray-100 text-gray-500 hover:bg-gray-200"
-                      }`}
-                    >
-                      {togglingIds.has(h.id) ? "..." : h.enabled ? "활성" : "비활성"}
-                    </button>
-                  </td>
-                  <td className="px-4 py-3">
-                    <button
-                      type="button"
-                      onClick={() => handleDelete(h)}
-                      disabled={deletingIds.has(h.id)}
-                      className="text-sm font-medium text-red-600 hover:text-red-800 disabled:opacity-50"
-                    >
-                      {deletingIds.has(h.id) ? "삭제 중..." : "삭제"}
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {filteredHymns.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="px-4 py-10 text-center text-gray-400">
+                      {hasActiveFilter ? (
+                        "검색 결과가 없습니다."
+                      ) : (
+                        <div className="space-y-2">
+                          <div>등록된 찬양이 없습니다.</div>
+                          <Link
+                            to="/hymns/new"
+                            className="inline-block rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-100"
+                          >
+                            첫 찬양 추가하기
+                          </Link>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                )}
+                {filteredHymns.map((hymn) => (
+                  <tr key={hymn.id} className="border-b border-slate-100 last:border-b-0 hover:bg-slate-50">
+                    <td className="px-4 py-3 text-sm">{hymn.number ?? "-"}</td>
+                    <td className="px-4 py-3">
+                      <Link to={`/hymns/${hymn.id}/edit`} className="font-medium text-indigo-600 hover:underline">
+                        {hymn.title}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-500">{hymn.tags ?? "-"}</td>
+                    <td className="px-4 py-3">
+                      <button
+                        type="button"
+                        onClick={() => void handleToggleEnabled(hymn)}
+                        disabled={togglingIds.has(hymn.id)}
+                        className={`inline-block rounded-full px-2.5 py-1 text-xs font-semibold transition-colors disabled:opacity-50 ${
+                          hymn.enabled
+                            ? "bg-green-100 text-green-700 hover:bg-green-200"
+                            : "bg-gray-100 text-gray-500 hover:bg-gray-200"
+                        }`}
+                      >
+                        {togglingIds.has(hymn.id) ? "..." : hymn.enabled ? "활성" : "비활성"}
+                      </button>
+                    </td>
+                    <td className="px-4 py-3">
+                      <button
+                        type="button"
+                        onClick={() => void handleDelete(hymn)}
+                        disabled={deletingIds.has(hymn.id)}
+                        className="text-sm font-medium text-red-600 hover:text-red-800 disabled:opacity-50"
+                      >
+                        {deletingIds.has(hymn.id) ? "삭제 중..." : "삭제"}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
       )}
 
-      {!loading && !error && (search || enabledFilter !== "all") && (
-        <p className="text-sm text-gray-500">{filteredHymns.length}건 / 전체 {hymns.length}건</p>
+      {!loading && !error && (
+        <p className="text-sm text-gray-500">
+          {filteredHymns.length}건 표시 / 전체 {hymns.length}건
+        </p>
       )}
     </div>
   );

--- a/apps/admin/src/pages/UserListPage.tsx
+++ b/apps/admin/src/pages/UserListPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { createUser, deleteUser, listUsers, updateUser, type UserResponse } from "../api/adminUsers";
 import { useAuth } from "../auth/AuthContext";
 
@@ -7,12 +7,32 @@ type StatusFilter = "all" | "ACTIVE" | "DISABLED";
 type EditableRole = "ADMIN" | "USER";
 type EditableStatus = "ACTIVE" | "DISABLED";
 
+const DISPLAY_NAME_MAX_LENGTH = 64;
+
+function roleLabel(role: string): string {
+  return role === "ADMIN" ? "관리자" : "일반";
+}
+
+function statusLabel(status: string): string {
+  return status === "ACTIVE" ? "활성" : "비활성";
+}
+
+function StatCard({ title, value }: { title: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2">
+      <div className="text-xs text-slate-500">{title}</div>
+      <div className="mt-1 text-xl font-semibold text-slate-900">{value.toLocaleString("ko-KR")}</div>
+    </div>
+  );
+}
+
 export default function UserListPage() {
   const { user: currentUser } = useAuth();
   const [users, setUsers] = useState<UserResponse[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [mutationError, setMutationError] = useState<string | null>(null);
+  const [mutationSuccess, setMutationSuccess] = useState<string | null>(null);
 
   const [search, setSearch] = useState("");
   const [roleFilter, setRoleFilter] = useState<RoleFilter>("all");
@@ -27,24 +47,27 @@ export default function UserListPage() {
   const [newStatus, setNewStatus] = useState<EditableStatus>("ACTIVE");
   const [creating, setCreating] = useState(false);
 
-  useEffect(() => {
-    let cancelled = false;
+  const loadUsers = useCallback(async () => {
     setLoading(true);
-    listUsers()
-      .then((data) => {
-        if (!cancelled) setUsers(data);
-      })
-      .catch((err) => {
-        if (!cancelled) setLoadError(err instanceof Error ? err.message : "사용자 목록을 불러올 수 없습니다.");
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
+    setLoadError(null);
+    try {
+      const data = await listUsers();
+      setUsers(data);
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : "사용자 목록을 불러올 수 없습니다.");
+    } finally {
+      setLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    void loadUsers();
+  }, [loadUsers]);
+
+  const clearMutationFeedback = () => {
+    setMutationError(null);
+    setMutationSuccess(null);
+  };
 
   const filteredUsers = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -56,10 +79,15 @@ export default function UserListPage() {
     });
   }, [users, search, roleFilter, statusFilter]);
 
+  const totalUsers = users.length;
+  const activeUsers = useMemo(() => users.filter((u) => u.status === "ACTIVE").length, [users]);
+  const disabledUsers = totalUsers - activeUsers;
   const activeAdminCount = useMemo(
     () => users.filter((u) => u.role === "ADMIN" && u.status === "ACTIVE").length,
     [users],
   );
+
+  const hasActiveFilter = search.trim().length > 0 || roleFilter !== "all" || statusFilter !== "all";
 
   const isCurrentOperator = (targetUser: UserResponse): boolean => currentUser?.userId === targetUser.id;
 
@@ -99,52 +127,62 @@ export default function UserListPage() {
     return null;
   };
 
-  const handleRoleChange = async (user: UserResponse, newRoleValue: string) => {
-    if (newRoleValue === user.role) {
+  const clearFilters = () => {
+    setSearch("");
+    setRoleFilter("all");
+    setStatusFilter("all");
+  };
+
+  const handleRoleChange = async (targetUser: UserResponse, newRoleValue: string) => {
+    if (newRoleValue === targetUser.role) {
       return;
     }
 
-    const lockReason = getRoleLockReason(user);
+    const lockReason = getRoleLockReason(targetUser);
     if (lockReason) {
       setMutationError(lockReason);
+      setMutationSuccess(null);
       return;
     }
 
-    setMutationError(null);
-    setUpdatingIds((prev) => new Set(prev).add(user.id));
+    clearMutationFeedback();
+    setUpdatingIds((prev) => new Set(prev).add(targetUser.id));
     try {
-      const updated = await updateUser(user.id, { role: newRoleValue });
-      setUsers((prev) => prev.map((u) => (u.id === user.id ? updated : u)));
+      const updated = await updateUser(targetUser.id, { role: newRoleValue });
+      setUsers((prev) => prev.map((u) => (u.id === targetUser.id ? updated : u)));
+      setMutationSuccess(`"${updated.displayName}" 사용자의 역할을 ${roleLabel(updated.role)}로 변경했습니다.`);
     } catch (err) {
       setMutationError(err instanceof Error ? err.message : "역할 변경에 실패했습니다.");
     } finally {
       setUpdatingIds((prev) => {
         const next = new Set(prev);
-        next.delete(user.id);
+        next.delete(targetUser.id);
         return next;
       });
     }
   };
 
-  const handleStatusToggle = async (user: UserResponse) => {
-    const lockReason = getStatusLockReason(user);
+  const handleStatusToggle = async (targetUser: UserResponse) => {
+    const lockReason = getStatusLockReason(targetUser);
     if (lockReason) {
       setMutationError(lockReason);
+      setMutationSuccess(null);
       return;
     }
 
-    const newStatusValue = user.status === "ACTIVE" ? "DISABLED" : "ACTIVE";
-    setMutationError(null);
-    setUpdatingIds((prev) => new Set(prev).add(user.id));
+    const newStatusValue = targetUser.status === "ACTIVE" ? "DISABLED" : "ACTIVE";
+    clearMutationFeedback();
+    setUpdatingIds((prev) => new Set(prev).add(targetUser.id));
     try {
-      const updated = await updateUser(user.id, { status: newStatusValue });
-      setUsers((prev) => prev.map((u) => (u.id === user.id ? updated : u)));
+      const updated = await updateUser(targetUser.id, { status: newStatusValue });
+      setUsers((prev) => prev.map((u) => (u.id === targetUser.id ? updated : u)));
+      setMutationSuccess(`"${updated.displayName}" 사용자를 ${statusLabel(updated.status)} 상태로 변경했습니다.`);
     } catch (err) {
       setMutationError(err instanceof Error ? err.message : "상태 변경에 실패했습니다.");
     } finally {
       setUpdatingIds((prev) => {
         const next = new Set(prev);
-        next.delete(user.id);
+        next.delete(targetUser.id);
         return next;
       });
     }
@@ -154,17 +192,19 @@ export default function UserListPage() {
     const lockReason = getDeleteLockReason(targetUser);
     if (lockReason) {
       setMutationError(lockReason);
+      setMutationSuccess(null);
       return;
     }
 
     const confirmed = window.confirm(`"${targetUser.displayName}" 사용자를 삭제(비활성) 처리하시겠습니까?`);
     if (!confirmed) return;
 
-    setMutationError(null);
+    clearMutationFeedback();
     setDeletingIds((prev) => new Set(prev).add(targetUser.id));
     try {
       const deleted = await deleteUser(targetUser.id);
       setUsers((prev) => prev.map((u) => (u.id === targetUser.id ? deleted : u)));
+      setMutationSuccess(`"${deleted.displayName}" 사용자를 비활성 처리했습니다.`);
     } catch (err) {
       setMutationError(err instanceof Error ? err.message : "삭제에 실패했습니다.");
     } finally {
@@ -184,20 +224,28 @@ export default function UserListPage() {
 
   const handleCreateUser = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!newDisplayName.trim()) {
+    const normalizedDisplayName = newDisplayName.trim();
+    if (!normalizedDisplayName) {
       setMutationError("이름을 입력해 주세요.");
+      setMutationSuccess(null);
+      return;
+    }
+    if (normalizedDisplayName.length > DISPLAY_NAME_MAX_LENGTH) {
+      setMutationError(`이름은 최대 ${DISPLAY_NAME_MAX_LENGTH}자까지 입력할 수 있습니다.`);
+      setMutationSuccess(null);
       return;
     }
 
-    setMutationError(null);
+    clearMutationFeedback();
     setCreating(true);
     try {
       const created = await createUser({
-        displayName: newDisplayName.trim(),
+        displayName: normalizedDisplayName,
         role: newRole,
         status: newStatus,
       });
       setUsers((prev) => [created, ...prev]);
+      setMutationSuccess(`"${created.displayName}" 사용자를 생성했습니다.`);
       resetCreateForm();
       setShowCreateForm(false);
     } catch (err) {
@@ -215,23 +263,40 @@ export default function UserListPage() {
             <h2 className="text-xl font-bold text-slate-900">사용자 관리</h2>
             <p className="mt-1 text-sm text-slate-600">생성/조회/수정/삭제(비활성) 작업을 수행합니다.</p>
           </div>
-          <button
-            type="button"
-            onClick={() => {
-              if (showCreateForm) {
-                resetCreateForm();
-              }
-              setShowCreateForm((prev) => !prev);
-            }}
-            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
-          >
-            {showCreateForm ? "생성 취소" : "새 사용자 생성"}
-          </button>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void loadUsers()}
+              disabled={loading}
+              className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100 disabled:opacity-50"
+            >
+              {loading ? "새로고침 중..." : "목록 새로고침"}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                if (showCreateForm) {
+                  resetCreateForm();
+                }
+                setShowCreateForm((prev) => !prev);
+              }}
+              className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
+            >
+              {showCreateForm ? "생성 취소" : "새 사용자 생성"}
+            </button>
+          </div>
         </div>
 
         <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
           현재 로그인한 운영자 계정과 마지막 활성 관리자 계정은 실수 방지를 위해 수정/삭제가 잠깁니다. 삭제는 soft-delete로
           `DISABLED` 처리됩니다.
+        </div>
+
+        <div className="mt-4 grid grid-cols-2 gap-3 md:grid-cols-4">
+          <StatCard title="전체 사용자" value={totalUsers} />
+          <StatCard title="활성 사용자" value={activeUsers} />
+          <StatCard title="비활성 사용자" value={disabledUsers} />
+          <StatCard title="활성 관리자" value={activeAdminCount} />
         </div>
 
         <div className="mt-4 flex flex-col gap-3 md:flex-row">
@@ -260,18 +325,33 @@ export default function UserListPage() {
             <option value="ACTIVE">활성</option>
             <option value="DISABLED">비활성</option>
           </select>
+          {hasActiveFilter && (
+            <button
+              type="button"
+              onClick={clearFilters}
+              className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100"
+            >
+              필터 초기화
+            </button>
+          )}
         </div>
 
         {showCreateForm && (
           <form onSubmit={handleCreateUser} className="mt-4 grid grid-cols-1 gap-3 rounded-xl border border-slate-200 bg-slate-50 p-3 md:grid-cols-4">
-            <input
-              type="text"
-              value={newDisplayName}
-              onChange={(e) => setNewDisplayName(e.target.value)}
-              placeholder="사용자 이름"
-              className="rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 md:col-span-2"
-              required
-            />
+            <div className="md:col-span-2">
+              <input
+                type="text"
+                value={newDisplayName}
+                onChange={(e) => setNewDisplayName(e.target.value)}
+                placeholder="사용자 이름"
+                maxLength={DISPLAY_NAME_MAX_LENGTH}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                required
+              />
+              <div className="mt-1 text-right text-xs text-slate-500">
+                {newDisplayName.trim().length}/{DISPLAY_NAME_MAX_LENGTH}
+              </div>
+            </div>
             <select
               value={newRole}
               onChange={(e) => setNewRole(e.target.value as EditableRole)}
@@ -312,104 +392,137 @@ export default function UserListPage() {
       </section>
 
       {loading && <p className="text-sm text-gray-500">로딩 중...</p>}
-      {loadError && <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{loadError}</div>}
+      {loadError && (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+          <span>{loadError}</span>
+          <button
+            type="button"
+            onClick={() => void loadUsers()}
+            className="rounded border border-red-300 px-2.5 py-1 text-xs font-semibold text-red-700 hover:bg-red-100"
+          >
+            다시 시도
+          </button>
+        </div>
+      )}
+      {mutationSuccess && (
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">{mutationSuccess}</div>
+      )}
       {mutationError && (
         <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{mutationError}</div>
       )}
 
       {!loading && !loadError && (
         <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
-          <table className="w-full text-left">
-            <thead className="border-b border-slate-200 bg-slate-50">
-              <tr>
-                <th className="px-4 py-3 text-sm font-semibold text-gray-600">이름</th>
-                <th className="px-4 py-3 text-sm font-semibold text-gray-600">역할</th>
-                <th className="px-4 py-3 text-sm font-semibold text-gray-600">상태</th>
-                <th className="px-4 py-3 text-sm font-semibold text-gray-600">가입일</th>
-                <th className="px-4 py-3 text-sm font-semibold text-gray-600">최근 로그인</th>
-                <th className="px-4 py-3 text-sm font-semibold text-gray-600">작업</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filteredUsers.length === 0 && (
+          <div className="overflow-x-auto">
+            <table className="min-w-[760px] w-full text-left">
+              <thead className="border-b border-slate-200 bg-slate-50">
                 <tr>
-                  <td colSpan={6} className="px-4 py-10 text-center text-gray-400">
-                    {search || roleFilter !== "all" || statusFilter !== "all"
-                      ? "검색 결과가 없습니다."
-                      : "등록된 사용자가 없습니다."}
-                  </td>
+                  <th className="px-4 py-3 text-sm font-semibold text-gray-600">이름</th>
+                  <th className="px-4 py-3 text-sm font-semibold text-gray-600">역할</th>
+                  <th className="px-4 py-3 text-sm font-semibold text-gray-600">상태</th>
+                  <th className="px-4 py-3 text-sm font-semibold text-gray-600">가입일</th>
+                  <th className="px-4 py-3 text-sm font-semibold text-gray-600">최근 로그인</th>
+                  <th className="px-4 py-3 text-sm font-semibold text-gray-600">작업</th>
                 </tr>
-              )}
-              {filteredUsers.map((u) => {
-                const roleLockReason = getRoleLockReason(u);
-                const statusLockReason = getStatusLockReason(u);
-                const deleteLockReason = getDeleteLockReason(u);
-                const inProgress = updatingIds.has(u.id) || deletingIds.has(u.id);
-
-                return (
-                  <tr key={u.id} className="border-b border-slate-100 last:border-b-0 hover:bg-slate-50">
-                    <td className="px-4 py-3 font-medium">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <span>{u.displayName}</span>
-                        {isCurrentOperator(u) && (
-                          <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-semibold text-indigo-700">
-                            현재 운영자
-                          </span>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-4 py-3">
-                      <select
-                        value={u.role}
-                        onChange={(e) => handleRoleChange(u, e.target.value)}
-                        disabled={inProgress || roleLockReason !== null}
-                        title={roleLockReason ?? ""}
-                        className="rounded border border-gray-300 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
-                      >
-                        <option value="USER">일반</option>
-                        <option value="ADMIN">관리자</option>
-                      </select>
-                    </td>
-                    <td className="px-4 py-3">
-                      <button
-                        type="button"
-                        onClick={() => handleStatusToggle(u)}
-                        disabled={inProgress || statusLockReason !== null}
-                        title={statusLockReason ?? ""}
-                        className={`inline-block rounded-full px-2.5 py-1 text-xs font-semibold transition-colors disabled:opacity-50 ${
-                          u.status === "ACTIVE"
-                            ? "bg-green-100 text-green-700 hover:bg-green-200"
-                            : "bg-red-100 text-red-700 hover:bg-red-200"
-                        }`}
-                      >
-                        {inProgress ? "..." : u.status === "ACTIVE" ? "활성" : "비활성"}
-                      </button>
-                    </td>
-                    <td className="px-4 py-3 text-sm text-gray-500">{new Date(u.createdAt).toLocaleDateString("ko-KR")}</td>
-                    <td className="px-4 py-3 text-sm text-gray-500">
-                      {u.lastLoginAt ? new Date(u.lastLoginAt).toLocaleDateString("ko-KR") : "-"}
-                    </td>
-                    <td className="px-4 py-3">
-                      <button
-                        type="button"
-                        onClick={() => handleDeleteUser(u)}
-                        disabled={inProgress || deleteLockReason !== null}
-                        title={deleteLockReason ?? ""}
-                        className="text-sm font-semibold text-red-600 hover:text-red-800 disabled:opacity-40"
-                      >
-                        {deletingIds.has(u.id) ? "삭제 중..." : "삭제"}
-                      </button>
+              </thead>
+              <tbody>
+                {filteredUsers.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-10 text-center text-gray-400">
+                      {hasActiveFilter ? (
+                        "검색 결과가 없습니다."
+                      ) : (
+                        <div className="space-y-2">
+                          <div>등록된 사용자가 없습니다.</div>
+                          <button
+                            type="button"
+                            onClick={() => setShowCreateForm(true)}
+                            className="rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-semibold text-slate-700 hover:bg-slate-100"
+                          >
+                            첫 사용자 생성하기
+                          </button>
+                        </div>
+                      )}
                     </td>
                   </tr>
-                );
-              })}
-            </tbody>
-          </table>
+                )}
+                {filteredUsers.map((user) => {
+                  const roleLockReason = getRoleLockReason(user);
+                  const statusLockReason = getStatusLockReason(user);
+                  const deleteLockReason = getDeleteLockReason(user);
+                  const lockHints = [...new Set([roleLockReason, statusLockReason, deleteLockReason].filter(Boolean))] as string[];
+                  const inProgress = updatingIds.has(user.id) || deletingIds.has(user.id);
+
+                  return (
+                    <tr key={user.id} className="border-b border-slate-100 last:border-b-0 hover:bg-slate-50">
+                      <td className="px-4 py-3 font-medium">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span>{user.displayName}</span>
+                          {isCurrentOperator(user) && (
+                            <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-semibold text-indigo-700">
+                              현재 운영자
+                            </span>
+                          )}
+                        </div>
+                        {lockHints.length > 0 && (
+                          <div className="mt-1 text-xs text-amber-700">{lockHints.join(" · ")}</div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <select
+                          value={user.role}
+                          onChange={(e) => void handleRoleChange(user, e.target.value)}
+                          disabled={inProgress || roleLockReason !== null}
+                          title={roleLockReason ?? ""}
+                          className="rounded border border-gray-300 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
+                        >
+                          <option value="USER">일반</option>
+                          <option value="ADMIN">관리자</option>
+                        </select>
+                      </td>
+                      <td className="px-4 py-3">
+                        <button
+                          type="button"
+                          onClick={() => void handleStatusToggle(user)}
+                          disabled={inProgress || statusLockReason !== null}
+                          title={statusLockReason ?? ""}
+                          className={`inline-block rounded-full px-2.5 py-1 text-xs font-semibold transition-colors disabled:opacity-50 ${
+                            user.status === "ACTIVE"
+                              ? "bg-green-100 text-green-700 hover:bg-green-200"
+                              : "bg-red-100 text-red-700 hover:bg-red-200"
+                          }`}
+                        >
+                          {inProgress ? "..." : statusLabel(user.status)}
+                        </button>
+                      </td>
+                      <td className="px-4 py-3 text-sm text-gray-500">{new Date(user.createdAt).toLocaleDateString("ko-KR")}</td>
+                      <td className="px-4 py-3 text-sm text-gray-500">
+                        {user.lastLoginAt ? new Date(user.lastLoginAt).toLocaleDateString("ko-KR") : "-"}
+                      </td>
+                      <td className="px-4 py-3">
+                        <button
+                          type="button"
+                          onClick={() => void handleDeleteUser(user)}
+                          disabled={inProgress || deleteLockReason !== null}
+                          title={deleteLockReason ?? ""}
+                          className="text-sm font-semibold text-red-600 hover:text-red-800 disabled:opacity-40"
+                        >
+                          {deletingIds.has(user.id) ? "삭제 중..." : "삭제"}
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
         </section>
       )}
 
-      {!loading && !loadError && (search || roleFilter !== "all" || statusFilter !== "all") && (
-        <p className="text-sm text-gray-500">{filteredUsers.length}명 / 전체 {users.length}명</p>
+      {!loading && !loadError && (
+        <p className="text-sm text-gray-500">
+          {filteredUsers.length}명 표시 / 전체 {users.length}명
+        </p>
       )}
     </div>
   );

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminCreateHymnUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminCreateHymnUseCase.java
@@ -1,9 +1,11 @@
 package com.eunhyehymn.application.usecases;
 
+import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.domain.model.Hymn;
 import com.eunhyehymn.domain.repository.HymnRepository;
 import java.time.Instant;
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
 
 public class AdminCreateHymnUseCase {
     private final HymnRepository hymnRepository;
@@ -13,8 +15,40 @@ public class AdminCreateHymnUseCase {
     }
 
     public Hymn create(String title, String number, String tags, Boolean enabled) {
+        String resolvedTitle = normalizeRequired(title, "title");
+        String resolvedNumber = normalizeOptional(number);
+        String resolvedTags = normalizeOptional(tags);
         boolean resolvedEnabled = enabled == null || enabled;
-        Hymn hymn = new Hymn(UUID.randomUUID(), title, number, tags, resolvedEnabled, Instant.now());
+
+        Hymn hymn = new Hymn(
+            UUID.randomUUID(),
+            resolvedTitle,
+            resolvedNumber,
+            resolvedTags,
+            resolvedEnabled,
+            Instant.now()
+        );
         return hymnRepository.save(hymn);
+    }
+
+    private String normalizeRequired(String value, String fieldName) {
+        String normalized = value == null ? "" : value.trim();
+        if (normalized.isBlank()) {
+            throw new ApiException(
+                HttpStatus.BAD_REQUEST,
+                "validation_error",
+                fieldName + " is required",
+                null
+            );
+        }
+        return normalized;
+    }
+
+    private String normalizeOptional(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isBlank() ? null : normalized;
     }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminCreateUserUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminCreateUserUseCase.java
@@ -6,10 +6,13 @@ import com.eunhyehymn.domain.model.User;
 import com.eunhyehymn.domain.model.UserStatus;
 import com.eunhyehymn.domain.repository.UserRepository;
 import java.time.Instant;
+import java.util.Map;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 
 public class AdminCreateUserUseCase {
+    private static final int MAX_DISPLAY_NAME_LENGTH = 64;
+
     private final UserRepository userRepository;
 
     public AdminCreateUserUseCase(UserRepository userRepository) {
@@ -17,11 +20,7 @@ public class AdminCreateUserUseCase {
     }
 
     public User create(String displayName, Role role, UserStatus status) {
-        String resolvedDisplayName = displayName == null ? "" : displayName.trim();
-        if (resolvedDisplayName.isBlank()) {
-            throw new ApiException(HttpStatus.BAD_REQUEST, "validation_error", "displayName은 비워둘 수 없습니다", null);
-        }
-
+        String resolvedDisplayName = normalizeDisplayName(displayName);
         Role resolvedRole = role != null ? role : Role.USER;
         UserStatus resolvedStatus = status != null ? status : UserStatus.ACTIVE;
         Instant now = Instant.now();
@@ -35,5 +34,27 @@ public class AdminCreateUserUseCase {
             null
         );
         return userRepository.save(user);
+    }
+
+    private String normalizeDisplayName(String displayName) {
+        String resolvedDisplayName = displayName == null ? "" : displayName.trim();
+        if (resolvedDisplayName.isBlank()) {
+            throw new ApiException(
+                HttpStatus.BAD_REQUEST,
+                "validation_error",
+                "displayName is required",
+                null
+            );
+        }
+
+        if (resolvedDisplayName.length() > MAX_DISPLAY_NAME_LENGTH) {
+            throw new ApiException(
+                HttpStatus.BAD_REQUEST,
+                "validation_error",
+                "displayName is too long",
+                Map.of("maxLength", MAX_DISPLAY_NAME_LENGTH)
+            );
+        }
+        return resolvedDisplayName;
     }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminDeleteUserUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminDeleteUserUseCase.java
@@ -7,6 +7,7 @@ import com.eunhyehymn.domain.model.UserStatus;
 import com.eunhyehymn.domain.repository.UserRepository;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
 
 public class AdminDeleteUserUseCase {
     private final UserRepository userRepository;
@@ -15,18 +16,24 @@ public class AdminDeleteUserUseCase {
         this.userRepository = userRepository;
     }
 
+    @Transactional
     public User delete(UUID requesterId, UUID targetUserId) {
         User existing = userRepository.findById(targetUserId)
-            .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "user_not_found", "사용자를 찾을 수 없습니다", null));
+            .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "user_not_found", "user not found", null));
 
         if (requesterId.equals(targetUserId)) {
-            throw new ApiException(HttpStatus.BAD_REQUEST, "self_delete", "자신의 계정은 삭제할 수 없습니다", null);
+            throw new ApiException(HttpStatus.BAD_REQUEST, "self_delete", "cannot delete your own account", null);
         }
 
         if (existing.role() == Role.ADMIN && existing.status() == UserStatus.ACTIVE) {
             long activeAdminCount = userRepository.countByRoleAndStatus(Role.ADMIN, UserStatus.ACTIVE);
             if (activeAdminCount <= 1) {
-                throw new ApiException(HttpStatus.BAD_REQUEST, "last_admin", "마지막 활성 관리자를 삭제할 수 없습니다", null);
+                throw new ApiException(
+                    HttpStatus.BAD_REQUEST,
+                    "last_admin",
+                    "cannot delete the last active admin",
+                    null
+                );
             }
         }
 

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminUpdateHymnUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminUpdateHymnUseCase.java
@@ -3,6 +3,7 @@ package com.eunhyehymn.application.usecases;
 import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.domain.model.Hymn;
 import com.eunhyehymn.domain.repository.HymnRepository;
+import java.util.Objects;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 
@@ -14,18 +15,62 @@ public class AdminUpdateHymnUseCase {
     }
 
     public Hymn update(UUID hymnId, String title, String number, String tags, Boolean enabled) {
+        if (title == null && number == null && tags == null && enabled == null) {
+            throw new ApiException(
+                HttpStatus.BAD_REQUEST,
+                "empty_update",
+                "at least one field is required",
+                null
+            );
+        }
+
         Hymn existing = hymnRepository.findById(hymnId)
-            .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "hymn_not_found", "찬송가를 찾을 수 없습니다", null));
+            .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "hymn_not_found", "hymn not found", null));
+
+        String effectiveTitle = title != null ? normalizeRequired(title, "title") : existing.title();
+        String effectiveNumber = number != null ? normalizeOptional(number) : existing.number();
+        String effectiveTags = tags != null ? normalizeOptional(tags) : existing.tags();
+        boolean effectiveEnabled = enabled != null ? enabled : existing.enabled();
+
+        if (
+            Objects.equals(effectiveTitle, existing.title())
+                && Objects.equals(effectiveNumber, existing.number())
+                && Objects.equals(effectiveTags, existing.tags())
+                && effectiveEnabled == existing.enabled()
+        ) {
+            return existing;
+        }
 
         Hymn updated = new Hymn(
             existing.id(),
-            title != null ? title : existing.title(),
-            number != null ? number : existing.number(),
-            tags != null ? tags : existing.tags(),
-            enabled != null ? enabled : existing.enabled(),
+            effectiveTitle,
+            effectiveNumber,
+            effectiveTags,
+            effectiveEnabled,
             existing.createdAt()
         );
 
         return hymnRepository.save(updated);
+    }
+
+    private String normalizeRequired(String value, String fieldName) {
+        String normalized = value == null ? "" : value.trim();
+        if (normalized.isBlank()) {
+            throw new ApiException(
+                HttpStatus.BAD_REQUEST,
+                "validation_error",
+                fieldName + " is required",
+                null
+            );
+        }
+        return normalized;
+    }
+
+    private String normalizeOptional(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isBlank() ? null : normalized;
     }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminUpdateUserUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminUpdateUserUseCase.java
@@ -7,6 +7,7 @@ import com.eunhyehymn.domain.model.UserStatus;
 import com.eunhyehymn.domain.repository.UserRepository;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
 
 public class AdminUpdateUserUseCase {
     private final UserRepository userRepository;
@@ -15,23 +16,47 @@ public class AdminUpdateUserUseCase {
         this.userRepository = userRepository;
     }
 
+    @Transactional
     public User update(UUID requesterId, UUID targetUserId, Role role, UserStatus status) {
+        if (role == null && status == null) {
+            throw new ApiException(
+                HttpStatus.BAD_REQUEST,
+                "empty_update",
+                "at least one field is required",
+                null
+            );
+        }
+
         User existing = userRepository.findById(targetUserId)
-            .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "user_not_found", "사용자를 찾을 수 없습니다", null));
+            .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "user_not_found", "user not found", null));
 
         if (requesterId.equals(targetUserId) && role != null && role != existing.role()) {
-            throw new ApiException(HttpStatus.BAD_REQUEST, "self_role_change", "자신의 역할은 변경할 수 없습니다", null);
+            throw new ApiException(
+                HttpStatus.BAD_REQUEST,
+                "self_role_change",
+                "cannot change your own role",
+                null
+            );
         }
 
         Role effectiveRole = role != null ? role : existing.role();
         UserStatus effectiveStatus = status != null ? status : existing.status();
+        if (effectiveRole == existing.role() && effectiveStatus == existing.status()) {
+            return existing;
+        }
+
         boolean wouldLoseAdmin = existing.role() == Role.ADMIN
             && (effectiveRole != Role.ADMIN || effectiveStatus != UserStatus.ACTIVE);
 
         if (wouldLoseAdmin) {
             long activeAdminCount = userRepository.countByRoleAndStatus(Role.ADMIN, UserStatus.ACTIVE);
             if (activeAdminCount <= 1) {
-                throw new ApiException(HttpStatus.BAD_REQUEST, "last_admin", "마지막 활성 관리자를 변경할 수 없습니다", null);
+                throw new ApiException(
+                    HttpStatus.BAD_REQUEST,
+                    "last_admin",
+                    "cannot update the last active admin",
+                    null
+                );
             }
         }
 

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminHymnController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminHymnController.java
@@ -4,13 +4,11 @@ import com.eunhyehymn.application.usecases.AdminCreateHymnUseCase;
 import com.eunhyehymn.application.usecases.AdminDeleteHymnUseCase;
 import com.eunhyehymn.application.usecases.AdminListHymnsUseCase;
 import com.eunhyehymn.application.usecases.AdminUpdateHymnUseCase;
-import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.common.response.ApiResponse;
 import com.eunhyehymn.domain.model.Hymn;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -55,9 +53,6 @@ public class AdminHymnController {
 
     @PatchMapping("/{id}")
     public ApiResponse<HymnResponse> update(@PathVariable UUID id, @RequestBody UpdateRequest request) {
-        if (request.title() != null && request.title().isBlank()) {
-            throw new ApiException(HttpStatus.BAD_REQUEST, "validation_error", "제목은 비워둘 수 없습니다", null);
-        }
         Hymn hymn = adminUpdateHymnUseCase.update(
             id,
             request.title(),

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminUserController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminUserController.java
@@ -12,15 +12,16 @@ import com.eunhyehymn.domain.model.UserStatus;
 import jakarta.validation.constraints.NotBlank;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -68,7 +69,7 @@ public class AdminUserController {
         @RequestBody UpdateUserRequest request,
         Authentication authentication
     ) {
-        UUID requesterId = UUID.fromString(authentication.getName());
+        UUID requesterId = parseRequesterId(authentication);
         Role role = parseEnum(Role.class, request.role(), "role");
         UserStatus status = parseEnum(UserStatus.class, request.status(), "status");
         User user = adminUpdateUserUseCase.update(requesterId, id, role, status);
@@ -77,20 +78,38 @@ public class AdminUserController {
 
     @DeleteMapping("/{id}")
     public ApiResponse<UserResponse> delete(@PathVariable UUID id, Authentication authentication) {
-        UUID requesterId = UUID.fromString(authentication.getName());
+        UUID requesterId = parseRequesterId(authentication);
         User user = adminDeleteUserUseCase.delete(requesterId, id);
         return ApiResponse.success(UserResponse.from(user));
     }
 
+    private UUID parseRequesterId(Authentication authentication) {
+        if (authentication == null || authentication.getName() == null || authentication.getName().isBlank()) {
+            throw new ApiException(HttpStatus.UNAUTHORIZED, "unauthorized", "authentication is required", null);
+        }
+
+        try {
+            return UUID.fromString(authentication.getName());
+        } catch (IllegalArgumentException ex) {
+            throw new ApiException(HttpStatus.UNAUTHORIZED, "invalid_principal", "invalid authenticated principal", null);
+        }
+    }
+
     private <E extends Enum<E>> E parseEnum(Class<E> enumClass, String value, String fieldName) {
-        if (value == null) {
+        if (value == null || value.isBlank()) {
             return null;
         }
+
+        String normalizedValue = value.trim().toUpperCase(Locale.ROOT);
         try {
-            return Enum.valueOf(enumClass, value);
+            return Enum.valueOf(enumClass, normalizedValue);
         } catch (IllegalArgumentException e) {
-            throw new ApiException(HttpStatus.BAD_REQUEST, "validation_error",
-                fieldName + " 값이 올바르지 않습니다: " + value, null);
+            throw new ApiException(
+                HttpStatus.BAD_REQUEST,
+                "validation_error",
+                "invalid " + fieldName + " value: " + value,
+                null
+            );
         }
     }
 

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminHymnApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminHymnApiTest.java
@@ -42,41 +42,18 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 class AdminHymnApiTest {
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @Autowired
-    private JwtService jwtService;
-
-    @Autowired
-    private UserJpaRepository userJpaRepository;
-
-    @Autowired
-    private HymnJpaRepository hymnJpaRepository;
-
-    @Autowired
-    private AssetJpaRepository assetJpaRepository;
-
-    @Autowired
-    private HymnNoteJpaRepository hymnNoteJpaRepository;
-
-    @Autowired
-    private UserHymnStateJpaRepository userHymnStateJpaRepository;
-
-    @Autowired
-    private EventJpaRepository eventJpaRepository;
-
-    @Autowired
-    private AuthIdentityJpaRepository authIdentityJpaRepository;
-
-    @Autowired
-    private RefreshTokenJpaRepository refreshTokenJpaRepository;
-
-    @Autowired
-    private InviteCodeJpaRepository inviteCodeJpaRepository;
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private JwtService jwtService;
+    @Autowired private UserJpaRepository userJpaRepository;
+    @Autowired private HymnJpaRepository hymnJpaRepository;
+    @Autowired private AssetJpaRepository assetJpaRepository;
+    @Autowired private HymnNoteJpaRepository hymnNoteJpaRepository;
+    @Autowired private UserHymnStateJpaRepository userHymnStateJpaRepository;
+    @Autowired private EventJpaRepository eventJpaRepository;
+    @Autowired private AuthIdentityJpaRepository authIdentityJpaRepository;
+    @Autowired private RefreshTokenJpaRepository refreshTokenJpaRepository;
+    @Autowired private InviteCodeJpaRepository inviteCodeJpaRepository;
 
     private String adminToken;
     private String userToken;
@@ -95,8 +72,8 @@ class AdminHymnApiTest {
 
         UUID adminId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
-        userJpaRepository.save(new UserEntity(adminId, "관리자", Role.ADMIN, UserStatus.ACTIVE, Instant.now(), Instant.now()));
-        userJpaRepository.save(new UserEntity(userId, "일반", Role.USER, UserStatus.ACTIVE, Instant.now(), Instant.now()));
+        userJpaRepository.save(new UserEntity(adminId, "admin", Role.ADMIN, UserStatus.ACTIVE, Instant.now(), Instant.now()));
+        userJpaRepository.save(new UserEntity(userId, "member", Role.USER, UserStatus.ACTIVE, Instant.now(), Instant.now()));
 
         adminToken = jwtService.issueAccessToken(adminId.toString(), Role.ADMIN.name());
         userToken = jwtService.issueAccessToken(userId.toString(), Role.USER.name());
@@ -104,7 +81,7 @@ class AdminHymnApiTest {
 
     @Test
     void adminEndpointRequiresAdminRole() throws Exception {
-        String payload = objectMapper.writeValueAsString(Map.of("title", "권한"));
+        String payload = objectMapper.writeValueAsString(Map.of("title", "forbidden"));
 
         mockMvc.perform(post("/admin/hymns")
                 .header("Authorization", "Bearer " + userToken)
@@ -118,7 +95,7 @@ class AdminHymnApiTest {
     @Test
     void adminCanCreateAndUpdateHymn() throws Exception {
         String createPayload = objectMapper.writeValueAsString(Map.of(
-            "title", "관리자 생성",
+            "title", "create hymn",
             "number", "101",
             "tags", "admin",
             "enabled", false
@@ -129,7 +106,7 @@ class AdminHymnApiTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(createPayload))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.title").value("관리자 생성"))
+            .andExpect(jsonPath("$.data.title").value("create hymn"))
             .andExpect(jsonPath("$.data.enabled").value(false))
             .andReturn()
             .getResponse()
@@ -138,7 +115,7 @@ class AdminHymnApiTest {
         String hymnId = objectMapper.readTree(createResponse).get("data").get("id").asText();
 
         String updatePayload = objectMapper.writeValueAsString(Map.of(
-            "title", "관리자 수정",
+            "title", "update hymn",
             "enabled", true
         ));
 
@@ -147,7 +124,7 @@ class AdminHymnApiTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(updatePayload))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.title").value("관리자 수정"))
+            .andExpect(jsonPath("$.data.title").value("update hymn"))
             .andExpect(jsonPath("$.data.enabled").value(true));
 
         HymnEntity saved = hymnJpaRepository.findById(UUID.fromString(hymnId)).orElseThrow();
@@ -155,9 +132,40 @@ class AdminHymnApiTest {
     }
 
     @Test
+    void updateWithEmptyPayloadReturnsBadRequest() throws Exception {
+        UUID hymnId = UUID.randomUUID();
+        hymnJpaRepository.save(new HymnEntity(hymnId, "hymn", "1", "tag", true, Instant.now()));
+
+        mockMvc.perform(patch("/admin/hymns/" + hymnId)
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error.code").value("empty_update"));
+    }
+
+    @Test
+    void createTrimsAndNormalizesOptionalFields() throws Exception {
+        String payload = objectMapper.writeValueAsString(Map.of(
+            "title", "  normalized hymn  ",
+            "number", "   ",
+            "tags", "  worship  "
+        ));
+
+        mockMvc.perform(post("/admin/hymns")
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.title").value("normalized hymn"))
+            .andExpect(jsonPath("$.data.number").isEmpty())
+            .andExpect(jsonPath("$.data.tags").value("worship"));
+    }
+
+    @Test
     void adminListReturnsAllHymns() throws Exception {
-        hymnJpaRepository.save(new HymnEntity(UUID.randomUUID(), "활성", "1", "tag", true, Instant.now()));
-        hymnJpaRepository.save(new HymnEntity(UUID.randomUUID(), "비활성", "2", "tag", false, Instant.now()));
+        hymnJpaRepository.save(new HymnEntity(UUID.randomUUID(), "enabled", "1", "tag", true, Instant.now()));
+        hymnJpaRepository.save(new HymnEntity(UUID.randomUUID(), "disabled", "2", "tag", false, Instant.now()));
 
         String response = mockMvc.perform(get("/admin/hymns")
                 .header("Authorization", "Bearer " + adminToken))
@@ -179,25 +187,20 @@ class AdminHymnApiTest {
     @Test
     void adminCanDeleteHymn() throws Exception {
         UUID hymnId = UUID.randomUUID();
-        hymnJpaRepository.save(new HymnEntity(hymnId, "삭제 대상", "99", "tag", true, Instant.now()));
+        hymnJpaRepository.save(new HymnEntity(hymnId, "delete target", "99", "tag", true, Instant.now()));
 
-        // 관련 에셋도 생성
         assetJpaRepository.save(new AssetEntity(
             UUID.randomUUID(), hymnId, AssetType.PNG, PartType.ALL,
             "https://example.com/test.png", "hymns/" + hymnId + "/PNG/ALL/test.png",
             null, null, Instant.now()
         ));
 
-        // 삭제 요청
         mockMvc.perform(delete("/admin/hymns/" + hymnId)
                 .header("Authorization", "Bearer " + adminToken))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.success").value(true));
 
-        // 찬양이 삭제되었는지 확인
         assertThat(hymnJpaRepository.findById(hymnId)).isEmpty();
-
-        // 관련 에셋도 삭제되었는지 확인
         assertThat(assetJpaRepository.findByHymnId(hymnId)).isEmpty();
     }
 
@@ -215,7 +218,7 @@ class AdminHymnApiTest {
     @Test
     void deleteHymnRequiresAdminRole() throws Exception {
         UUID hymnId = UUID.randomUUID();
-        hymnJpaRepository.save(new HymnEntity(hymnId, "권한 테스트", "100", "tag", true, Instant.now()));
+        hymnJpaRepository.save(new HymnEntity(hymnId, "protected", "100", "tag", true, Instant.now()));
 
         mockMvc.perform(delete("/admin/hymns/" + hymnId)
                 .header("Authorization", "Bearer " + userToken))
@@ -223,7 +226,6 @@ class AdminHymnApiTest {
             .andExpect(jsonPath("$.success").value(false))
             .andExpect(jsonPath("$.error.code").value("forbidden"));
 
-        // 찬양이 삭제되지 않았는지 확인
         assertThat(hymnJpaRepository.findById(hymnId)).isPresent();
     }
 }

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminUserApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminUserApiTest.java
@@ -69,8 +69,8 @@ class AdminUserApiTest {
 
         adminId = UUID.randomUUID();
         userId = UUID.randomUUID();
-        userJpaRepository.save(new UserEntity(adminId, "관리자", Role.ADMIN, UserStatus.ACTIVE, Instant.now(), Instant.now()));
-        userJpaRepository.save(new UserEntity(userId, "일반", Role.USER, UserStatus.ACTIVE, Instant.now(), Instant.now()));
+        userJpaRepository.save(new UserEntity(adminId, "admin", Role.ADMIN, UserStatus.ACTIVE, Instant.now(), Instant.now()));
+        userJpaRepository.save(new UserEntity(userId, "member", Role.USER, UserStatus.ACTIVE, Instant.now(), Instant.now()));
 
         adminToken = jwtService.issueAccessToken(adminId.toString(), Role.ADMIN.name());
         userToken = jwtService.issueAccessToken(userId.toString(), Role.USER.name());
@@ -101,7 +101,7 @@ class AdminUserApiTest {
                 .content(payload))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.role").value("ADMIN"))
-            .andExpect(jsonPath("$.data.displayName").value("일반"));
+            .andExpect(jsonPath("$.data.displayName").value("member"));
     }
 
     @Test
@@ -117,9 +117,19 @@ class AdminUserApiTest {
     }
 
     @Test
+    void updateWithoutAnyFieldsReturnsBadRequest() throws Exception {
+        mockMvc.perform(patch("/admin/users/" + userId)
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error.code").value("empty_update"));
+    }
+
+    @Test
     void adminCanCreateUser() throws Exception {
         String payload = objectMapper.writeValueAsString(Map.of(
-            "displayName", "신규사용자",
+            "displayName", "new-user",
             "role", "USER",
             "status", "ACTIVE"
         ));
@@ -129,15 +139,46 @@ class AdminUserApiTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(payload))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.displayName").value("신규사용자"))
+            .andExpect(jsonPath("$.data.displayName").value("new-user"))
             .andExpect(jsonPath("$.data.role").value("USER"))
             .andExpect(jsonPath("$.data.status").value("ACTIVE"));
     }
 
     @Test
+    void createUserAcceptsCaseInsensitiveRoleAndDefaultsBlankStatus() throws Exception {
+        String payload = objectMapper.writeValueAsString(Map.of(
+            "displayName", "admin2",
+            "role", "admin",
+            "status", " "
+        ));
+
+        mockMvc.perform(post("/admin/users")
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.role").value("ADMIN"))
+            .andExpect(jsonPath("$.data.status").value("ACTIVE"));
+    }
+
+    @Test
+    void createUserWithBlankDisplayNameReturnsBadRequest() throws Exception {
+        String payload = objectMapper.writeValueAsString(Map.of(
+            "displayName", "   "
+        ));
+
+        mockMvc.perform(post("/admin/users")
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error.code").value("validation_error"));
+    }
+
+    @Test
     void createUserWithInvalidRoleReturnsBadRequest() throws Exception {
         String payload = objectMapper.writeValueAsString(Map.of(
-            "displayName", "신규사용자",
+            "displayName", "new-user",
             "role", "INVALID"
         ));
 
@@ -200,14 +241,10 @@ class AdminUserApiTest {
 
     @Test
     void cannotDemoteLastActiveAdmin() throws Exception {
-        // setUp creates one ADMIN (adminId) and one USER (userId).
-        // adminId is the only active admin, so demoting them via another admin should fail.
-        // Create a second admin to perform the request.
         UUID secondAdminId = UUID.randomUUID();
-        userJpaRepository.save(new UserEntity(secondAdminId, "두번째관리자", Role.ADMIN, UserStatus.ACTIVE, Instant.now(), Instant.now()));
+        userJpaRepository.save(new UserEntity(secondAdminId, "admin2", Role.ADMIN, UserStatus.ACTIVE, Instant.now(), Instant.now()));
         String secondAdminToken = jwtService.issueAccessToken(secondAdminId.toString(), Role.ADMIN.name());
 
-        // Now there are 2 active admins. Demoting one should succeed.
         String demotePayload = objectMapper.writeValueAsString(Map.of("role", "USER"));
         mockMvc.perform(patch("/admin/users/" + adminId)
                 .header("Authorization", "Bearer " + secondAdminToken)
@@ -215,7 +252,6 @@ class AdminUserApiTest {
                 .content(demotePayload))
             .andExpect(status().isOk());
 
-        // Now secondAdmin is the only active admin. Use adminToken (demoted but JWT still valid) to try demoting the last admin.
         mockMvc.perform(patch("/admin/users/" + secondAdminId)
                 .header("Authorization", "Bearer " + adminToken)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -227,7 +263,7 @@ class AdminUserApiTest {
     @Test
     void cannotDeleteLastActiveAdmin() throws Exception {
         UUID secondAdminId = UUID.randomUUID();
-        userJpaRepository.save(new UserEntity(secondAdminId, "두번째관리자", Role.ADMIN, UserStatus.ACTIVE, Instant.now(), Instant.now()));
+        userJpaRepository.save(new UserEntity(secondAdminId, "admin2", Role.ADMIN, UserStatus.ACTIVE, Instant.now(), Instant.now()));
         String secondAdminToken = jwtService.issueAccessToken(secondAdminId.toString(), Role.ADMIN.name());
 
         mockMvc.perform(delete("/admin/users/" + adminId)
@@ -239,5 +275,18 @@ class AdminUserApiTest {
                 .header("Authorization", "Bearer " + adminToken))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.error.code").value("last_admin"));
+    }
+
+    @Test
+    void malformedPrincipalReturnsUnauthorized() throws Exception {
+        String malformedToken = jwtService.issueAccessToken("not-a-uuid", Role.ADMIN.name());
+        String payload = objectMapper.writeValueAsString(Map.of("role", "USER"));
+
+        mockMvc.perform(patch("/admin/users/" + userId)
+                .header("Authorization", "Bearer " + malformedToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.error.code").value("invalid_principal"));
     }
 }


### PR DESCRIPTION
## Why
- Admin CRUD had weak edge-case handling on API side.
- Operator UX in user/hymn management needed clearer feedback, safer inputs, and easier recovery flows.

## What changed
### API hardening
- Added validation/normalization for admin user create/update/delete flows.
- Added empty-update protection and idempotent no-op behavior where applicable.
- Added safer authenticated principal parsing in admin user controller.
- Added hymn input normalization and empty-update guard.
- Expanded API tests for malformed principal, empty payloads, and normalization behavior.

### Admin UX refactor
- User management: summary cards, refresh/retry flows, clearer success/error feedback, filter reset, lock reason visibility, and safer create form constraints.
- Hymn management: summary cards, refresh/retry flows, clearer mutation feedback, filter reset, and empty-state CTA.
- Hymn create/edit: switched hymn number to string input model (preserve formatting), improved validation, dirty-check on edit, and safer asset action feedback.

## Validation
- pps/api: ./gradlew.bat test --no-daemon
- pps/admin: 
px tsc --noEmit
- pps/admin: 
pm run build
