### PR TITLE
feat(admin): add admin ID/password rotation

### DIFF
--- a/apps/admin/src/api/auth.ts
+++ b/apps/admin/src/api/auth.ts
@@ -28,6 +28,17 @@ export interface AdminPasswordLoginRequest {
   password: string;
 }
 
+export interface AdminPasswordChangeRequest {
+  currentPassword: string;
+  newLoginId: string;
+  newPassword: string;
+}
+
+export interface AdminPasswordChangeResponse {
+  loginId: string;
+  updatedAt: string;
+}
+
 const PUBLIC_AUTH_OPTIONS = {
   includeAuth: false,
   unauthorized: "throw",
@@ -39,6 +50,10 @@ export function socialLogin(req: SocialLoginRequest): Promise<SocialLoginRespons
 
 export function adminPasswordLogin(req: AdminPasswordLoginRequest): Promise<SocialLoginResponse> {
   return apiPost<SocialLoginResponse>("/auth/admin/login", req, PUBLIC_AUTH_OPTIONS);
+}
+
+export function changeAdminPasswordCredential(req: AdminPasswordChangeRequest): Promise<AdminPasswordChangeResponse> {
+  return apiPost<AdminPasswordChangeResponse>("/admin/auth/password", req);
 }
 
 export function validateInviteCode(code: string): Promise<{ valid: boolean }> {

--- a/apps/admin/src/pages/HelpPage.tsx
+++ b/apps/admin/src/pages/HelpPage.tsx
@@ -1,9 +1,133 @@
+import { FormEvent, useState } from "react";
+import { changeAdminPasswordCredential } from "../api/auth";
+
 export default function HelpPage() {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newLoginId, setNewLoginId] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState<string | null>(null);
+
+  const handleCredentialUpdate = async (event: FormEvent) => {
+    event.preventDefault();
+    setSaveError(null);
+    setSaveSuccess(null);
+
+    if (!currentPassword || !newLoginId.trim() || !newPassword) {
+      setSaveError("현재 비밀번호, 새 로그인 ID, 새 비밀번호를 모두 입력해 주세요.");
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setSaveError("새 비밀번호는 8자 이상이어야 합니다.");
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setSaveError("새 비밀번호와 확인 값이 일치하지 않습니다.");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const result = await changeAdminPasswordCredential({
+        currentPassword,
+        newLoginId: newLoginId.trim(),
+        newPassword,
+      });
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+      setSaveSuccess(`관리자 로그인 정보가 갱신되었습니다. 새 로그인 ID: ${result.loginId}`);
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : "관리자 로그인 정보 변경에 실패했습니다.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
     <div className="space-y-4">
       <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
         <h1 className="text-2xl font-bold text-slate-900">도움말</h1>
         <p className="mt-1 text-sm text-slate-600">운영자 1인 기준 로그인/권한 문제를 빠르게 해결하는 가이드입니다.</p>
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">관리자 ID/PW 변경</h2>
+        <p className="mt-1 text-sm text-slate-600">
+          현재 비밀번호를 확인한 뒤 관리자 로그인 ID와 비밀번호를 바로 교체할 수 있습니다.
+        </p>
+        <form className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2" onSubmit={handleCredentialUpdate}>
+          <label className="text-sm text-slate-700">
+            <div className="mb-1 font-medium">현재 비밀번호</div>
+            <input
+              type="password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              autoComplete="current-password"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              disabled={saving}
+            />
+          </label>
+
+          <label className="text-sm text-slate-700">
+            <div className="mb-1 font-medium">새 로그인 ID</div>
+            <input
+              type="text"
+              value={newLoginId}
+              onChange={(e) => setNewLoginId(e.target.value)}
+              autoComplete="username"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              disabled={saving}
+            />
+          </label>
+
+          <label className="text-sm text-slate-700">
+            <div className="mb-1 font-medium">새 비밀번호</div>
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              autoComplete="new-password"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              disabled={saving}
+            />
+          </label>
+
+          <label className="text-sm text-slate-700">
+            <div className="mb-1 font-medium">새 비밀번호 확인</div>
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              autoComplete="new-password"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              disabled={saving}
+            />
+          </label>
+
+          <div className="md:col-span-2">
+            <button
+              type="submit"
+              disabled={saving}
+              className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {saving ? "변경 중..." : "로그인 정보 변경"}
+            </button>
+          </div>
+        </form>
+
+        {saveError && (
+          <div className="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{saveError}</div>
+        )}
+        {saveSuccess && (
+          <div className="mt-3 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+            {saveSuccess}
+          </div>
+        )}
       </section>
 
       <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
@@ -25,21 +149,11 @@ export default function HelpPage() {
       </section>
 
       <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h2 className="text-lg font-semibold text-slate-900">사용자 관리 잠금 정책</h2>
-        <div className="mt-2 space-y-1 text-sm text-slate-600">
-          <div>- 사용자 관리에서 생성/조회/수정/삭제(비활성)가 가능합니다.</div>
-          <div>- 현재 로그인한 운영자 계정은 역할/상태 변경이 잠깁니다.</div>
-          <div>- 마지막 활성 관리자 계정은 USER 변경/비활성화가 잠깁니다.</div>
-          <div>- 사용자 삭제는 소프트 삭제이며 `DISABLED` 상태로 처리됩니다.</div>
-          <div>- 목적: 단일 운영자 환경에서 관리자 계정 잠금(셀프 락아웃) 방지</div>
-        </div>
-      </section>
-
-      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
         <h2 className="text-lg font-semibold text-slate-900">자주 보이는 API 에러 코드</h2>
         <div className="mt-2 space-y-1 text-sm text-slate-600">
           <div>- `admin_login_disabled`: 서버에 관리자 ID/PW가 비어 있음</div>
-          <div>- `admin_login_failed`: 아이디 또는 비밀번호 불일치</div>
+          <div>- `admin_login_failed`: ID/비밀번호 불일치</div>
+          <div>- `admin_password_change_failed`: 현재 비밀번호 검증 실패</div>
           <div>- `unauthorized`: 토큰 만료/누락</div>
           <div>- `forbidden`: ADMIN이 아닌 토큰으로 Admin API 호출</div>
         </div>
@@ -47,4 +161,3 @@ export default function HelpPage() {
     </div>
   );
 }
-

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminPasswordLoginUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminPasswordLoginUseCase.java
@@ -2,11 +2,13 @@ package com.eunhyehymn.application.usecases;
 
 import com.eunhyehymn.application.ports.TokenHashService;
 import com.eunhyehymn.application.ports.TokenService;
+import com.eunhyehymn.domain.model.AdminPasswordCredential;
 import com.eunhyehymn.domain.model.AuthIdentity;
 import com.eunhyehymn.domain.model.RefreshToken;
 import com.eunhyehymn.domain.model.Role;
 import com.eunhyehymn.domain.model.User;
 import com.eunhyehymn.domain.model.UserStatus;
+import com.eunhyehymn.domain.repository.AdminPasswordCredentialRepository;
 import com.eunhyehymn.domain.repository.AuthIdentityRepository;
 import com.eunhyehymn.domain.repository.RefreshTokenRepository;
 import com.eunhyehymn.domain.repository.UserRepository;
@@ -15,36 +17,43 @@ import java.security.MessageDigest;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 public class AdminPasswordLoginUseCase {
-    private static final String PROVIDER_LOCAL_ADMIN = "LOCAL_ADMIN";
+    static final String PROVIDER_LOCAL_ADMIN = "LOCAL_ADMIN";
     private static final String DEFAULT_DISPLAY_NAME = "Admin";
 
+    private final AdminPasswordCredentialRepository adminPasswordCredentialRepository;
     private final AuthIdentityRepository authIdentityRepository;
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final TokenService tokenService;
     private final TokenHashService tokenHashService;
+    private final PasswordEncoder passwordEncoder;
     private final long refreshTokenTtlSeconds;
     private final String configuredLoginId;
     private final String configuredPassword;
 
     public AdminPasswordLoginUseCase(
+        AdminPasswordCredentialRepository adminPasswordCredentialRepository,
         AuthIdentityRepository authIdentityRepository,
         UserRepository userRepository,
         RefreshTokenRepository refreshTokenRepository,
         TokenService tokenService,
         TokenHashService tokenHashService,
+        PasswordEncoder passwordEncoder,
         long refreshTokenTtlSeconds,
         String configuredLoginId,
         String configuredPassword
     ) {
+        this.adminPasswordCredentialRepository = adminPasswordCredentialRepository;
         this.authIdentityRepository = authIdentityRepository;
         this.userRepository = userRepository;
         this.refreshTokenRepository = refreshTokenRepository;
         this.tokenService = tokenService;
         this.tokenHashService = tokenHashService;
+        this.passwordEncoder = passwordEncoder;
         this.refreshTokenTtlSeconds = refreshTokenTtlSeconds;
         this.configuredLoginId = configuredLoginId != null ? configuredLoginId.trim() : "";
         this.configuredPassword = configuredPassword != null ? configuredPassword : "";
@@ -52,14 +61,12 @@ public class AdminPasswordLoginUseCase {
 
     @Transactional
     public LoginResult login(String loginId, String password) {
-        if (configuredLoginId.isBlank() || configuredPassword.isBlank()) {
-            throw new LoginDisabledException("관리자 ID/PW 로그인이 설정되지 않았습니다");
-        }
+        EffectiveCredential credential = resolveEffectiveCredential();
 
         String inputLoginId = loginId != null ? loginId.trim() : "";
         String inputPassword = password != null ? password : "";
-        if (!secureEquals(configuredLoginId, inputLoginId) || !secureEquals(configuredPassword, inputPassword)) {
-            throw new InvalidCredentialsException("아이디 또는 비밀번호가 올바르지 않습니다");
+        if (!secureEquals(credential.loginId(), inputLoginId) || !verifyPassword(credential, inputPassword)) {
+            throw new InvalidCredentialsException("Invalid admin login ID or password.");
         }
 
         Instant now = Instant.now();
@@ -67,7 +74,7 @@ public class AdminPasswordLoginUseCase {
         User user;
 
         Optional<AuthIdentity> existingIdentity = authIdentityRepository
-            .findByProviderAndProviderSubject(PROVIDER_LOCAL_ADMIN, configuredLoginId);
+            .findByProviderAndProviderSubject(PROVIDER_LOCAL_ADMIN, credential.loginId());
 
         if (existingIdentity.isPresent()) {
             UUID userId = existingIdentity.get().userId();
@@ -93,7 +100,7 @@ public class AdminPasswordLoginUseCase {
                 UUID.randomUUID(),
                 userId,
                 PROVIDER_LOCAL_ADMIN,
-                configuredLoginId,
+                credential.loginId(),
                 null,
                 now
             );
@@ -116,10 +123,41 @@ public class AdminPasswordLoginUseCase {
         return new LoginResult(accessToken, refreshToken, newUser);
     }
 
+    private EffectiveCredential resolveEffectiveCredential() {
+        Optional<AdminPasswordCredential> storedCredential = adminPasswordCredentialRepository.find();
+        if (storedCredential.isPresent()) {
+            AdminPasswordCredential credential = storedCredential.get();
+            return EffectiveCredential.fromStored(credential.loginId(), credential.passwordHash());
+        }
+
+        if (configuredLoginId.isBlank() || configuredPassword.isBlank()) {
+            throw new LoginDisabledException("Admin ID/password login is not configured.");
+        }
+
+        return EffectiveCredential.fromConfigured(configuredLoginId, configuredPassword);
+    }
+
+    private boolean verifyPassword(EffectiveCredential credential, String inputPassword) {
+        if (credential.fromConfigured()) {
+            return secureEquals(credential.secret(), inputPassword);
+        }
+        return passwordEncoder.matches(inputPassword, credential.secret());
+    }
+
     private static boolean secureEquals(String expected, String actual) {
         byte[] expectedBytes = expected.getBytes(StandardCharsets.UTF_8);
         byte[] actualBytes = actual.getBytes(StandardCharsets.UTF_8);
         return MessageDigest.isEqual(expectedBytes, actualBytes);
+    }
+
+    private record EffectiveCredential(String loginId, String secret, boolean fromConfigured) {
+        static EffectiveCredential fromConfigured(String loginId, String password) {
+            return new EffectiveCredential(loginId, password, true);
+        }
+
+        static EffectiveCredential fromStored(String loginId, String passwordHash) {
+            return new EffectiveCredential(loginId, passwordHash, false);
+        }
     }
 
     public record LoginResult(String accessToken, String refreshToken, boolean newUser) {
@@ -137,4 +175,3 @@ public class AdminPasswordLoginUseCase {
         }
     }
 }
-

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/UpdateAdminPasswordCredentialUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/UpdateAdminPasswordCredentialUseCase.java
@@ -1,0 +1,178 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.domain.model.AdminPasswordCredential;
+import com.eunhyehymn.domain.model.AuthIdentity;
+import com.eunhyehymn.domain.repository.AdminPasswordCredentialRepository;
+import com.eunhyehymn.domain.repository.AuthIdentityRepository;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+public class UpdateAdminPasswordCredentialUseCase {
+    private static final int MIN_LOGIN_ID_LENGTH = 3;
+    private static final int MAX_LOGIN_ID_LENGTH = 100;
+    private static final int MIN_PASSWORD_LENGTH = 8;
+
+    private final AdminPasswordCredentialRepository adminPasswordCredentialRepository;
+    private final AuthIdentityRepository authIdentityRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final String configuredLoginId;
+    private final String configuredPassword;
+
+    public UpdateAdminPasswordCredentialUseCase(
+        AdminPasswordCredentialRepository adminPasswordCredentialRepository,
+        AuthIdentityRepository authIdentityRepository,
+        PasswordEncoder passwordEncoder,
+        String configuredLoginId,
+        String configuredPassword
+    ) {
+        this.adminPasswordCredentialRepository = adminPasswordCredentialRepository;
+        this.authIdentityRepository = authIdentityRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.configuredLoginId = configuredLoginId != null ? configuredLoginId.trim() : "";
+        this.configuredPassword = configuredPassword != null ? configuredPassword : "";
+    }
+
+    @Transactional
+    public Result update(UUID requesterId, String currentPassword, String newLoginId, String newPassword) {
+        EffectiveCredential activeCredential = resolveEffectiveCredential();
+        validateNewCredential(newLoginId, newPassword);
+
+        String current = currentPassword != null ? currentPassword : "";
+        if (!matchesCurrentPassword(activeCredential, current)) {
+            throw new InvalidCredentialsException("Current admin password is incorrect.");
+        }
+
+        String normalizedLoginId = newLoginId.trim();
+        String encodedPassword = passwordEncoder.encode(newPassword);
+        Instant now = Instant.now();
+
+        Optional<AdminPasswordCredential> storedCredential = adminPasswordCredentialRepository.find();
+        if (storedCredential.isPresent()) {
+            AdminPasswordCredential existing = storedCredential.get();
+            adminPasswordCredentialRepository.save(new AdminPasswordCredential(
+                existing.id(),
+                normalizedLoginId,
+                encodedPassword,
+                existing.createdAt(),
+                now
+            ));
+        } else {
+            adminPasswordCredentialRepository.save(new AdminPasswordCredential(
+                UUID.randomUUID(),
+                normalizedLoginId,
+                encodedPassword,
+                now,
+                now
+            ));
+        }
+
+        syncLocalAdminIdentity(requesterId, normalizedLoginId, now);
+
+        return new Result(normalizedLoginId, now);
+    }
+
+    private void syncLocalAdminIdentity(UUID requesterId, String loginId, Instant now) {
+        Optional<AuthIdentity> identity = authIdentityRepository.findByUserIdAndProvider(
+            requesterId,
+            AdminPasswordLoginUseCase.PROVIDER_LOCAL_ADMIN
+        );
+
+        if (identity.isPresent()) {
+            AuthIdentity existing = identity.get();
+            if (!existing.providerSubject().equals(loginId)) {
+                authIdentityRepository.save(new AuthIdentity(
+                    existing.id(),
+                    existing.userId(),
+                    existing.provider(),
+                    loginId,
+                    existing.email(),
+                    existing.createdAt()
+                ));
+            }
+            return;
+        }
+
+        authIdentityRepository.save(new AuthIdentity(
+            UUID.randomUUID(),
+            requesterId,
+            AdminPasswordLoginUseCase.PROVIDER_LOCAL_ADMIN,
+            loginId,
+            null,
+            now
+        ));
+    }
+
+    private EffectiveCredential resolveEffectiveCredential() {
+        Optional<AdminPasswordCredential> storedCredential = adminPasswordCredentialRepository.find();
+        if (storedCredential.isPresent()) {
+            AdminPasswordCredential credential = storedCredential.get();
+            return EffectiveCredential.fromStored(credential.loginId(), credential.passwordHash());
+        }
+
+        if (configuredLoginId.isBlank() || configuredPassword.isBlank()) {
+            throw new LoginDisabledException("Admin ID/password login is not configured.");
+        }
+        return EffectiveCredential.fromConfigured(configuredLoginId, configuredPassword);
+    }
+
+    private boolean matchesCurrentPassword(EffectiveCredential credential, String currentPassword) {
+        if (credential.fromConfigured()) {
+            return secureEquals(credential.secret(), currentPassword);
+        }
+        return passwordEncoder.matches(currentPassword, credential.secret());
+    }
+
+    private static void validateNewCredential(String loginId, String password) {
+        String normalizedLoginId = loginId != null ? loginId.trim() : "";
+        String normalizedPassword = password != null ? password : "";
+
+        if (normalizedLoginId.length() < MIN_LOGIN_ID_LENGTH || normalizedLoginId.length() > MAX_LOGIN_ID_LENGTH) {
+            throw new InvalidCredentialFormatException("New login ID must be 3-100 characters.");
+        }
+        if (normalizedPassword.length() < MIN_PASSWORD_LENGTH) {
+            throw new InvalidCredentialFormatException("New password must be at least 8 characters.");
+        }
+    }
+
+    private static boolean secureEquals(String expected, String actual) {
+        byte[] expectedBytes = expected.getBytes(StandardCharsets.UTF_8);
+        byte[] actualBytes = actual.getBytes(StandardCharsets.UTF_8);
+        return MessageDigest.isEqual(expectedBytes, actualBytes);
+    }
+
+    private record EffectiveCredential(String loginId, String secret, boolean fromConfigured) {
+        static EffectiveCredential fromConfigured(String loginId, String password) {
+            return new EffectiveCredential(loginId, password, true);
+        }
+
+        static EffectiveCredential fromStored(String loginId, String passwordHash) {
+            return new EffectiveCredential(loginId, passwordHash, false);
+        }
+    }
+
+    public record Result(String loginId, Instant updatedAt) {
+    }
+
+    public static class LoginDisabledException extends RuntimeException {
+        public LoginDisabledException(String message) {
+            super(message);
+        }
+    }
+
+    public static class InvalidCredentialsException extends RuntimeException {
+        public InvalidCredentialsException(String message) {
+            super(message);
+        }
+    }
+
+    public static class InvalidCredentialFormatException extends RuntimeException {
+        public InvalidCredentialFormatException(String message) {
+            super(message);
+        }
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/AuthConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/AuthConfig.java
@@ -8,6 +8,8 @@ import com.eunhyehymn.application.usecases.DevLoginUseCase;
 import com.eunhyehymn.application.usecases.LogoutUseCase;
 import com.eunhyehymn.application.usecases.RefreshTokenUseCase;
 import com.eunhyehymn.application.usecases.SocialLoginUseCase;
+import com.eunhyehymn.application.usecases.UpdateAdminPasswordCredentialUseCase;
+import com.eunhyehymn.domain.repository.AdminPasswordCredentialRepository;
 import com.eunhyehymn.domain.repository.AuthIdentityRepository;
 import com.eunhyehymn.domain.repository.InviteCodeRepository;
 import com.eunhyehymn.domain.repository.RefreshTokenRepository;
@@ -24,6 +26,8 @@ import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 public class AuthConfig {
@@ -54,6 +58,11 @@ public class AuthConfig {
     @Bean
     TokenHashService tokenHashService() {
         return new Sha256TokenHashService();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
     @Bean
@@ -139,22 +148,43 @@ public class AuthConfig {
 
     @Bean
     AdminPasswordLoginUseCase adminPasswordLoginUseCase(
+        AdminPasswordCredentialRepository adminPasswordCredentialRepository,
         AuthIdentityRepository authIdentityRepository,
         UserRepository userRepository,
         RefreshTokenRepository refreshTokenRepository,
         TokenService tokenService,
         TokenHashService tokenHashService,
+        PasswordEncoder passwordEncoder,
         @Value("${security.jwt.refresh-token-ttl-seconds}") long refreshTokenTtlSeconds,
         @Value("${security.admin.login-id:}") String loginId,
         @Value("${security.admin.login-password:}") String loginPassword
     ) {
         return new AdminPasswordLoginUseCase(
+            adminPasswordCredentialRepository,
             authIdentityRepository,
             userRepository,
             refreshTokenRepository,
             tokenService,
             tokenHashService,
+            passwordEncoder,
             refreshTokenTtlSeconds,
+            loginId,
+            loginPassword
+        );
+    }
+
+    @Bean
+    UpdateAdminPasswordCredentialUseCase updateAdminPasswordCredentialUseCase(
+        AdminPasswordCredentialRepository adminPasswordCredentialRepository,
+        AuthIdentityRepository authIdentityRepository,
+        PasswordEncoder passwordEncoder,
+        @Value("${security.admin.login-id:}") String loginId,
+        @Value("${security.admin.login-password:}") String loginPassword
+    ) {
+        return new UpdateAdminPasswordCredentialUseCase(
+            adminPasswordCredentialRepository,
+            authIdentityRepository,
+            passwordEncoder,
             loginId,
             loginPassword
         );

--- a/apps/api/src/main/java/com/eunhyehymn/domain/model/AdminPasswordCredential.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/model/AdminPasswordCredential.java
@@ -1,0 +1,13 @@
+package com.eunhyehymn.domain.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record AdminPasswordCredential(
+    UUID id,
+    String loginId,
+    String passwordHash,
+    Instant createdAt,
+    Instant updatedAt
+) {
+}

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/AdminPasswordCredentialRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/AdminPasswordCredentialRepository.java
@@ -1,0 +1,10 @@
+package com.eunhyehymn.domain.repository;
+
+import com.eunhyehymn.domain.model.AdminPasswordCredential;
+import java.util.Optional;
+
+public interface AdminPasswordCredentialRepository {
+    Optional<AdminPasswordCredential> find();
+
+    AdminPasswordCredential save(AdminPasswordCredential credential);
+}

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/AuthIdentityRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/AuthIdentityRepository.java
@@ -13,4 +13,6 @@ public interface AuthIdentityRepository {
     Optional<AuthIdentity> findByProviderAndProviderSubject(String provider, String providerSubject);
 
     List<AuthIdentity> findByUserIdIn(List<UUID> userIds);
+
+    Optional<AuthIdentity> findByUserIdAndProvider(UUID userId, String provider);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AdminPasswordCredentialEntity.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AdminPasswordCredentialEntity.java
@@ -1,0 +1,64 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "admin_password_credentials")
+public class AdminPasswordCredentialEntity {
+    @Id
+    private UUID id;
+
+    @Column(name = "login_id", nullable = false, length = 100)
+    private String loginId;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected AdminPasswordCredentialEntity() {
+    }
+
+    public AdminPasswordCredentialEntity(
+        UUID id,
+        String loginId,
+        String passwordHash,
+        Instant createdAt,
+        Instant updatedAt
+    ) {
+        this.id = id;
+        this.loginId = loginId;
+        this.passwordHash = passwordHash;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public String getLoginId() {
+        return loginId;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AdminPasswordCredentialJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AdminPasswordCredentialJpaRepository.java
@@ -1,0 +1,8 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminPasswordCredentialJpaRepository
+    extends JpaRepository<AdminPasswordCredentialEntity, UUID> {
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AdminPasswordCredentialRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AdminPasswordCredentialRepositoryAdapter.java
@@ -1,0 +1,38 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import com.eunhyehymn.domain.model.AdminPasswordCredential;
+import com.eunhyehymn.domain.repository.AdminPasswordCredentialRepository;
+import com.eunhyehymn.infrastructure.persistence.mapper.AdminPasswordCredentialMapper;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class AdminPasswordCredentialRepositoryAdapter implements AdminPasswordCredentialRepository {
+    private static final UUID CREDENTIAL_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+
+    private final AdminPasswordCredentialJpaRepository jpaRepository;
+
+    public AdminPasswordCredentialRepositoryAdapter(AdminPasswordCredentialJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Optional<AdminPasswordCredential> find() {
+        return jpaRepository.findById(CREDENTIAL_ID).map(AdminPasswordCredentialMapper::toDomain);
+    }
+
+    @Override
+    public AdminPasswordCredential save(AdminPasswordCredential credential) {
+        AdminPasswordCredential normalized = new AdminPasswordCredential(
+            CREDENTIAL_ID,
+            credential.loginId(),
+            credential.passwordHash(),
+            credential.createdAt(),
+            credential.updatedAt()
+        );
+        return AdminPasswordCredentialMapper.toDomain(
+            jpaRepository.save(AdminPasswordCredentialMapper.toEntity(normalized))
+        );
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AuthIdentityJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AuthIdentityJpaRepository.java
@@ -9,4 +9,6 @@ public interface AuthIdentityJpaRepository extends JpaRepository<AuthIdentityEnt
     Optional<AuthIdentityEntity> findByProviderAndProviderSubject(String provider, String providerSubject);
 
     List<AuthIdentityEntity> findByUserIdIn(List<UUID> userIds);
+
+    Optional<AuthIdentityEntity> findByUserIdAndProvider(UUID userId, String provider);
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AuthIdentityRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AuthIdentityRepositoryAdapter.java
@@ -42,4 +42,10 @@ public class AuthIdentityRepositoryAdapter implements AuthIdentityRepository {
             .map(AuthIdentityMapper::toDomain)
             .toList();
     }
+
+    @Override
+    public Optional<AuthIdentity> findByUserIdAndProvider(UUID userId, String provider) {
+        return authIdentityJpaRepository.findByUserIdAndProvider(userId, provider)
+            .map(AuthIdentityMapper::toDomain);
+    }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/mapper/AdminPasswordCredentialMapper.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/mapper/AdminPasswordCredentialMapper.java
@@ -1,0 +1,29 @@
+package com.eunhyehymn.infrastructure.persistence.mapper;
+
+import com.eunhyehymn.domain.model.AdminPasswordCredential;
+import com.eunhyehymn.infrastructure.persistence.AdminPasswordCredentialEntity;
+
+public final class AdminPasswordCredentialMapper {
+    private AdminPasswordCredentialMapper() {
+    }
+
+    public static AdminPasswordCredential toDomain(AdminPasswordCredentialEntity entity) {
+        return new AdminPasswordCredential(
+            entity.getId(),
+            entity.getLoginId(),
+            entity.getPasswordHash(),
+            entity.getCreatedAt(),
+            entity.getUpdatedAt()
+        );
+    }
+
+    public static AdminPasswordCredentialEntity toEntity(AdminPasswordCredential credential) {
+        return new AdminPasswordCredentialEntity(
+            credential.id(),
+            credential.loginId(),
+            credential.passwordHash(),
+            credential.createdAt(),
+            credential.updatedAt()
+        );
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminAuthController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AdminAuthController.java
@@ -1,0 +1,70 @@
+package com.eunhyehymn.presentation.controllers;
+
+import com.eunhyehymn.application.usecases.UpdateAdminPasswordCredentialUseCase;
+import com.eunhyehymn.common.error.ApiException;
+import com.eunhyehymn.common.response.ApiResponse;
+import jakarta.validation.constraints.NotBlank;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/auth")
+@Validated
+public class AdminAuthController {
+    private final UpdateAdminPasswordCredentialUseCase updateAdminPasswordCredentialUseCase;
+
+    public AdminAuthController(UpdateAdminPasswordCredentialUseCase updateAdminPasswordCredentialUseCase) {
+        this.updateAdminPasswordCredentialUseCase = updateAdminPasswordCredentialUseCase;
+    }
+
+    @PostMapping("/password")
+    public ApiResponse<UpdateAdminCredentialResponse> updateCredential(
+        @RequestBody @Validated UpdateAdminCredentialRequest request,
+        Authentication authentication
+    ) {
+        UUID requesterId = parseRequesterId(authentication);
+        try {
+            UpdateAdminPasswordCredentialUseCase.Result result = updateAdminPasswordCredentialUseCase.update(
+                requesterId,
+                request.currentPassword(),
+                request.newLoginId(),
+                request.newPassword()
+            );
+            return ApiResponse.success(new UpdateAdminCredentialResponse(result.loginId(), result.updatedAt()));
+        } catch (UpdateAdminPasswordCredentialUseCase.LoginDisabledException e) {
+            throw new ApiException(HttpStatus.SERVICE_UNAVAILABLE, "admin_login_disabled", e.getMessage(), null);
+        } catch (UpdateAdminPasswordCredentialUseCase.InvalidCredentialsException e) {
+            throw new ApiException(HttpStatus.UNAUTHORIZED, "admin_password_change_failed", e.getMessage(), null);
+        } catch (UpdateAdminPasswordCredentialUseCase.InvalidCredentialFormatException e) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "invalid_request", e.getMessage(), null);
+        }
+    }
+
+    private UUID parseRequesterId(Authentication authentication) {
+        if (authentication == null || authentication.getName() == null || authentication.getName().isBlank()) {
+            throw new ApiException(HttpStatus.UNAUTHORIZED, "invalid_principal", "Authentication principal is missing.", null);
+        }
+        try {
+            return UUID.fromString(authentication.getName());
+        } catch (IllegalArgumentException e) {
+            throw new ApiException(HttpStatus.UNAUTHORIZED, "invalid_principal", "Authentication principal is not a valid UUID.", null);
+        }
+    }
+
+    public record UpdateAdminCredentialRequest(
+        @NotBlank String currentPassword,
+        @NotBlank String newLoginId,
+        @NotBlank String newPassword
+    ) {
+    }
+
+    public record UpdateAdminCredentialResponse(String loginId, Instant updatedAt) {
+    }
+}

--- a/apps/api/src/main/resources/db/migration/V11__admin_password_credentials.sql
+++ b/apps/api/src/main/resources/db/migration/V11__admin_password_credentials.sql
@@ -1,0 +1,7 @@
+CREATE TABLE admin_password_credentials (
+    id UUID PRIMARY KEY,
+    login_id VARCHAR(100) NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminPasswordCredentialApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminPasswordCredentialApiTest.java
@@ -1,14 +1,11 @@
 package com.eunhyehymn.presentation.controllers;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.eunhyehymn.infrastructure.persistence.AssetJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.AdminPasswordCredentialJpaRepository;
-import com.eunhyehymn.infrastructure.persistence.AuthIdentityEntity;
+import com.eunhyehymn.infrastructure.persistence.AssetJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.AuthIdentityJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.EventJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.HymnJpaRepository;
@@ -17,7 +14,6 @@ import com.eunhyehymn.infrastructure.persistence.InviteCodeJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.RefreshTokenJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.UserHymnStateJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.UserJpaRepository;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +33,7 @@ import org.springframework.test.web.servlet.MockMvc;
     "security.admin.login-id=owner",
     "security.admin.login-password=test-password-123!"
 })
-class AdminPasswordLoginApiTest {
+class AdminPasswordCredentialApiTest {
     @Autowired private MockMvc mockMvc;
     @Autowired private ObjectMapper objectMapper;
     @Autowired private UserJpaRepository userJpaRepository;
@@ -66,65 +62,74 @@ class AdminPasswordLoginApiTest {
     }
 
     @Test
-    void firstLoginCreatesAdminUserAndIssuesTokens() throws Exception {
-        String response = login("owner", "test-password-123!");
+    void adminCanRotateLoginIdAndPassword() throws Exception {
+        String token = loginAndExtractAccessToken("owner", "test-password-123!");
 
-        JsonNode data = objectMapper.readTree(response).get("data");
-        String accessToken = data.get("accessToken").asText();
-        assertThat(data.get("newUser").asBoolean()).isTrue();
-
-        mockMvc.perform(get("/me/profile")
-                .header("Authorization", "Bearer " + accessToken))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.role").value("ADMIN"));
-
-        assertThat(userJpaRepository.count()).isEqualTo(1);
-        assertThat(authIdentityJpaRepository.count()).isEqualTo(1);
-        AuthIdentityEntity identity = authIdentityJpaRepository.findAll().get(0);
-        assertThat(identity.getProvider()).isEqualTo("LOCAL_ADMIN");
-        assertThat(identity.getProviderSubject()).isEqualTo("owner");
-    }
-
-    @Test
-    void secondLoginUsesExistingAdminUser() throws Exception {
-        login("owner", "test-password-123!");
-        String response = login("owner", "test-password-123!");
-
-        JsonNode data = objectMapper.readTree(response).get("data");
-        assertThat(data.get("newUser").asBoolean()).isFalse();
-        assertThat(userJpaRepository.count()).isEqualTo(1);
-        assertThat(authIdentityJpaRepository.count()).isEqualTo(1);
-    }
-
-    @Test
-    void invalidCredentialsReturnsUnauthorized() throws Exception {
-        String payload = objectMapper.writeValueAsString(Map.of(
-            "loginId", "owner",
-            "password", "wrong-password"
+        String updatePayload = objectMapper.writeValueAsString(Map.of(
+            "currentPassword", "test-password-123!",
+            "newLoginId", "owner2",
+            "newPassword", "new-password-456!"
         ));
+
+        mockMvc.perform(post("/admin/auth/password")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.loginId").value("owner2"));
 
         mockMvc.perform(post("/auth/admin/login")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(payload))
+                .content(objectMapper.writeValueAsString(Map.of(
+                    "loginId", "owner",
+                    "password", "test-password-123!"
+                ))))
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.error.code").value("admin_login_failed"));
+
+        mockMvc.perform(post("/auth/admin/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of(
+                    "loginId", "owner2",
+                    "password", "new-password-456!"
+                ))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.accessToken").isNotEmpty());
     }
 
-    private String login(String loginId, String password) throws Exception {
+    @Test
+    void changePasswordRequiresValidCurrentPassword() throws Exception {
+        String token = loginAndExtractAccessToken("owner", "test-password-123!");
+
+        String updatePayload = objectMapper.writeValueAsString(Map.of(
+            "currentPassword", "wrong-current-password",
+            "newLoginId", "owner2",
+            "newPassword", "new-password-456!"
+        ));
+
+        mockMvc.perform(post("/admin/auth/password")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.error.code").value("admin_password_change_failed"));
+    }
+
+    private String loginAndExtractAccessToken(String loginId, String password) throws Exception {
         String payload = objectMapper.writeValueAsString(Map.of(
             "loginId", loginId,
             "password", password
         ));
 
-        return mockMvc.perform(post("/auth/admin/login")
+        String body = mockMvc.perform(post("/auth/admin/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(payload))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
-            .andExpect(jsonPath("$.data.refreshToken").isNotEmpty())
             .andReturn()
             .getResponse()
             .getContentAsString();
+
+        return objectMapper.readTree(body).path("data").path("accessToken").asText();
     }
 }
-

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -57,7 +57,43 @@ Base URL: `/api/v1`
 - 요청 `data`: `{ "refreshToken": "jwt-refresh" }`
 - 응답 `data`: `null`
 
-### 1.5 DEV 로그인 (개발 환경 전용)
+### 1.5 Admin ID/PW 로그인
+- `POST /auth/admin/login`
+- 요청 `data` 예시:
+```json
+{
+  "loginId": "owner",
+  "password": "your-admin-password"
+}
+```
+- 응답 `data` 예시:
+```json
+{
+  "accessToken": "jwt-access",
+  "refreshToken": "jwt-refresh",
+  "newUser": false
+}
+```
+
+### 1.6 Admin ID/PW 변경 (관리자 토큰 필요)
+- `POST /admin/auth/password`
+- 요청 `data` 예시:
+```json
+{
+  "currentPassword": "current-password",
+  "newLoginId": "owner2",
+  "newPassword": "new-password-456!"
+}
+```
+- 응답 `data` 예시:
+```json
+{
+  "loginId": "owner2",
+  "updatedAt": "2026-02-15T14:00:00Z"
+}
+```
+
+### 1.7 DEV 로그인 (개발 환경 전용)
 - `POST /auth/dev/login`
 - 요청 `data` 예시:
 ```json

--- a/docs/staging-admin-login.md
+++ b/docs/staging-admin-login.md
@@ -16,6 +16,9 @@ Important:
 API endpoint:
 - `POST /api/v1/auth/admin/login`
 
+Credential rotation endpoint (admin token required):
+- `POST /api/v1/admin/auth/password`
+
 Request body:
 ```json
 {
@@ -25,6 +28,8 @@ Request body:
 ```
 
 If login succeeds, API issues normal access/refresh tokens with `ADMIN` role.
+
+You can rotate admin ID/password from Admin web `/help` page.
 
 ## Optional: Social Login Allowlist Mode
 


### PR DESCRIPTION
﻿## Summary
- add admin self-service ID/password rotation endpoint (`POST /api/v1/admin/auth/password`)
- persist rotated admin credentials in DB with bcrypt hash and keep backward compatibility with env-based bootstrap credentials
- add admin Help page form to rotate current admin login ID/password in-app
- update API docs and staging admin login docs

## Backend
- new table migration: `admin_password_credentials`
- new domain/persistence/repository layer for admin credential storage
- new use case: `UpdateAdminPasswordCredentialUseCase`
- admin login flow now resolves credential priority as: DB stored credential > env credential
- sync LOCAL_ADMIN auth identity providerSubject when login ID rotates

## Admin Web
- add API client: `changeAdminPasswordCredential`
- add credential rotation form in `/help`
- input validation: required fields, password min length, password confirm match

## Validation
- `cd apps/api && ./gradlew.bat test --no-daemon`
- `cd apps/admin && npm run build`

## Notes
- local untracked directories `apps/mobile/android/` and `apps/mobile/ios/` are intentionally not included
