### PR TITLE
ci(mobile): add android release build readiness workflow

### DIFF
--- a/.github/workflows/mobile-release-check.yml
+++ b/.github/workflows/mobile-release-check.yml
@@ -1,0 +1,57 @@
+name: Mobile Release Check
+
+on:
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - "apps/mobile/**"
+      - ".github/workflows/mobile-release-check.yml"
+  push:
+    branches:
+      - develop
+    paths:
+      - "apps/mobile/**"
+      - ".github/workflows/mobile-release-check.yml"
+  workflow_dispatch:
+    inputs:
+      api_base_url:
+        description: "API base URL passed to flutter build"
+        required: false
+        default: "https://example.com/api/v1"
+
+jobs:
+  android-release-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/mobile
+    env:
+      API_BASE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.api_base_url || 'https://example.com/api/v1' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Build Android release APK
+        run: flutter build apk --release --dart-define=API_BASE_URL=${{ env.API_BASE_URL }}
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-android-release-apk
+          path: apps/mobile/build/app/outputs/flutter-apk/app-release.apk
+          if-no-files-found: error

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 ﻿# CLAUDE.md - Eunhye Hymn 프로젝트 컨텍스트
 
 > 이 파일은 Claude Code가 프로젝트를 빠르게 파악하고 작업할 수 있도록 작성된 종합 레퍼런스입니다.
-> 마지막 업데이트: 2026-02-15
+> 마지막 업데이트: 2026-02-16
 
 ---
 
@@ -50,6 +50,7 @@ Eunhye_Hymn/
 │   ├── api-ci.yml        # API 테스트 (PR + develop push)
 │   ├── admin-ci.yml      # Admin 타입체크 + 빌드 (PR + develop push)
 │   ├── mobile-ci.yml     # Mobile lint/test (PR + develop push)
+│   ├── mobile-release-check.yml # Mobile Android release APK 빌드 검증 + artifact
 │   └── deploy-staging.yml # Staging 자동 배포 (develop push)
 ├── CLAUDE.md             # 이 파일
 ├── README.md
@@ -521,6 +522,12 @@ com.eunhyehymn/
 - **캐시**: Flutter SDK + Pub cache
 - **실행**: `flutter pub get` → `flutter analyze` → `flutter test`
 
+### Mobile Release Check (`mobile-release-check.yml`)
+- **트리거**: PR 및 develop push (apps/mobile/** 변경 시) + `workflow_dispatch`
+- **환경**: ubuntu-latest, Java 17 + Flutter stable
+- **실행**: `flutter pub get` → `flutter build apk --release --dart-define=API_BASE_URL=...`
+- **산출물**: `app-release.apk`를 GitHub Actions artifact로 업로드
+
 ### Deploy Staging (`deploy-staging.yml`)
 - **트리거**: develop push + `workflow_dispatch`
 - **Jobs**: `preflight-secrets` → `test-api` → `check-admin` → `build-and-push` → `deploy`
@@ -765,6 +772,7 @@ develop push → GitHub Actions
 
 **4. 모바일 배포 패키징**
 - 현재 저장소 기준 실행은 `flutter run -d chrome` 중심
+- Android release APK 빌드 검증 워크플로우 추가 완료 (`mobile-release-check.yml`, 2026-02-16)
 - 앱스토어 배포(Android/iOS)를 위한 네이티브 프로젝트 디렉토리 및 서명/릴리즈 파이프라인 준비 필요
 
 ---

--- a/apps/mobile/android/.gitignore
+++ b/apps/mobile/android/.gitignore
@@ -1,5 +1,6 @@
 gradle-wrapper.jar
 /.gradle
+/.kotlin
 /captures/
 /gradlew
 /gradlew.bat

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -954,3 +954,32 @@
 - `cd apps/mobile && ..\\..\\scripts\\flutterw.ps1 analyze`
 - `cd apps/mobile && ..\\..\\scripts\\flutterw.ps1 test`
 
+## 34. 이번 사이클 기록 (2026-02-16, mobile release readiness)
+
+### 목표
+- 모바일 배포 패키징 준비의 첫 단계로 Android release APK 빌드 검증 경로를 CI에 추가한다.
+
+### 범위
+- 포함: release APK 빌드 워크플로우 추가, 모바일/기준 문서 동기화
+- 제외: 앱스토어 서명 키 연동, iOS 릴리즈 파이프라인 구성
+
+### 수행 작업
+1. Mobile release 검증 워크플로우 추가
+- `.github/workflows/mobile-release-check.yml` 신규 추가
+- PR/develop push + workflow_dispatch 트리거 구성
+- `flutter build apk --release` 실행 및 `app-release.apk` artifact 업로드
+
+2. 모바일 문서 동기화
+- `docs/mobile/README.md`에 release 패키징 준비 섹션 추가
+- 수동 실행 입력(`api_base_url`) 및 artifact 확인 경로 안내 반영
+
+3. 기준 문서 동기화
+- `CLAUDE.md` 마지막 업데이트 날짜 갱신
+- 워크플로우 목록/CI 설명/미완료 항목(모바일 배포 패키징) 상태 갱신
+
+### 검증
+- `cd apps/mobile && ..\\..\\scripts\\flutterw.ps1 analyze`
+- `cd apps/mobile && ..\\..\\scripts\\flutterw.ps1 test`
+- `cd apps/mobile && ..\\..\\scripts\\flutterw.ps1 build apk --release --dart-define=API_BASE_URL=https://example.com/api/v1`
+- 로컬 환경에서 Android SDK 미설치로 release APK 빌드는 실패(`Android SDK could not be found`), CI 워크플로우에서 동일 단계로 검증 보완
+

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -104,6 +104,26 @@ Android Kakao 콜백 스킴은 `kakao<KAKAO_NATIVE_APP_KEY>`이므로,
   - `flutter analyze`
   - `flutter test`
 
+## 6.1 Release 패키징 준비
+
+- 워크플로우: `.github/workflows/mobile-release-check.yml`
+- 트리거:
+  - PR 및 `develop` push (`apps/mobile/**` 변경 시)
+  - 수동 실행(`workflow_dispatch`)
+- 목적:
+  - Android `release` APK 빌드가 깨지지 않는지 사전 검증
+  - 빌드 산출물(`app-release.apk`)을 Actions artifact로 업로드
+
+수동 실행 시 `api_base_url` 입력을 제공하면 해당 값으로 `--dart-define=API_BASE_URL`를 주입한다.
+
+로컬에서 동일 검증을 수행하려면 Android SDK가 설치되어 있어야 한다.
+예시:
+
+```powershell
+cd apps/mobile
+..\..\scripts\flutterw.ps1 build apk --release --dart-define=API_BASE_URL=https://example.com/api/v1
+```
+
 ## 7. 운영 연계 체크포인트
 
 - 스테이징 스모크 테스트는 `docs/staging-smoke-checklist.md` 기준으로 수행한다.


### PR DESCRIPTION
## Summary
- add a new mobile release readiness workflow that builds Android release APK and uploads artifact
- sync mobile docs and cycle docs for release packaging readiness
- update Android mobile gitignore to ignore generated `.kotlin/` build directory

## Changes
1. New CI workflow for release packaging check
- `.github/workflows/mobile-release-check.yml`
- triggers:
  - pull_request (target: develop, paths: `apps/mobile/**`)
  - push (develop, paths: `apps/mobile/**`)
  - workflow_dispatch (`api_base_url` input)
- steps:
  - setup Java 17 + Flutter stable
  - `flutter pub get`
  - `flutter build apk --release --dart-define=API_BASE_URL=...`
  - upload `app-release.apk` artifact

2. Documentation sync
- `docs/mobile/README.md`
  - add "Release 패키징 준비" section
  - add local release build command and Android SDK prerequisite note
- `CLAUDE.md`
  - workflow list/CI section updated
  - mobile packaging backlog item updated with partial progress
- `docs/WORK_CYCLE.md`
  - append cycle record #34

3. Repository hygiene
- `apps/mobile/android/.gitignore`
  - add `/.kotlin` generated directory ignore

## Validation
- `cd apps/mobile && ..\\..\\scripts\\flutterw.ps1 analyze` ✅
- `cd apps/mobile && ..\\..\\scripts\\flutterw.ps1 test` ✅
- `cd apps/mobile && ..\\..\\scripts\\flutterw.ps1 build apk --release --dart-define=API_BASE_URL=https://example.com/api/v1` ❌
  - local environment lacks Android SDK (`Android SDK could not be found`)
  - release build step is validated in GitHub Actions workflow environment

## Risk
- CI/workflow and docs focused changes, no runtime app behavior change