### PR TITLE
docs: sync latest scope and readiness docs (2026-02-17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 ﻿# CLAUDE.md - Eunhye Hymn 프로젝트 컨텍스트
 
 > 이 파일은 Claude Code가 프로젝트를 빠르게 파악하고 작업할 수 있도록 작성된 종합 레퍼런스입니다.
-> 마지막 업데이트: 2026-02-16
+> 마지막 업데이트: 2026-02-17
 
 ---
 
@@ -732,6 +732,9 @@ develop push → GitHub Actions
   - `docs/current-usable-scope.md`
   - `docs/mobile/README.md`
   - `README.md`
+- 최신 기준점 문서 동기화 (2026-02-17)
+  - `docs/current-usable-scope.md` (`c578c3f` 기준 커밋/근거 PR/실행 run 반영)
+  - `docs/deployment-readiness-audit.md` (최신 Actions 실행 근거/잔여 리스크 갱신)
 - 개발 변경 이력 동기화
   - `docs/changelog-dev.md`
 - 스테이징 실가동 체크리스트/런북 동기화

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ npm run dev
 | Storage | AWS S3 (presigned URL) |
 | Auth | Spring Security + JWT + Kakao OAuth |
 | Frontend | React 18, TypeScript, Vite, Tailwind CSS v4 |
-| CI/CD | GitHub Actions (API 테스트 + Admin 빌드/타입체크 + Mobile lint/test) |
+| CI/CD | GitHub Actions (API 테스트 + Admin 빌드/타입체크 + Mobile lint/test + Mobile release APK check + Staging 자동 배포) |
 
 ## API 엔드포인트
 

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -1007,3 +1007,41 @@
 - `rg -n "changelog-dev.md" CLAUDE.md docs/WORK_CYCLE.md`
 - `rg -n "^(<<<<<<<|>>>>>>>|=======)$" docs/changelog-dev.md CLAUDE.md docs/WORK_CYCLE.md`
 
+## 36. 이번 사이클 기록 (2026-02-17, docs latest sync + pr/merge)
+
+### 목표
+- 최신 `develop` 기준으로 핵심 운영 문서를 동기화하고 PR 생성/머지까지 완료한다.
+
+### 범위
+- 포함: `README.md`, `docs/current-usable-scope.md`, `docs/deployment-readiness-audit.md` 최신화 + 추적 문서(`docs/changelog-dev.md`, `CLAUDE.md`, `docs/WORK_CYCLE.md`) 동기화
+- 제외: 애플리케이션 코드/인프라 동작 변경
+
+### 수행 작업
+1. 문서 기준점 최신화
+- `docs/current-usable-scope.md`
+- 작성일/기준 커밋을 `c578c3f` 기준으로 갱신
+- 근거 PR에 #91/#90/#89/#88/#87 반영
+- 스테이징/모바일 실행 증빙(run `22052664286`, `22052482140`) 반영
+
+2. 배포 준비도 리포트 최신화
+- `docs/deployment-readiness-audit.md`
+- 작성일/점검 브랜치 최신화
+- 최신 GitHub Actions 성공 run 근거 추가
+- 잔여 리스크를 "수동 스모크 정례화" 기준으로 명시
+
+3. 루트 문서 정합성 보강
+- `README.md` CI/CD 설명을 현재 워크플로우 구성(API/Admin/Mobile + mobile release + staging deploy)에 맞게 갱신
+
+4. 추적 문서 동기화
+- `docs/changelog-dev.md`에 2026-02-17 문서 동기화 이력 추가
+- `CLAUDE.md` 마지막 업데이트 날짜 및 문서/준비도 점검 항목 동기화
+- `docs/WORK_CYCLE.md`에 본 사이클 기록 추가
+
+### 검증
+- `git pull --ff-only origin develop`
+- `gh run list --repo V4N1LLA/Eunhye_Hymn --workflow deploy-staging.yml --limit 5 --json databaseId,headBranch,headSha,status,conclusion,url`
+- `gh run list --repo V4N1LLA/Eunhye_Hymn --workflow mobile-release-check.yml --limit 5 --json databaseId,headBranch,headSha,status,conclusion,url`
+- `rg -n "c578c3f|22052664286|22052482140|#91|#90|#89|#88|#87" docs/current-usable-scope.md docs/deployment-readiness-audit.md docs/changelog-dev.md`
+- `rg -n "Mobile release APK check|Staging 자동 배포" README.md`
+- `rg -n "^(<<<<<<<|>>>>>>>|=======)$" README.md docs/current-usable-scope.md docs/deployment-readiness-audit.md docs/changelog-dev.md CLAUDE.md docs/WORK_CYCLE.md`
+

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -2,6 +2,21 @@
 
 작업 단위별 핵심 변경만 기록한다. 상세 구현은 각 PR 본문과 커밋 로그를 참고한다.
 
+## 2026-02-17
+
+### 문서 최신화 동기화
+- 기준 범위 문서 최신화
+  - `docs/current-usable-scope.md` 기준 커밋을 `c578c3f`로 갱신
+  - 근거 PR에 #91/#90/#89/#88/#87 반영
+  - 최신 실행 증빙(run `22052664286`, `22052482140`) 반영
+- 배포 준비도 점검 리포트 최신화
+  - `docs/deployment-readiness-audit.md` 작성일/점검 브랜치/최신 Actions 실행 근거 갱신
+  - 잔여 리스크(수동 스모크 정례화 필요) 기준 명확화
+- 루트 문서 정합성 보강
+  - `README.md`의 CI/CD 설명에 Mobile release check + Staging 자동 배포 반영
+- 기준 문서 동기화
+  - `CLAUDE.md`, `docs/WORK_CYCLE.md` 업데이트
+
 ## 2026-02-16
 
 ### Mobile UI/UX 개선 (PR #89)

--- a/docs/current-usable-scope.md
+++ b/docs/current-usable-scope.md
@@ -1,10 +1,10 @@
 # 현재 사용 가능 범위 정리
 
-- 작성일: 2026-02-14
+- 작성일: 2026-02-17
 - 기준 브랜치: `develop` (통합/배포 기준)
-- 기준 커밋: `5b08dc0` (2026-02-14 16:58 +09:00 기준 `develop` HEAD)
+- 기준 커밋: `c578c3f` (2026-02-16 15:36:26 +09:00 기준 `develop` HEAD)
 - 근거 문서: `README.md`, `CLAUDE.md`, `docs/WORK_CYCLE.md`
-- 근거 PR: #56, #55, #54, #53, #52, #49, #48, #47, #46, #45, #43, #42, #41, #40, #38, #37, #36, #31
+- 근거 PR: #91, #90, #89, #88, #87, #56, #55, #54, #53, #52, #49, #48, #47, #46, #45, #43, #42, #41, #40, #38, #37, #36, #31
 
 ## 1. 요약
 
@@ -12,10 +12,10 @@
 
 - 로컬 기능: 관리자 웹(Admin) + 백엔드 API + 모바일 앱(MVP + 모바일 고도화 3건) 사용 가능
 - 배포 기능: AWS 스테이징 자동 배포 파이프라인 코드 구성 완료
-- CI 기능: API/Admin/Mobile 검증 워크플로우 구성 완료
+- CI 기능: API/Admin/Mobile 검증 + Mobile release APK 검증 워크플로우 구성 완료
 - 스테이징 리허설/롤백/복구 자동 실행 증빙 확보(run `22010284332`, `22010387328`, `22010470389`)
 - 현재 우선 과제: 운영 PC 기준 preflight 무스킵 통과 환경 유지 + Admin/Mobile 수동 스모크 정례화
-- 모바일 배포 상태: 현재 저장소 기준 웹 실행(`-d chrome`) 중심이며, 앱스토어 배포(Android/iOS)는 별도 준비가 필요
+- 모바일 배포 상태: Android release APK 빌드 검증 경로(CI) 확보, 앱스토어 배포(Android/iOS)는 별도 준비가 필요
 
 ## 2. 지금 바로 검증 가능한 범위 (로컬)
 
@@ -82,6 +82,7 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
 
 - `develop` push 트리거
 - API 테스트 + Admin 타입체크/빌드 + Mobile analyze/test
+- Mobile release APK 빌드 검증(`mobile-release-check.yml`)
 - API/Admin Docker 이미지 ECR push
 - EC2 SSH 배포 및 헬스체크
 
@@ -89,18 +90,21 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
 
 - `.github/workflows/deploy-staging.yml`
 - `.github/workflows/mobile-ci.yml`
+- `.github/workflows/mobile-release-check.yml`
 - `infra/aws/*`
 - `apps/admin/Dockerfile`
 - `apps/admin/nginx.conf`
 - `apps/api/Dockerfile`
 
-실행 상태(2026-02-14 기준):
+실행 상태(2026-02-17 기준):
 
 - [x] AWS 리소스 생성(Terraform)
 - [x] GitHub Secrets 설정(`AWS_*`, `ECR_REGISTRY`, `EC2_HOST`, `EC2_SSH_KEY`, `DEPLOY_ENV_FILE`, 선택: `ENABLE_AWSLOGS`)
 - [x] EC2 접근 가능 상태 및 배포 계정 권한 확인
 - [x] 배포 서버 `.env` 준비 (`DEPLOY_ENV_FILE` 기반)
 - [x] `develop` 배포 후 헬스체크 통과 (`deploy` verify 단계 성공)
+- [x] `develop` 최신 자동 배포 성공 (`deploy-staging.yml`, run `22052664286`, commit `c578c3f`)
+- [x] Android release APK 빌드 검증 성공 (`mobile-release-check.yml`, run `22052482140`, commit `35569af`)
 - [x] `docs/staging-smoke-checklist.md` 및 `docs/staging-rehearsal-log.md`에 결과 기록
 - [ ] Admin/Mobile 런타임 수동 스모크(실기기/실계정) 주기 실행
 
@@ -110,6 +114,26 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
 - IAM 권한 샘플: `infra/aws/terraform-deployer-iam-policy.json`
 
 ## 4. 최근 PR 기준 변경 포인트
+
+### PR #91 (changelog-sync-mobile-20260216)
+- PR #89/#90 머지 결과를 `docs/changelog-dev.md`에 반영
+- `docs/WORK_CYCLE.md`, `CLAUDE.md` 문서 싱크
+
+### PR #90 (mobile-release-readiness)
+- Android release APK 빌드 검증 워크플로우 추가
+- `workflow_dispatch` 입력(`api_base_url`) + artifact 업로드 경로 정리
+
+### PR #89 (mobile-friendly-ui-ux)
+- 모바일 목록/히스토리 화면 UX 개선(검색 즉시삭제, 필터, 빈 상태, soft error 배너)
+- 히스토리 기간 필터 처리 보정(날짜 없는 항목 제외)
+
+### PR #88 (staging-feedback-checklist)
+- 스테이징 수동 검수용 체크리스트 문서 추가
+- 사이클 종료 시 `Ship/Hold/Rollback` 판단 기록 템플릿 정리
+
+### PR #87 (mobile-ux-multipage-png)
+- 다중 페이지 PNG 악보 지원
+- 모바일 앱 탐색/표시 UX 보강
 
 ### PR #56 (export-csv-security-hardening)
 - 동기/비동기 CSV 내보내기 수식 주입 방어(`=`, `+`, `-`, `@`) 적용

--- a/docs/deployment-readiness-audit.md
+++ b/docs/deployment-readiness-audit.md
@@ -1,13 +1,13 @@
 # 배포 준비도 점검 리포트
 
-- 작성일: 2026-02-13
-- 점검 브랜치: `feat/docs-readiness-audit` (base: `develop`)
+- 작성일: 2026-02-17
+- 점검 브랜치: `feat/docs-sync-latest-20260217` (base: `develop`)
 - 점검 목적: "현재 개발 상태가 문서와 일치하는지"와 "실제 배포 가능 여부"를 코드/실행 기준으로 확인
 
 ## 1. 결론 요약
 
 - 로컬 개발/검증: **가능**
-- 스테이징 자동배포 파이프라인: **코드 구성 완료 (조건부 가능)**
+- 스테이징 자동배포/모바일 release 검증 파이프라인: **코드 구성 완료 (조건부 가능)**
 - 스테이징 실가동: **조건부 가능** (배포/롤백/복구 리허설 성공, 수동 스모크 정례화 필요)
 - 프로덕션 배포: **준비 전**
 - 모바일 스토어 배포(Android/iOS): **준비 전**
@@ -51,6 +51,15 @@
   - 로컬 compose 파싱 통과
   - 스테이징 compose는 `.env` 파일 없이 실행 불가 (`infra/aws/docker-compose.prod.yml`에서 `env_file: .env` 요구)
 
+### 2.5 GitHub Actions 최신 실행 증빙 (2026-02-16)
+
+- `deploy-staging.yml` (`develop`, commit `c578c3f`) 성공
+  - run: `22052664286`
+  - URL: `https://github.com/V4N1LLA/Eunhye_Hymn/actions/runs/22052664286`
+- `mobile-release-check.yml` (`develop`, commit `35569af`) 성공
+  - run: `22052482140`
+  - URL: `https://github.com/V4N1LLA/Eunhye_Hymn/actions/runs/22052482140`
+
 ## 3. 문서 정합성 점검 결과
 
 - 일치:
@@ -58,15 +67,15 @@
   - 스테이징 배포 워크플로우 존재 및 단계 구성
   - 선행 조건(Terraform/Secrets/EC2 접근) 필요
 - 보완:
-  - Flyway 마이그레이션 문서에 `V7__events_admin_indexes.sql` 반영 필요
-  - 기준 커밋 고정값 문서(`docs/current-usable-scope.md`) 최신화 필요
-  - 모바일 배포 범위(현재 웹 실행 기준, 스토어 배포 준비 전) 명시 강화 필요
+  - 기준 커밋/PR/실행 run ID를 문서(`docs/current-usable-scope.md`, 본 문서)에서 주기적으로 최신화 필요
+  - Admin/Mobile 런타임 수동 스모크를 정례 수행하고 증빙을 문서에 누적할 필요
 
-### 3.1 후속 반영 (2026-02-14)
+### 3.1 후속 반영 (2026-02-14 ~ 2026-02-17)
 - 아래 항목을 문서에 반영 완료:
   - `docs/data-model.md`: events 인덱스(`V7__events_admin_indexes.sql`) 반영
-  - `docs/current-usable-scope.md`: 기준 커밋 최신화
+  - `docs/current-usable-scope.md`: 기준 커밋(`c578c3f`)/근거 PR(#91~#87 포함) 최신화
   - `docs/mobile/README.md`: 모바일 배포 범위/운영 연계 체크포인트 보강
+  - `README.md`: CI/CD 설명에 `mobile-release-check.yml` 및 staging 자동 배포 반영
 
 ## 4. 실배포 전 필수 체크리스트
 
@@ -126,6 +135,16 @@
 - 잔여:
   - 운영 PC 기준 preflight 무스킵 통과 상태 유지 (`aws` 자격증명 + `terraform.tfvars`)
   - Admin/Mobile 런타임 수동 스모크 정기 수행
+
+### 4.3 2026-02-16 진행 업데이트 (기록)
+
+- 완료:
+  - `develop` 최신 자동 배포 성공
+    - run `22052664286` (commit `c578c3f`)
+  - Mobile Android release APK 빌드 검증 성공
+    - run `22052482140` (commit `35569af`)
+- 잔여:
+  - Admin/Mobile 런타임 수동 스모크 정기 수행 및 결과 문서화
 
 ## 5. 현재 판단 (Go/No-Go)
 


### PR DESCRIPTION
﻿## 요약
- 운영 문서 최신화(`2026-02-17` 기준)
  - `docs/current-usable-scope.md`: 기준 커밋 `c578c3f`, 근거 PR(#91~#87 포함), 최신 run 증빙 반영
  - `docs/deployment-readiness-audit.md`: 최신 Actions 실행 증빙(run `22052664286`, `22052482140`) 및 잔여 리스크 갱신
- 루트 문서 정합성 보강
  - `README.md` CI/CD 설명을 실제 워크플로우 구성(Mobile release check + Staging deploy 포함)으로 정렬
- 추적 문서 동기화
  - `docs/changelog-dev.md`, `docs/WORK_CYCLE.md`, `CLAUDE.md` 업데이트

## 변경 파일
- `README.md`
- `docs/current-usable-scope.md`
- `docs/deployment-readiness-audit.md`
- `docs/changelog-dev.md`
- `docs/WORK_CYCLE.md`
- `CLAUDE.md`

## 검증
- `git pull --ff-only origin develop`
- `gh run list --repo V4N1LLA/Eunhye_Hymn --workflow deploy-staging.yml --limit 5 --json databaseId,headBranch,headSha,status,conclusion,url`
- `gh run list --repo V4N1LLA/Eunhye_Hymn --workflow mobile-release-check.yml --limit 5 --json databaseId,headBranch,headSha,status,conclusion,url`
- `rg -n "c578c3f|22052664286|22052482140|#91|#90|#89|#88|#87" docs/current-usable-scope.md docs/deployment-readiness-audit.md docs/changelog-dev.md`
- `rg -n "Mobile release APK check|Staging 자동 배포" README.md`
- `rg -n "^(<<<<<<<|>>>>>>>|=======)$" README.md docs/current-usable-scope.md docs/deployment-readiness-audit.md docs/changelog-dev.md CLAUDE.md docs/WORK_CYCLE.md`
