### PR TITLE
docs: sync changelog for merged mobile PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -732,6 +732,8 @@ develop push → GitHub Actions
   - `docs/current-usable-scope.md`
   - `docs/mobile/README.md`
   - `README.md`
+- 개발 변경 이력 동기화
+  - `docs/changelog-dev.md`
 - 스테이징 실가동 체크리스트/런북 동기화
   - `docs/staging-smoke-checklist.md`
   - `docs/runbook.md`

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -983,3 +983,27 @@
 - `cd apps/mobile && ..\\..\\scripts\\flutterw.ps1 build apk --release --dart-define=API_BASE_URL=https://example.com/api/v1`
 - 로컬 환경에서 Android SDK 미설치로 release APK 빌드는 실패(`Android SDK could not be found`), CI 워크플로우에서 동일 단계로 검증 보완
 
+## 35. 이번 사이클 기록 (2026-02-16, changelog sync for merged mobile PRs)
+
+### 목표
+- 머지 완료된 모바일 작업(#89, #90)이 `docs/changelog-dev.md`에도 누락 없이 반영되도록 문서 싱크를 맞춘다.
+
+### 범위
+- 포함: changelog 최신화, 기준 문서(CLAUDE/WORK_CYCLE) 동기화
+- 제외: 애플리케이션 코드/워크플로우 동작 변경
+
+### 수행 작업
+1. changelog 누락분 반영
+- `docs/changelog-dev.md`에 `2026-02-16` 섹션 추가
+- PR #89(모바일 목록/히스토리 UX 개선)과 PR #90(Android release readiness) 반영
+- 머지 커밋(`0520074`, `35569af`) 기준으로 추적 정보 명시
+
+2. 기준 문서 동기화
+- `CLAUDE.md` 문서/준비도 점검 항목에 `docs/changelog-dev.md` 동기화 항목 추가
+- `docs/WORK_CYCLE.md`에 이번 사이클 기록 추가
+
+### 검증
+- `rg -n "2026-02-16|PR #89|PR #90|0520074|35569af" docs/changelog-dev.md`
+- `rg -n "changelog-dev.md" CLAUDE.md docs/WORK_CYCLE.md`
+- `rg -n "^(<<<<<<<|>>>>>>>|=======)$" docs/changelog-dev.md CLAUDE.md docs/WORK_CYCLE.md`
+

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -2,6 +2,34 @@
 
 작업 단위별 핵심 변경만 기록한다. 상세 구현은 각 PR 본문과 커밋 로그를 참고한다.
 
+## 2026-02-16
+
+### Mobile UI/UX 개선 (PR #89)
+- Hymn 목록/History 화면의 탐색 UX 개선
+  - 검색어 즉시 삭제 버튼
+  - 태그/기간 필터
+  - 필터 초기화 액션
+  - 빈 상태 가이드/soft error 배너
+- 반영 파일
+  - `apps/mobile/lib/src/features/hymn/hymn_list_page.dart`
+  - `apps/mobile/lib/src/features/history/history_page.dart`
+  - `docs/mobile/README.md`
+  - `CLAUDE.md`
+  - `docs/WORK_CYCLE.md`
+- merge: `0520074` (`feat(mobile): improve hymn list and history usability (#89)`)
+
+### Mobile release readiness (PR #90)
+- Android release APK 빌드 검증 워크플로우 추가
+  - `.github/workflows/mobile-release-check.yml`
+  - PR/develop push + workflow_dispatch 트리거
+  - `app-release.apk` artifact 업로드
+- 문서/기준 동기화
+  - `docs/mobile/README.md` (Release 패키징 준비 섹션)
+  - `CLAUDE.md` (CI/미완료 상태 반영)
+  - `docs/WORK_CYCLE.md` (cycle #34 반영)
+- 저장소 정리
+  - `apps/mobile/android/.gitignore`에 `/.kotlin` 추가
+- merge: `35569af` (`ci(mobile): add android release build readiness check (#90)`)
 ## 2026-02-15
 
 ### Admin CRUD 예외 하드닝 + 운영자 UX 개선


### PR DESCRIPTION
## Summary
- sync `docs/changelog-dev.md` with already-merged mobile PRs (#89, #90)
- add cycle record for this sync in `docs/WORK_CYCLE.md`
- sync `CLAUDE.md` docs checklist to explicitly include changelog sync

## Changes
1. Changelog sync
- `docs/changelog-dev.md`
- added `2026-02-16` section with:
  - PR #89 (mobile list/history UX improvements)
  - PR #90 (mobile Android release readiness workflow)
  - merge commit trace (`0520074`, `35569af`)

2. Work-cycle sync
- `docs/WORK_CYCLE.md`
- appended cycle #35 with goal/scope/work/validation

3. CLAUDE sync
- `CLAUDE.md`
- added `docs/changelog-dev.md` under document sync checklist

## Validation
- `rg -n "2026-02-16|PR #89|PR #90|0520074|35569af" docs/changelog-dev.md`
- `rg -n "changelog-dev.md" CLAUDE.md docs/WORK_CYCLE.md`
- `rg -n "^(<<<<<<<|>>>>>>>|=======)$" docs/changelog-dev.md CLAUDE.md docs/WORK_CYCLE.md`

## Risk
- docs-only change, no runtime behavior impact