### PR TITLE
feat: 다중 PNG 악보 지원 및 모바일 UX 전면 개선

### DIFF
--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminConfirmAssetUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminConfirmAssetUseCase.java
@@ -42,7 +42,10 @@ public class AdminConfirmAssetUseCase {
             throw new ApiException(HttpStatus.NOT_FOUND, "hymn_not_found", "찬송가를 찾을 수 없습니다", null);
         }
 
-        assetRepository.deleteByHymnIdAndTypeAndPart(hymnId, type, resolvedPart);
+        // PNG 악보는 한 곡에 여러 장(페이지) 등록할 수 있어 기존 파일을 유지한다.
+        if (type != AssetType.PNG) {
+            assetRepository.deleteByHymnIdAndTypeAndPart(hymnId, type, resolvedPart);
+        }
 
         Asset asset = new Asset(
             UUID.randomUUID(),

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AssetJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AssetJpaRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface AssetJpaRepository extends JpaRepository<AssetEntity, UUID> {
-    List<AssetEntity> findByHymnId(UUID hymnId);
+    List<AssetEntity> findByHymnIdOrderByCreatedAtAscIdAsc(UUID hymnId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Transactional

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AssetRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/AssetRepositoryAdapter.java
@@ -29,7 +29,10 @@ public class AssetRepositoryAdapter implements AssetRepository {
 
     @Override
     public List<Asset> findByHymnId(UUID hymnId) {
-        return assetJpaRepository.findByHymnId(hymnId).stream().map(AssetMapper::toDomain).toList();
+        return assetJpaRepository.findByHymnIdOrderByCreatedAtAscIdAsc(hymnId)
+            .stream()
+            .map(AssetMapper::toDomain)
+            .toList();
     }
 
     @Override

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminAssetApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminAssetApiTest.java
@@ -202,7 +202,7 @@ class AdminAssetApiTest {
     }
 
     @Test
-    void confirmReplacesExistingAssetForSameKey() throws Exception {
+    void confirmAllowsMultiplePngAssetsPerHymn() throws Exception {
         assetJpaRepository.save(new com.eunhyehymn.infrastructure.persistence.AssetEntity(
             UUID.randomUUID(),
             hymnId,
@@ -229,12 +229,53 @@ class AdminAssetApiTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.objectKey").value("hymns/" + hymnId + "/PNG/ALL/new.png"));
 
-        var sameKeyAssets = assetJpaRepository.findByHymnId(hymnId).stream()
+        var sameTypeAssets = assetJpaRepository.findByHymnIdOrderByCreatedAtAscIdAsc(hymnId).stream()
             .filter(asset -> asset.getType() == AssetType.PNG)
             .filter(asset -> asset.getPart() == com.eunhyehymn.domain.model.PartType.ALL)
             .toList();
-        assertThat(sameKeyAssets).hasSize(1);
-        assertThat(sameKeyAssets.get(0).getObjectKey()).isEqualTo("hymns/" + hymnId + "/PNG/ALL/new.png");
+        assertThat(sameTypeAssets).hasSize(2);
+        assertThat(sameTypeAssets)
+            .extracting(com.eunhyehymn.infrastructure.persistence.AssetEntity::getObjectKey)
+            .containsExactly(
+                "hymns/" + hymnId + "/PNG/ALL/old.png",
+                "hymns/" + hymnId + "/PNG/ALL/new.png"
+            );
+    }
+
+    @Test
+    void confirmReplacesExistingMidiAssetForSamePart() throws Exception {
+        assetJpaRepository.save(new com.eunhyehymn.infrastructure.persistence.AssetEntity(
+            UUID.randomUUID(),
+            hymnId,
+            AssetType.MIDI,
+            com.eunhyehymn.domain.model.PartType.ALL,
+            "https://public.local/hymns/old.mid",
+            "hymns/" + hymnId + "/MIDI/ALL/old.mid",
+            null,
+            null,
+            Instant.now()
+        ));
+
+        String payload = objectMapper.writeValueAsString(Map.of(
+            "hymnId", hymnId.toString(),
+            "type", AssetType.MIDI.name(),
+            "publicUrl", "https://public.local/hymns/new.mid",
+            "objectKey", "hymns/" + hymnId + "/MIDI/ALL/new.mid"
+        ));
+
+        mockMvc.perform(post("/admin/assets/confirm")
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.objectKey").value("hymns/" + hymnId + "/MIDI/ALL/new.mid"));
+
+        var midiAssets = assetJpaRepository.findByHymnIdOrderByCreatedAtAscIdAsc(hymnId).stream()
+            .filter(asset -> asset.getType() == AssetType.MIDI)
+            .filter(asset -> asset.getPart() == com.eunhyehymn.domain.model.PartType.ALL)
+            .toList();
+        assertThat(midiAssets).hasSize(1);
+        assertThat(midiAssets.get(0).getObjectKey()).isEqualTo("hymns/" + hymnId + "/MIDI/ALL/new.mid");
     }
 
     @Test

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminHymnApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminHymnApiTest.java
@@ -201,7 +201,7 @@ class AdminHymnApiTest {
             .andExpect(jsonPath("$.success").value(true));
 
         assertThat(hymnJpaRepository.findById(hymnId)).isEmpty();
-        assertThat(assetJpaRepository.findByHymnId(hymnId)).isEmpty();
+        assertThat(assetJpaRepository.findByHymnIdOrderByCreatedAtAscIdAsc(hymnId)).isEmpty();
     }
 
     @Test

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -5,12 +5,13 @@
 ## Scope
 
 - Social login
-  - Kakao SDK login (mobile)
-  - Dev login (local/dev only)
+  - Kakao SDK login (mobile, redirect flow)
+  - Invite code input (first login only)
+  - Hidden dev login switch (`ENABLE_DEV_LOGIN=true`)
 - Hymn
   - List and search
   - Detail view
-  - PNG asset display
+  - PNG asset display (multi-page per hymn)
   - MIDI playback controls (play/pause/stop/speed)
 - Personalization
   - Favorites toggle
@@ -47,6 +48,7 @@ Notes:
 - `API_BASE_URL` automatically appends `/api/v1` if omitted.
 - For physical devices, use the reachable host IP/domain instead of `10.0.2.2`.
 - Kakao Android callback scheme is `kakao<KAKAO_NATIVE_APP_KEY>`. If the key is missing/mismatched at run time, Kakao consent can stop at "Continue" without returning to the app.
+- `ENABLE_DEV_LOGIN=true` adds hidden local dev login panel on the login screen.
 
 ## Structure
 

--- a/apps/mobile/lib/src/app.dart
+++ b/apps/mobile/lib/src/app.dart
@@ -41,8 +41,7 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
       apiClient: _apiClient,
       tokenStorage: _tokenStorage,
     );
-    _socialSdkService = SocialSdkService();
-    _socialSdkService.initialize();
+    _socialSdkService = SocialSdkService()..initialize();
     _hymnRepository = HymnRepository(apiClient: _apiClient);
     _bootstrap();
   }
@@ -79,6 +78,9 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
       });
       await _hymnRepository.syncPendingActions();
     } catch (e) {
+      if (!mounted) {
+        return;
+      }
       setState(() {
         _initError = e.toString();
       });
@@ -113,10 +115,24 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Eunhye Hymn',
+      title: '은혜찬송',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFFFF6F0F)),
         useMaterial3: true,
+        scaffoldBackgroundColor: const Color(0xFFF6F7F9),
+        appBarTheme: const AppBarTheme(
+          backgroundColor: Colors.white,
+          foregroundColor: Color(0xFF1F2937),
+          elevation: 0,
+          surfaceTintColor: Colors.transparent,
+        ),
+        cardTheme: CardThemeData(
+          color: Colors.white,
+          elevation: 0,
+          margin: EdgeInsets.zero,
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        ),
       ),
       home: _buildHome(),
     );
@@ -133,7 +149,7 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
       return Scaffold(
         body: Center(
           child: Padding(
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.all(20),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -159,7 +175,6 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
     }
 
     return _HomeShell(
-      profile: _profile!,
       authRepository: _authRepository,
       hymnRepository: _hymnRepository,
       onLogout: _onLogout,
@@ -168,13 +183,11 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
 }
 
 class _HomeShell extends StatefulWidget {
-  final SessionProfile profile;
   final AuthRepository authRepository;
   final HymnRepository hymnRepository;
   final Future<void> Function() onLogout;
 
   const _HomeShell({
-    required this.profile,
     required this.authRepository,
     required this.hymnRepository,
     required this.onLogout,
@@ -203,6 +216,7 @@ class _HomeShellState extends State<_HomeShell> {
     if (_loggingOut) {
       return;
     }
+
     setState(() {
       _loggingOut = true;
     });
@@ -229,18 +243,29 @@ class _HomeShellState extends State<_HomeShell> {
         onOpenHymnDetail: _openHymnDetail,
       ),
     ];
-
-    final titles = ['찬양 목록', '최근 열람'];
-    final roleLabel = widget.profile.role == UserRole.admin ? 'ADMIN' : 'USER';
+    final titles = <String>['찬양 둘러보기', '최근 본 찬양'];
 
     return Scaffold(
       appBar: AppBar(
-        title: Text('${titles[_index]} · $roleLabel'),
+        title: Text(titles[_index]),
         actions: [
-          IconButton(
-            onPressed: _loggingOut ? null : _handleLogout,
-            icon: const Icon(Icons.logout),
-            tooltip: '로그아웃',
+          PopupMenuButton<String>(
+            enabled: !_loggingOut,
+            onSelected: (value) {
+              if (value == 'logout') {
+                _handleLogout();
+              }
+            },
+            itemBuilder: (_) => const [
+              PopupMenuItem(value: 'logout', child: Text('로그아웃')),
+            ],
+            icon: _loggingOut
+                ? const SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.more_vert),
           ),
         ],
       ),
@@ -248,7 +273,9 @@ class _HomeShellState extends State<_HomeShell> {
       bottomNavigationBar: NavigationBar(
         selectedIndex: _index,
         onDestinationSelected: (index) {
-          setState(() => _index = index);
+          setState(() {
+            _index = index;
+          });
         },
         destinations: const [
           NavigationDestination(
@@ -259,7 +286,7 @@ class _HomeShellState extends State<_HomeShell> {
           NavigationDestination(
             icon: Icon(Icons.history_outlined),
             selectedIcon: Icon(Icons.history),
-            label: '히스토리',
+            label: '최근 본 항목',
           ),
         ],
       ),

--- a/apps/mobile/lib/src/core/config/app_config.dart
+++ b/apps/mobile/lib/src/core/config/app_config.dart
@@ -13,6 +13,11 @@ class AppConfig {
     defaultValue: '',
   );
 
+  static const enableDevLogin = bool.fromEnvironment(
+    'ENABLE_DEV_LOGIN',
+    defaultValue: false,
+  );
+
   static String normalizeApiBaseUrl(String value) {
     final trimmed = value.trim();
     if (trimmed.isEmpty) {

--- a/apps/mobile/lib/src/features/auth/login_page.dart
+++ b/apps/mobile/lib/src/features/auth/login_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
 
+import '../../core/config/app_config.dart';
 import '../../core/network/api_exception.dart';
 import 'auth_repository.dart';
 import 'social_sdk_service.dart';
@@ -23,7 +24,7 @@ class LoginPage extends StatefulWidget {
 
 class _LoginPageState extends State<LoginPage> {
   final _inviteCodeController = TextEditingController();
-  final _displayNameController = TextEditingController(text: 'Mobile User');
+  final _displayNameController = TextEditingController(text: '테스트 사용자');
 
   UserRole _devRole = UserRole.user;
   bool _loading = false;
@@ -37,7 +38,7 @@ class _LoginPageState extends State<LoginPage> {
     super.dispose();
   }
 
-  Future<void> _handleSocialLogin() async {
+  Future<void> _handleKakaoLogin() async {
     setState(() {
       _loading = true;
       _error = null;
@@ -53,12 +54,18 @@ class _LoginPageState extends State<LoginPage> {
       );
       await widget.onLoggedIn(profile);
     } on ApiException catch (e) {
+      if (!mounted) {
+        return;
+      }
       setState(() {
         _error = e.message;
       });
-    } catch (e) {
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
       setState(() {
-        _error = 'Social login failed: $e';
+        _error = '카카오 로그인에 실패했습니다. 잠시 후 다시 시도해 주세요.';
       });
     } finally {
       if (mounted) {
@@ -72,7 +79,7 @@ class _LoginPageState extends State<LoginPage> {
   Future<void> _handleDevLogin() async {
     if (_displayNameController.text.trim().isEmpty) {
       setState(() {
-        _error = 'Display name is required.';
+        _error = '이름을 입력해 주세요.';
       });
       return;
     }
@@ -90,12 +97,18 @@ class _LoginPageState extends State<LoginPage> {
       );
       await widget.onLoggedIn(profile);
     } on ApiException catch (e) {
+      if (!mounted) {
+        return;
+      }
       setState(() {
         _error = e.message;
       });
-    } catch (e) {
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
       setState(() {
-        _error = 'Dev login failed: $e';
+        _error = '개발용 로그인에 실패했습니다.';
       });
     } finally {
       if (mounted) {
@@ -109,106 +122,112 @@ class _LoginPageState extends State<LoginPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Eunhye Hymn Login'),
-      ),
+      backgroundColor: const Color(0xFFF6F7F9),
       body: SafeArea(
         child: Center(
           child: SingleChildScrollView(
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.all(20),
             child: ConstrainedBox(
               constraints: const BoxConstraints(maxWidth: 480),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  if (_error != null)
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 12),
+                  const _LoginHero(),
+                  const SizedBox(height: 16),
+                  Card(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 20, 16, 16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          const Text(
+                            '카카오 로그인',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(height: 6),
+                          const Text(
+                            '한 번만 로그인하면 자동으로 유지됩니다.',
+                            style: TextStyle(color: Color(0xFF5B6572)),
+                          ),
+                          const SizedBox(height: 14),
+                          TextField(
+                            controller: _inviteCodeController,
+                            enabled: !_loading,
+                            decoration: InputDecoration(
+                              labelText: '초대 코드 (최초 1회)',
+                              hintText: '코드가 없다면 비워두세요',
+                              filled: true,
+                              fillColor: const Color(0xFFF9FAFB),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: BorderSide.none,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 14),
+                          _SocialLoginButton(
+                            onPressed: _loading ? null : _handleKakaoLogin,
+                            label: _loading ? '로그인 중...' : '카카오로 시작하기',
+                            icon: const Icon(Icons.chat_bubble_rounded),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  if (_error != null) ...[
+                    const SizedBox(height: 10),
+                    Container(
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFFFF1F0),
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(color: const Color(0xFFFFD1CC)),
+                      ),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 10,
+                      ),
                       child: Text(
                         _error!,
-                        style: const TextStyle(color: Colors.red),
-                      ),
-                    ),
-                  const Text(
-                    'Social Login',
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  const Text(
-                    'Tap Kakao icon to sign in with provider redirect.',
-                  ),
-                  const SizedBox(height: 12),
-                  _SocialLoginButton(
-                    onPressed: _loading ? null : _handleSocialLogin,
-                    label: _loading ? 'Signing in...' : 'Continue with Kakao',
-                    backgroundColor: const Color(0xFFFEE500),
-                    foregroundColor: Colors.black87,
-                    borderColor: const Color(0xFFFEE500),
-                    icon: const Icon(Icons.chat_bubble_rounded),
-                  ),
-                  const SizedBox(height: 12),
-                  TextField(
-                    controller: _inviteCodeController,
-                    enabled: !_loading,
-                    decoration: const InputDecoration(
-                      labelText: 'Invite code (first login only)',
-                      border: OutlineInputBorder(),
-                    ),
-                  ),
-                  const SizedBox(height: 20),
-                  OutlinedButton.icon(
-                    onPressed: _loading
-                        ? null
-                        : () {
-                            setState(() => _showDevLogin = !_showDevLogin);
-                          },
-                    icon: Icon(
-                        _showDevLogin ? Icons.expand_less : Icons.expand_more),
-                    label: const Text('Dev Login (local only)'),
-                  ),
-                  if (_showDevLogin) ...[
-                    const SizedBox(height: 12),
-                    TextField(
-                      controller: _displayNameController,
-                      enabled: !_loading,
-                      decoration: const InputDecoration(
-                        labelText: 'Display name',
-                        border: OutlineInputBorder(),
-                      ),
-                    ),
-                    const SizedBox(height: 12),
-                    DropdownButtonFormField<UserRole>(
-                      initialValue: _devRole,
-                      decoration: const InputDecoration(
-                        labelText: 'Role',
-                        border: OutlineInputBorder(),
-                      ),
-                      items: const [
-                        DropdownMenuItem(
-                          value: UserRole.user,
-                          child: Text('USER'),
+                        style: const TextStyle(
+                          color: Color(0xFFC2291E),
+                          fontWeight: FontWeight.w500,
                         ),
-                        DropdownMenuItem(
-                          value: UserRole.admin,
-                          child: Text('ADMIN'),
-                        ),
-                      ],
-                      onChanged: _loading
+                      ),
+                    ),
+                  ],
+                  if (AppConfig.enableDevLogin) ...[
+                    const SizedBox(height: 10),
+                    OutlinedButton.icon(
+                      onPressed: _loading
                           ? null
-                          : (value) {
-                              if (value != null) {
-                                setState(() => _devRole = value);
-                              }
+                          : () {
+                              setState(() {
+                                _showDevLogin = !_showDevLogin;
+                              });
                             },
+                      icon: Icon(
+                        _showDevLogin ? Icons.expand_less : Icons.expand_more,
+                      ),
+                      label: const Text('개발용 로그인'),
                     ),
-                    const SizedBox(height: 12),
-                    FilledButton.tonal(
-                      onPressed: _loading ? null : _handleDevLogin,
-                      child: Text(_loading ? 'Processing...' : 'Dev Login'),
-                    ),
+                    if (_showDevLogin)
+                      _DevLoginPanel(
+                        loading: _loading,
+                        displayNameController: _displayNameController,
+                        role: _devRole,
+                        onRoleChanged: (nextRole) {
+                          setState(() {
+                            _devRole = nextRole;
+                          });
+                        },
+                        onSubmit: _handleDevLogin,
+                      ),
                   ],
                 ],
               ),
@@ -220,43 +239,130 @@ class _LoginPageState extends State<LoginPage> {
   }
 }
 
+class _LoginHero extends StatelessWidget {
+  const _LoginHero();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          width: 72,
+          height: 72,
+          decoration: const BoxDecoration(
+            color: Color(0xFFFF6F0F),
+            shape: BoxShape.circle,
+          ),
+          child: const Icon(Icons.music_note_rounded,
+              color: Colors.white, size: 36),
+        ),
+        const SizedBox(height: 12),
+        const Text(
+          '은혜찬송',
+          style: TextStyle(fontSize: 28, fontWeight: FontWeight.w800),
+        ),
+        const SizedBox(height: 4),
+        const Text(
+          '모바일에서 빠르게 찬양 악보를 확인하세요.',
+          style: TextStyle(color: Color(0xFF5B6572)),
+        ),
+      ],
+    );
+  }
+}
+
 class _SocialLoginButton extends StatelessWidget {
   final VoidCallback? onPressed;
   final String label;
-  final Color backgroundColor;
-  final Color foregroundColor;
-  final Color borderColor;
   final Widget icon;
 
   const _SocialLoginButton({
     required this.onPressed,
     required this.label,
-    required this.backgroundColor,
-    required this.foregroundColor,
-    required this.borderColor,
     required this.icon,
   });
 
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: 52,
+      height: 54,
       child: FilledButton.icon(
         onPressed: onPressed,
         icon: icon,
         label: Text(
           label,
-          textAlign: TextAlign.center,
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
         ),
         style: FilledButton.styleFrom(
-          backgroundColor: backgroundColor,
-          foregroundColor: foregroundColor,
-          side: BorderSide(color: borderColor),
+          backgroundColor: const Color(0xFFFEE500),
+          foregroundColor: Colors.black87,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DevLoginPanel extends StatelessWidget {
+  final bool loading;
+  final TextEditingController displayNameController;
+  final UserRole role;
+  final ValueChanged<UserRole> onRoleChanged;
+  final Future<void> Function() onSubmit;
+
+  const _DevLoginPanel({
+    required this.loading,
+    required this.displayNameController,
+    required this.role,
+    required this.onRoleChanged,
+    required this.onSubmit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(top: 10),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: displayNameController,
+              enabled: !loading,
+              decoration: const InputDecoration(
+                labelText: '이름',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 10),
+            DropdownButtonFormField<UserRole>(
+              initialValue: role,
+              decoration: const InputDecoration(
+                labelText: '권한',
+                border: OutlineInputBorder(),
+              ),
+              items: const [
+                DropdownMenuItem(value: UserRole.user, child: Text('일반 사용자')),
+                DropdownMenuItem(value: UserRole.admin, child: Text('관리자')),
+              ],
+              onChanged: loading
+                  ? null
+                  : (value) {
+                      if (value != null) {
+                        onRoleChanged(value);
+                      }
+                    },
+            ),
+            const SizedBox(height: 10),
+            FilledButton.tonal(
+              onPressed: loading ? null : () => onSubmit(),
+              child: Text(loading ? '처리 중...' : '개발용 로그인'),
+            ),
+          ],
         ),
       ),
     );

--- a/apps/mobile/lib/src/features/history/history_page.dart
+++ b/apps/mobile/lib/src/features/history/history_page.dart
@@ -66,55 +66,167 @@ class _HistoryPageState extends State<HistoryPage> {
     if (_error != null) {
       return Center(
         child: Padding(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.all(20),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
               Text(_error!, style: const TextStyle(color: Colors.red)),
               const SizedBox(height: 12),
-              FilledButton(
-                onPressed: _load,
-                child: const Text('다시 시도'),
-              ),
+              FilledButton(onPressed: _load, child: const Text('다시 시도')),
             ],
           ),
         ),
       );
     }
 
-    if (_items.isEmpty) {
-      return RefreshIndicator(
-        onRefresh: _load,
-        child: ListView(
-          children: const [
-            SizedBox(height: 80),
-            Center(child: Text('최근 열람 히스토리가 없습니다.')),
-          ],
-        ),
-      );
-    }
-
     return RefreshIndicator(
       onRefresh: _load,
-      child: ListView.separated(
-        itemCount: _items.length,
-        separatorBuilder: (_, __) => const Divider(height: 1),
-        itemBuilder: (context, index) {
-          final item = _items[index];
-          final subtitle = [
-            if (item.number != null && item.number!.isNotEmpty) '#${item.number}',
-            if (item.tags != null && item.tags!.isNotEmpty) item.tags,
-            if (item.lastOpenedAt != null && item.lastOpenedAt!.isNotEmpty) item.lastOpenedAt,
-          ].join(' · ');
-
-          return ListTile(
-            title: Text(item.title),
-            subtitle: subtitle.isEmpty ? null : Text(subtitle),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () => widget.onOpenHymnDetail(item.id),
-          );
-        },
+      child: CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 14, 16, 10),
+              child: Text(
+                _items.isEmpty
+                    ? '아직 열어본 찬양이 없어요.'
+                    : '최근에 열어본 ${_items.length}곡',
+                style: const TextStyle(
+                  color: Color(0xFF5B6572),
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+          ),
+          if (_items.isEmpty)
+            const SliverFillRemaining(
+              hasScrollBody: false,
+              child: Center(
+                child: Text(
+                  '찬양을 열어보면 이곳에 기록됩니다.',
+                  style: TextStyle(color: Color(0xFF6B7280)),
+                ),
+              ),
+            )
+          else
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+              sliver: SliverList.builder(
+                itemCount: _items.length,
+                itemBuilder: (context, index) {
+                  final item = _items[index];
+                  return Padding(
+                    padding: const EdgeInsets.only(bottom: 10),
+                    child: _HistoryCard(
+                      item: item,
+                      onTap: () => widget.onOpenHymnDetail(item.id),
+                    ),
+                  );
+                },
+              ),
+            ),
+        ],
       ),
     );
   }
+}
+
+class _HistoryCard extends StatelessWidget {
+  final HistoryItem item;
+  final VoidCallback onTap;
+
+  const _HistoryCard({
+    required this.item,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final lastOpened = _formatRelativeTime(item.lastOpenedAt);
+    final numberText = item.number?.trim();
+
+    return Material(
+      color: Colors.white,
+      borderRadius: BorderRadius.circular(16),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(16),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(14),
+          child: Row(
+            children: [
+              Container(
+                width: 42,
+                height: 42,
+                decoration: const BoxDecoration(
+                  color: Color(0xFFFFEEE1),
+                  shape: BoxShape.circle,
+                ),
+                child:
+                    const Icon(Icons.history_rounded, color: Color(0xFFEA580C)),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      item.title,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w700,
+                        fontSize: 15.5,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      numberText == null || numberText.isEmpty
+                          ? lastOpened
+                          : '$numberText · $lastOpened',
+                      style: const TextStyle(
+                        color: Color(0xFF6B7280),
+                        fontSize: 12.5,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 6),
+              const Icon(Icons.chevron_right_rounded, color: Color(0xFF9CA3AF)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+String _formatRelativeTime(String? value) {
+  if (value == null || value.trim().isEmpty) {
+    return '방금 전';
+  }
+
+  final parsed = DateTime.tryParse(value)?.toLocal();
+  if (parsed == null) {
+    return value;
+  }
+
+  final diff = DateTime.now().difference(parsed);
+  if (diff.inMinutes < 1) {
+    return '방금 전';
+  }
+  if (diff.inHours < 1) {
+    return '${diff.inMinutes}분 전';
+  }
+  if (diff.inDays < 1) {
+    return '${diff.inHours}시간 전';
+  }
+  if (diff.inDays < 30) {
+    return '${diff.inDays}일 전';
+  }
+
+  final month = parsed.month.toString().padLeft(2, '0');
+  final day = parsed.day.toString().padLeft(2, '0');
+  return '${parsed.year}.$month.$day';
 }

--- a/apps/mobile/lib/src/features/hymn/hymn_detail_page.dart
+++ b/apps/mobile/lib/src/features/hymn/hymn_detail_page.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter/material.dart';
 
 import '../../core/network/api_exception.dart';
 import 'hymn_repository.dart';
@@ -50,6 +50,7 @@ class _HymnDetailPageState extends State<HymnDetailPage> {
       final detail = await widget.hymnRepository.getHymnDetail(widget.hymnId);
       final note = await widget.hymnRepository.getNote(widget.hymnId);
       final favorite = await widget.hymnRepository.getFavorite(widget.hymnId);
+
       if (!mounted) {
         return;
       }
@@ -84,7 +85,8 @@ class _HymnDetailPageState extends State<HymnDetailPage> {
     });
 
     try {
-      final favorite = await widget.hymnRepository.toggleFavorite(widget.hymnId);
+      final favorite =
+          await widget.hymnRepository.toggleFavorite(widget.hymnId);
       if (!mounted) {
         return;
       }
@@ -93,7 +95,9 @@ class _HymnDetailPageState extends State<HymnDetailPage> {
       });
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text(favorite ? '즐겨찾기에 추가했습니다.' : '즐겨찾기를 해제했습니다.'),
+          content: Text(
+            favorite ? '즐겨찾기에 추가했어요.' : '즐겨찾기에서 삭제했어요.',
+          ),
         ),
       );
     } on ApiException catch (e) {
@@ -116,10 +120,11 @@ class _HymnDetailPageState extends State<HymnDetailPage> {
     if (_savingNote) {
       return;
     }
+
     final content = _noteController.text.trim();
     if (content.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('메모를 입력한 뒤 저장하세요.')),
+        const SnackBar(content: Text('메모를 입력해 주세요.')),
       );
       return;
     }
@@ -134,7 +139,7 @@ class _HymnDetailPageState extends State<HymnDetailPage> {
         return;
       }
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('메모를 저장했습니다.')),
+        const SnackBar(content: Text('메모를 저장했어요.')),
       );
     } on ApiException catch (e) {
       if (!mounted) {
@@ -154,46 +159,11 @@ class _HymnDetailPageState extends State<HymnDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    if (_loading) {
-      return Scaffold(
-        appBar: AppBar(title: const Text('찬양 상세')),
-        body: const Center(child: CircularProgressIndicator()),
-      );
-    }
-
-    if (_error != null) {
-      return Scaffold(
-        appBar: AppBar(title: const Text('찬양 상세')),
-        body: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(_error!, style: const TextStyle(color: Colors.red)),
-                const SizedBox(height: 12),
-                FilledButton(
-                  onPressed: _load,
-                  child: const Text('다시 시도'),
-                ),
-              ],
-            ),
-          ),
-        ),
-      );
-    }
-
     final detail = _detail;
-    if (detail == null) {
-      return Scaffold(
-        appBar: AppBar(title: const Text('찬양 상세')),
-        body: const Center(child: Text('데이터가 없습니다.')),
-      );
-    }
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(detail.title),
+        title: Text(detail?.title ?? '찬양 상세'),
         actions: [
           IconButton(
             onPressed: _togglingFavorite ? null : _toggleFavorite,
@@ -202,58 +172,120 @@ class _HymnDetailPageState extends State<HymnDetailPage> {
           ),
         ],
       ),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
+      body: _buildBody(detail),
+    );
+  }
+
+  Widget _buildBody(HymnDetail? detail) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(_error!, style: const TextStyle(color: Colors.red)),
+              const SizedBox(height: 12),
+              FilledButton(
+                onPressed: _load,
+                child: const Text('다시 시도'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (detail == null) {
+      return const Center(child: Text('찬양 정보를 불러오지 못했습니다.'));
+    }
+
+    final imageAssets = detail.assets.where((asset) => asset.isImage).toList();
+    final midiAssets = detail.assets.where((asset) => asset.isMidi).toList();
+
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
         children: [
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(12),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    detail.title,
-                    style: Theme.of(context).textTheme.titleLarge,
-                  ),
-                  const SizedBox(height: 8),
-                  Text('번호: ${detail.number ?? "-"}'),
-                  Text('태그: ${detail.tags ?? "-"}'),
-                  Text('활성화: ${detail.enabled ? "예" : "아니오"}'),
-                ],
+          _SongSummaryCard(detail: detail),
+          const SizedBox(height: 16),
+          _SectionTitle(
+            title: '악보',
+            subtitle: imageAssets.isEmpty
+                ? '등록된 악보가 없습니다.'
+                : '총 ${imageAssets.length}페이지',
+          ),
+          const SizedBox(height: 8),
+          if (imageAssets.isEmpty)
+            const _EmptyCard(message: '관리자가 악보를 등록하면 여기에서 바로 볼 수 있어요.')
+          else
+            ...List.generate(
+              imageAssets.length,
+              (index) => Padding(
+                padding: const EdgeInsets.only(bottom: 10),
+                child: _ImageAssetCard(
+                  asset: imageAssets[index],
+                  label: '악보 ${index + 1}페이지',
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 12),
-          Text(
-            '에셋',
-            style: Theme.of(context).textTheme.titleMedium,
+          const SizedBox(height: 10),
+          _SectionTitle(
+            title: '반주',
+            subtitle: midiAssets.isEmpty
+                ? '등록된 반주 파일이 없습니다.'
+                : '총 ${midiAssets.length}개',
           ),
           const SizedBox(height: 8),
-          if (detail.assets.isEmpty)
-            const Text('등록된 에셋이 없습니다.')
+          if (midiAssets.isEmpty)
+            const _EmptyCard(message: '등록된 반주 파일이 없습니다.')
           else
-            ...detail.assets.map((asset) => _AssetCard(asset: asset)),
-          const SizedBox(height: 20),
-          Text(
-            '메모',
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          const SizedBox(height: 8),
-          TextField(
-            controller: _noteController,
-            minLines: 4,
-            maxLines: 8,
-            decoration: const InputDecoration(
-              border: OutlineInputBorder(),
-              hintText: '찬양 메모를 입력하세요.',
+            ...List.generate(
+              midiAssets.length,
+              (index) => Padding(
+                padding: const EdgeInsets.only(bottom: 10),
+                child: _MidiCard(
+                  title: '반주 ${index + 1}',
+                  url: midiAssets[index].url,
+                ),
+              ),
             ),
-          ),
+          const SizedBox(height: 10),
+          const _SectionTitle(title: '메모', subtitle: '개인 메모를 저장해 보세요.'),
           const SizedBox(height: 8),
-          Align(
-            alignment: Alignment.centerRight,
-            child: FilledButton(
-              onPressed: _savingNote ? null : _saveNote,
-              child: Text(_savingNote ? '저장 중...' : '메모 저장'),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextField(
+                    controller: _noteController,
+                    minLines: 4,
+                    maxLines: 8,
+                    decoration: InputDecoration(
+                      hintText: '이 찬양에 대한 메모를 남겨보세요.',
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: FilledButton(
+                      onPressed: _savingNote ? null : _saveNote,
+                      child: Text(_savingNote ? '저장 중...' : '메모 저장'),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ],
@@ -262,38 +294,188 @@ class _HymnDetailPageState extends State<HymnDetailPage> {
   }
 }
 
-class _AssetCard extends StatelessWidget {
-  final HymnAsset asset;
+class _SongSummaryCard extends StatelessWidget {
+  final HymnDetail detail;
 
-  const _AssetCard({required this.asset});
+  const _SongSummaryCard({required this.detail});
 
   @override
   Widget build(BuildContext context) {
     return Card(
-      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              detail.title,
+              style: const TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                if (detail.number != null && detail.number!.trim().isNotEmpty)
+                  _Badge(text: '번호 ${detail.number}'),
+                if (detail.tags != null && detail.tags!.trim().isNotEmpty)
+                  _Badge(text: detail.tags!),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Badge extends StatelessWidget {
+  final String text;
+
+  const _Badge({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: const Color(0xFFFFEEE1),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Text(
+        text,
+        style: const TextStyle(
+          color: Color(0xFFEA580C),
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  final String title;
+  final String subtitle;
+
+  const _SectionTitle({
+    required this.title,
+    required this.subtitle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w800),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          subtitle,
+          style: const TextStyle(color: Color(0xFF6B7280)),
+        ),
+      ],
+    );
+  }
+}
+
+class _EmptyCard extends StatelessWidget {
+  final String message;
+
+  const _EmptyCard({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Text(
+          message,
+          style: const TextStyle(color: Color(0xFF6B7280)),
+        ),
+      ),
+    );
+  }
+}
+
+class _ImageAssetCard extends StatelessWidget {
+  final HymnAsset asset;
+  final String label;
+
+  const _ImageAssetCard({
+    required this.asset,
+    required this.label,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
       child: Padding(
         padding: const EdgeInsets.all(12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('타입: ${asset.type} / 파트: ${asset.part ?? "-"}'),
-            const SizedBox(height: 6),
-            if (asset.isImage && asset.url.startsWith('http'))
+            Text(
+              label,
+              style: const TextStyle(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 8),
+            if (asset.url.startsWith('http'))
               ClipRRect(
-                borderRadius: BorderRadius.circular(8),
-                child: Image.network(
-                  asset.url,
-                  fit: BoxFit.cover,
-                  errorBuilder: (_, __, ___) => const Padding(
-                    padding: EdgeInsets.all(12),
-                    child: Text('이미지를 불러올 수 없습니다.'),
+                borderRadius: BorderRadius.circular(10),
+                child: InteractiveViewer(
+                  minScale: 1,
+                  maxScale: 4,
+                  child: Image.network(
+                    asset.url,
+                    fit: BoxFit.fitWidth,
+                    errorBuilder: (_, __, ___) => const Padding(
+                      padding: EdgeInsets.all(12),
+                      child: Text('악보 이미지를 불러오지 못했습니다.'),
+                    ),
                   ),
                 ),
               )
-            else if (asset.isMidi && asset.url.startsWith('http'))
-              _MidiAssetPlayer(url: asset.url)
             else
-              SelectableText(asset.url),
+              const Text(
+                '이미지 주소가 올바르지 않습니다.',
+                style: TextStyle(color: Colors.red),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MidiCard extends StatelessWidget {
+  final String title;
+  final String url;
+
+  const _MidiCard({
+    required this.title,
+    required this.url,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 8),
+            _MidiAssetPlayer(url: url),
           ],
         ),
       ),
@@ -357,7 +539,7 @@ class _MidiAssetPlayerState extends State<_MidiAssetPlayer> {
         return;
       }
       setState(() {
-        _error = 'MIDI 재생에 실패했습니다. 기기/브라우저 코덱 지원을 확인하세요.';
+        _error = '반주 재생에 실패했습니다.';
       });
     }
   }
@@ -366,7 +548,7 @@ class _MidiAssetPlayerState extends State<_MidiAssetPlayer> {
     try {
       await _player.stop();
     } catch (_) {
-      // stop 실패 시에도 UI는 계속 사용 가능하게 둔다.
+      // 정지 실패는 사용 흐름을 막지 않는다.
     }
   }
 
@@ -410,10 +592,10 @@ class _MidiAssetPlayerState extends State<_MidiAssetPlayer> {
             DropdownButton<double>(
               value: _speed,
               items: const [
-                DropdownMenuItem(value: 0.75, child: Text('0.75x')),
-                DropdownMenuItem(value: 1.0, child: Text('1.0x')),
-                DropdownMenuItem(value: 1.25, child: Text('1.25x')),
-                DropdownMenuItem(value: 1.5, child: Text('1.5x')),
+                DropdownMenuItem(value: 0.75, child: Text('0.75배속')),
+                DropdownMenuItem(value: 1.0, child: Text('1.0배속')),
+                DropdownMenuItem(value: 1.25, child: Text('1.25배속')),
+                DropdownMenuItem(value: 1.5, child: Text('1.5배속')),
               ],
               onChanged: (value) {
                 if (value != null) {
@@ -423,8 +605,6 @@ class _MidiAssetPlayerState extends State<_MidiAssetPlayer> {
             ),
           ],
         ),
-        const SizedBox(height: 8),
-        SelectableText(widget.url),
         if (_error != null) ...[
           const SizedBox(height: 6),
           Text(

--- a/apps/mobile/lib/src/features/hymn/hymn_list_page.dart
+++ b/apps/mobile/lib/src/features/hymn/hymn_list_page.dart
@@ -67,7 +67,7 @@ class _HymnListPageState extends State<HymnListPage> {
     if (_error != null) {
       return Center(
         child: Padding(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.all(20),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -83,63 +83,164 @@ class _HymnListPageState extends State<HymnListPage> {
       );
     }
 
+    final query = _query.trim().toLowerCase();
     final filtered = _items.where((item) {
-      final q = _query.trim().toLowerCase();
-      if (q.isEmpty) {
+      if (query.isEmpty) {
         return true;
       }
-      return item.title.toLowerCase().contains(q) ||
-          (item.number ?? '').toLowerCase().contains(q) ||
-          (item.tags ?? '').toLowerCase().contains(q);
+      return item.title.toLowerCase().contains(query) ||
+          (item.number ?? '').toLowerCase().contains(query) ||
+          (item.tags ?? '').toLowerCase().contains(query);
     }).toList();
 
-    return Column(
-      children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-          child: TextField(
-            decoration: const InputDecoration(
-              border: OutlineInputBorder(),
-              hintText: '제목, 번호, 태그 검색',
-              prefixIcon: Icon(Icons.search),
-            ),
-            onChanged: (value) {
-              setState(() {
-                _query = value;
-              });
-            },
-          ),
-        ),
-        Expanded(
-          child: RefreshIndicator(
-            onRefresh: _load,
-            child: filtered.isEmpty
-                ? ListView(
-                    children: const [
-                      SizedBox(height: 80),
-                      Center(child: Text('검색 결과가 없습니다.')),
-                    ],
-                  )
-                : ListView.separated(
-                    itemCount: filtered.length,
-                    separatorBuilder: (_, __) => const Divider(height: 1),
-                    itemBuilder: (context, index) {
-                      final hymn = filtered[index];
-                      final subtitle = [
-                        if (hymn.number != null && hymn.number!.isNotEmpty) '#${hymn.number}',
-                        if (hymn.tags != null && hymn.tags!.isNotEmpty) hymn.tags,
-                      ].join(' · ');
-                      return ListTile(
-                        title: Text(hymn.title),
-                        subtitle: subtitle.isEmpty ? null : Text(subtitle),
-                        trailing: const Icon(Icons.chevron_right),
-                        onTap: () => widget.onOpenHymnDetail(hymn.id),
-                      );
+    return RefreshIndicator(
+      onRefresh: _load,
+      child: CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  TextField(
+                    decoration: InputDecoration(
+                      hintText: '제목, 번호, 태그 검색',
+                      prefixIcon: const Icon(Icons.search),
+                      filled: true,
+                      fillColor: Colors.white,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(14),
+                        borderSide: BorderSide.none,
+                      ),
+                    ),
+                    onChanged: (value) {
+                      setState(() {
+                        _query = value;
+                      });
                     },
                   ),
+                  const SizedBox(height: 10),
+                  Text(
+                    query.isEmpty
+                        ? '전체 ${_items.length}곡'
+                        : '검색 결과 ${filtered.length}곡',
+                    style: const TextStyle(
+                      color: Color(0xFF5B6572),
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          if (filtered.isEmpty)
+            const SliverFillRemaining(
+              hasScrollBody: false,
+              child: Center(
+                child: Text(
+                  '조건에 맞는 찬양이 없어요.',
+                  style: TextStyle(color: Color(0xFF6B7280)),
+                ),
+              ),
+            )
+          else
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 24),
+              sliver: SliverList.builder(
+                itemCount: filtered.length,
+                itemBuilder: (context, index) {
+                  final hymn = filtered[index];
+                  return Padding(
+                    padding: const EdgeInsets.only(bottom: 10),
+                    child: _HymnCard(
+                      hymn: hymn,
+                      onTap: () => widget.onOpenHymnDetail(hymn.id),
+                    ),
+                  );
+                },
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HymnCard extends StatelessWidget {
+  final HymnSummary hymn;
+  final VoidCallback onTap;
+
+  const _HymnCard({
+    required this.hymn,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.white,
+      borderRadius: BorderRadius.circular(16),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(16),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(14),
+          child: Row(
+            children: [
+              Container(
+                constraints: const BoxConstraints(minWidth: 54),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFFFEEE1),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(
+                  hymn.number?.isNotEmpty == true ? hymn.number! : '찬양',
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: Color(0xFFEA580C),
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      hymn.title,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w700,
+                        fontSize: 15.5,
+                      ),
+                    ),
+                    if (hymn.tags != null && hymn.tags!.trim().isNotEmpty) ...[
+                      const SizedBox(height: 6),
+                      Text(
+                        hymn.tags!,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: Color(0xFF6B7280),
+                          fontSize: 12.5,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              const SizedBox(width: 6),
+              const Icon(Icons.chevron_right_rounded, color: Color(0xFF9CA3AF)),
+            ],
           ),
         ),
-      ],
+      ),
     );
   }
 }

--- a/apps/mobile/lib/src/features/hymn/hymn_repository.dart
+++ b/apps/mobile/lib/src/features/hymn/hymn_repository.dart
@@ -1,4 +1,4 @@
-﻿import 'dart:convert';
+import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -201,7 +201,10 @@ class HymnRepository {
     } catch (_) {
       final cached = await _readJsonList(_hymnListCacheKey);
       if (cached != null) {
-        return cached.whereType<Map<String, dynamic>>().map(HymnSummary.fromJson).toList();
+        return cached
+            .whereType<Map<String, dynamic>>()
+            .map(HymnSummary.fromJson)
+            .toList();
       }
       rethrow;
     }
@@ -315,7 +318,10 @@ class HymnRepository {
     } catch (_) {
       final cached = await _readJsonList(_userScopedKey(_historyCacheKey));
       if (cached != null) {
-        return cached.whereType<Map<String, dynamic>>().map(HistoryItem.fromJson).toList();
+        return cached
+            .whereType<Map<String, dynamic>>()
+            .map(HistoryItem.fromJson)
+            .toList();
       }
       rethrow;
     }
@@ -361,7 +367,8 @@ class HymnRepository {
   String _detailCacheKey(String hymnId) => 'mobile.cache.hymn.detail.$hymnId';
   String _favoriteCacheKey(String hymnId) =>
       _userScopedKey('mobile.cache.hymn.favorite.$hymnId');
-  String _noteCacheKey(String hymnId) => _userScopedKey('mobile.cache.hymn.note.$hymnId');
+  String _noteCacheKey(String hymnId) =>
+      _userScopedKey('mobile.cache.hymn.note.$hymnId');
 
   Future<void> _writeFavoriteCache(String hymnId, bool favorite) async {
     await _writeJsonObject(_favoriteCacheKey(hymnId), {'favorite': favorite});
@@ -443,7 +450,8 @@ class HymnRepository {
     return null;
   }
 
-  Future<void> _writeJsonList(String key, List<Map<String, dynamic>> value) async {
+  Future<void> _writeJsonList(
+      String key, List<Map<String, dynamic>> value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(key, jsonEncode(value));
   }

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -9,11 +9,12 @@
 - 로그인
   - 소셜 SDK 직접 로그인 (Kakao 모바일)
   - 로그인 화면에서 Kakao 버튼 클릭 시 provider 앱/브라우저로 리디렉션
-  - Dev 로그인 (개발 환경)
+  - 초대코드 입력 지원 (최초 1회)
+  - Dev 로그인은 `ENABLE_DEV_LOGIN=true`일 때만 노출
 - 찬양
   - 목록 조회 + 검색
   - 상세 조회
-  - PNG 에셋 이미지 표시
+  - PNG 에셋 이미지 표시 (한 곡 다중 페이지 지원)
   - MIDI 에셋 앱 내 재생 UX (재생/일시정지/정지/속도)
 - 개인화
   - 즐겨찾기 토글
@@ -84,6 +85,7 @@ cd apps/mobile
 Android Kakao 콜백 스킴은 `kakao<KAKAO_NATIVE_APP_KEY>`이므로,
 앱 실행 시 `--dart-define=KAKAO_NATIVE_APP_KEY=...` 값이 누락/불일치하면
 동의 화면의 "계속하기" 이후 앱으로 복귀하지 않을 수 있다.
+로컬 개발용 로그인 화면이 필요하면 `--dart-define=ENABLE_DEV_LOGIN=true`를 함께 사용한다.
 
 ## 5.1 배포 범위 주의
 


### PR DESCRIPTION
## 변경 사항\n- API: PNG 자산은 덮어쓰지 않고 누적 저장되도록 변경\n- API: 자산 조회를 생성 시각 기준 정렬로 고정\n- 테스트: PNG 다중 등록/ MIDI 교체 동작 검증 케이스 추가\n- Mobile: 로그인/목록/히스토리/상세 UI를 한국어 중심 카드형 UX로 개편\n- Mobile: 한 곡 다중 PNG 페이지 표시(악보 1페이지, 2페이지...)\n- 문서: 다중 PNG/개발 로그인 플래그 반영\n\n## 검증\n- [x] apps/api: ./gradlew.bat test\n- [x] apps/mobile: lutter analyze\n- [x] apps/mobile: lutter test\n- [x] apps/mobile: lutter build apk --debug\n