### PR TITLE
feat(ops): automate staging cycle and add mobile store readiness

### DIFF
--- a/.github/workflows/mobile-store-release.yml
+++ b/.github/workflows/mobile-store-release.yml
@@ -1,0 +1,111 @@
+name: Mobile Store Release Readiness
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Release readiness target"
+        required: true
+        default: both
+        type: choice
+        options:
+          - android
+          - ios
+          - both
+      api_base_url:
+        description: "API base URL passed to Flutter build"
+        required: false
+        default: "https://example.com/api/v1"
+
+concurrency:
+  group: mobile-store-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  android-signed-aab:
+    if: ${{ inputs.target == 'android' || inputs.target == 'both' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/mobile
+    env:
+      API_BASE_URL: ${{ inputs.api_base_url }}
+      MOBILE_ANDROID_KEYSTORE_BASE64: ${{ secrets.MOBILE_ANDROID_KEYSTORE_BASE64 }}
+      MOBILE_ANDROID_KEY_ALIAS: ${{ secrets.MOBILE_ANDROID_KEY_ALIAS }}
+      MOBILE_ANDROID_KEY_PASSWORD: ${{ secrets.MOBILE_ANDROID_KEY_PASSWORD }}
+      MOBILE_ANDROID_STORE_PASSWORD: ${{ secrets.MOBILE_ANDROID_STORE_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Validate Android signing secrets
+        run: |
+          : "${MOBILE_ANDROID_KEYSTORE_BASE64:?Missing MOBILE_ANDROID_KEYSTORE_BASE64 secret}"
+          : "${MOBILE_ANDROID_KEY_ALIAS:?Missing MOBILE_ANDROID_KEY_ALIAS secret}"
+          : "${MOBILE_ANDROID_KEY_PASSWORD:?Missing MOBILE_ANDROID_KEY_PASSWORD secret}"
+          : "${MOBILE_ANDROID_STORE_PASSWORD:?Missing MOBILE_ANDROID_STORE_PASSWORD secret}"
+
+      - name: Prepare Android keystore
+        run: |
+          mkdir -p android/keystore
+          echo "$MOBILE_ANDROID_KEYSTORE_BASE64" | base64 --decode > android/keystore/release.jks
+          cat > android/key.properties <<EOF
+          storeFile=keystore/release.jks
+          storePassword=$MOBILE_ANDROID_STORE_PASSWORD
+          keyAlias=$MOBILE_ANDROID_KEY_ALIAS
+          keyPassword=$MOBILE_ANDROID_KEY_PASSWORD
+          EOF
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Build Android signed AAB
+        run: flutter build appbundle --release --dart-define=API_BASE_URL=${{ env.API_BASE_URL }}
+
+      - name: Upload Android AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-android-release-aab
+          path: apps/mobile/build/app/outputs/bundle/release/app-release.aab
+          if-no-files-found: error
+
+  ios-release-no-codesign:
+    if: ${{ inputs.target == 'ios' || inputs.target == 'both' }}
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: apps/mobile
+    env:
+      API_BASE_URL: ${{ inputs.api_base_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Build iOS release (no codesign)
+        run: flutter build ios --release --no-codesign --dart-define=API_BASE_URL=${{ env.API_BASE_URL }}
+
+      - name: Upload iOS app artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-ios-release-no-codesign
+          path: apps/mobile/build/ios/iphoneos/Runner.app
+          if-no-files-found: error

--- a/.github/workflows/mobile-store-release.yml
+++ b/.github/workflows/mobile-store-release.yml
@@ -58,8 +58,8 @@ jobs:
 
       - name: Prepare Android keystore
         run: |
-          mkdir -p android/keystore
-          echo "$MOBILE_ANDROID_KEYSTORE_BASE64" | base64 --decode > android/keystore/release.jks
+          mkdir -p android/app/keystore
+          echo "$MOBILE_ANDROID_KEYSTORE_BASE64" | base64 --decode > android/app/keystore/release.jks
           cat > android/key.properties <<EOF
           storeFile=keystore/release.jks
           storePassword=$MOBILE_ANDROID_STORE_PASSWORD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Eunhye_Hymn/
 │   ├── admin-ci.yml      # Admin 타입체크 + 빌드 (PR + develop push)
 │   ├── mobile-ci.yml     # Mobile lint/test (PR + develop push)
 │   ├── mobile-release-check.yml # Mobile Android release APK 빌드 검증 + artifact
+│   ├── mobile-store-release.yml # Mobile store release readiness (manual: android/ios)
 │   └── deploy-staging.yml # Staging 자동 배포 (develop push)
 ├── CLAUDE.md             # 이 파일
 ├── README.md
@@ -528,6 +529,14 @@ com.eunhyehymn/
 - **실행**: `flutter pub get` → `flutter build apk --release --dart-define=API_BASE_URL=...`
 - **산출물**: `app-release.apk`를 GitHub Actions artifact로 업로드
 
+### Mobile Store Release Readiness (`mobile-store-release.yml`)
+- **트리거**: `workflow_dispatch` (manual)
+- **입력**: `target=android|ios|both`, `api_base_url`
+- **Android 경로**: signed AAB 빌드(`flutter build appbundle --release`)
+  - required secrets: `MOBILE_ANDROID_KEYSTORE_BASE64`, `MOBILE_ANDROID_KEY_ALIAS`, `MOBILE_ANDROID_KEY_PASSWORD`, `MOBILE_ANDROID_STORE_PASSWORD`
+- **iOS 경로**: release no-codesign 빌드(`flutter build ios --release --no-codesign`)
+- **목적**: 스토어 업로드 전 빌드/서명 readiness 검증
+
 ### Deploy Staging (`deploy-staging.yml`)
 - **트리거**: develop push + `workflow_dispatch`
 - **Jobs**: `preflight-secrets` → `test-api` → `check-admin` → `build-and-push` → `deploy`
@@ -733,13 +742,15 @@ develop push → GitHub Actions
   - `docs/mobile/README.md`
   - `README.md`
 - 최신 기준점 문서 동기화 (2026-02-17)
-  - `docs/current-usable-scope.md` (`c578c3f` 기준 커밋/근거 PR/실행 run 반영)
+  - `docs/current-usable-scope.md` (`ee49a0e` 기준 커밋/근거 PR/실행 run 반영)
   - `docs/deployment-readiness-audit.md` (최신 Actions 실행 근거/잔여 리스크 갱신)
 - 개발 변경 이력 동기화
   - `docs/changelog-dev.md`
 - 스테이징 실가동 체크리스트/런북 동기화
   - `docs/staging-smoke-checklist.md`
   - `docs/runbook.md`
+- 스테이징 운영 사이클 로그 문서 추가
+  - `docs/staging-smoke-log.md`
 - 스테이징 피드백 루프 체크리스트 추가
   - `docs/staging-feedback-checklist.md`
 - 스테이징 리허설 실행 로그 문서 추가
@@ -763,13 +774,14 @@ develop push → GitHub Actions
   - `scripts/staging-preflight.ps1`
   - `scripts/staging-sync-secrets.ps1`
   - `scripts/staging-rehearsal.ps1`
+  - `scripts/staging-ops-cycle.ps1`
 - IAM 정책 샘플:
   - `infra/aws/terraform-deployer-iam-policy.json`
 - 진행 상태는 preflight 결과(`scripts/staging-preflight.ps1`)와 `gh secret list` 기준으로 최신화한다.
 
 **2. 운영 문서/절차 고도화**
 - `docs/runbook.md` + `docs/staging-smoke-checklist.md` + `docs/staging-feedback-checklist.md` 기준으로 롤백/장애 대응 리허설 수행 후 결과 반영
-- 배포 후 스모크 테스트 항목과 점검 결과를 `docs/staging-rehearsal-log.md`에 주기적으로 갱신
+- 배포 후 스모크 테스트 항목과 점검 결과를 `docs/staging-rehearsal-log.md`, `docs/staging-smoke-log.md`에 주기적으로 갱신
 
 **3. 기능 백로그**
 - 비동기 export 운영 지표(실패율/처리시간/정리량) 정례화 완료 (2026-02-14)
@@ -778,7 +790,8 @@ develop push → GitHub Actions
 **4. 모바일 배포 패키징**
 - 현재 저장소 기준 실행은 `flutter run -d chrome` 중심
 - Android release APK 빌드 검증 워크플로우 추가 완료 (`mobile-release-check.yml`, 2026-02-16)
-- 앱스토어 배포(Android/iOS)를 위한 네이티브 프로젝트 디렉토리 및 서명/릴리즈 파이프라인 준비 필요
+- Android signed AAB / iOS no-codesign 수동 readiness 워크플로우 추가 완료 (`mobile-store-release.yml`, 2026-02-17)
+- 남은 과제: 스토어 업로드 자동화(서명/인증서/배포 트랙/릴리즈 노트) 파이프라인 확정
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ docs/       프로젝트 문서
 - 배포 준비도 점검 리포트: [docs/deployment-readiness-audit.md](./docs/deployment-readiness-audit.md)
 - 운영 런북(스테이징): [docs/runbook.md](./docs/runbook.md)
 - 스테이징 스모크 체크리스트: [docs/staging-smoke-checklist.md](./docs/staging-smoke-checklist.md)
+- 스테이징 운영 사이클 로그: [docs/staging-smoke-log.md](./docs/staging-smoke-log.md)
 - 스테이징 피드백 체크리스트: [docs/staging-feedback-checklist.md](./docs/staging-feedback-checklist.md)
 - 모바일 문서: [docs/mobile/README.md](./docs/mobile/README.md)
 - 로컬 셋업 가이드: [docs/LOCAL_SETUP.md](./docs/LOCAL_SETUP.md)
@@ -90,7 +91,7 @@ npm run dev
 | Storage | AWS S3 (presigned URL) |
 | Auth | Spring Security + JWT + Kakao OAuth |
 | Frontend | React 18, TypeScript, Vite, Tailwind CSS v4 |
-| CI/CD | GitHub Actions (API 테스트 + Admin 빌드/타입체크 + Mobile lint/test + Mobile release APK check + Staging 자동 배포) |
+| CI/CD | GitHub Actions (API 테스트 + Admin 빌드/타입체크 + Mobile lint/test + Mobile release APK check + Mobile store release readiness(manual) + Staging 자동 배포) |
 
 ## API 엔드포인트
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -76,3 +76,17 @@ lib/
   - `flutter pub get`
   - `flutter analyze`
   - `flutter test`
+
+## Release Readiness
+
+- Android release check: `.github/workflows/mobile-release-check.yml`
+  - Builds `app-release.apk` and uploads artifact.
+- Store release readiness: `.github/workflows/mobile-store-release.yml` (manual)
+  - `target=android`: signed AAB build (`flutter build appbundle --release`)
+  - `target=ios`: release build without codesign (`flutter build ios --release --no-codesign`)
+  - `target=both`: runs both jobs
+
+Android signing config:
+- Copy `apps/mobile/android/key.properties.example` to `apps/mobile/android/key.properties`.
+- Fill `storeFile`, `storePassword`, `keyAlias`, `keyPassword`.
+- `key.properties` and keystore files are ignored by git.

--- a/apps/mobile/android/app/build.gradle.kts
+++ b/apps/mobile/android/app/build.gradle.kts
@@ -1,10 +1,22 @@
 import java.util.Base64
+import java.util.Properties
 
 plugins {
     id("com.android.application")
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+val keystoreProperties = Properties()
+val keystorePropertiesFile = rootProject.file("key.properties")
+val hasReleaseSigningConfig = if (keystorePropertiesFile.exists()) {
+    keystorePropertiesFile.inputStream().use { keystoreProperties.load(it) }
+    listOf("storeFile", "storePassword", "keyAlias", "keyPassword").all { key ->
+        !keystoreProperties.getProperty(key).isNullOrBlank()
+    }
+} else {
+    false
 }
 
 fun Project.flutterDartDefine(name: String): String? {
@@ -56,11 +68,26 @@ android {
             if (kakaoNativeAppKey == null) "kakao" else "kakao$kakaoNativeAppKey"
     }
 
+    signingConfigs {
+        create("release") {
+            if (hasReleaseSigningConfig) {
+                storeFile = file(keystoreProperties.getProperty("storeFile"))
+                storePassword = keystoreProperties.getProperty("storePassword")
+                keyAlias = keystoreProperties.getProperty("keyAlias")
+                keyPassword = keystoreProperties.getProperty("keyPassword")
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            // Use release signing when key.properties is provided.
+            // Fallback to debug signing for local release checks.
+            signingConfig = if (hasReleaseSigningConfig) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
         }
     }
 }

--- a/apps/mobile/android/key.properties.example
+++ b/apps/mobile/android/key.properties.example
@@ -1,5 +1,7 @@
 # Copy to `apps/mobile/android/key.properties` for signed release builds.
 # The file must not be committed.
+# `storeFile` is resolved from `apps/mobile/android/app`, so `keystore/release.jks`
+# points to `apps/mobile/android/app/keystore/release.jks`.
 
 storeFile=keystore/release.jks
 storePassword=CHANGE_ME

--- a/apps/mobile/android/key.properties.example
+++ b/apps/mobile/android/key.properties.example
@@ -1,0 +1,7 @@
+# Copy to `apps/mobile/android/key.properties` for signed release builds.
+# The file must not be committed.
+
+storeFile=keystore/release.jks
+storePassword=CHANGE_ME
+keyAlias=CHANGE_ME
+keyPassword=CHANGE_ME

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -1073,6 +1073,7 @@
   - manual target 선택(`android|ios|both`)
   - Android signed AAB build
   - iOS release no-codesign build
+  - 리뷰 반영: keystore 생성 경로를 `android/app/keystore/release.jks`로 수정
 
 4. 문서 동기화
 - 운영 문서: `docs/staging-smoke-checklist.md`, `docs/staging-feedback-checklist.md`, `docs/runbook.md`, `infra/aws/README.md`

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -1045,3 +1045,45 @@
 - `rg -n "Mobile release APK check|Staging 자동 배포" README.md`
 - `rg -n "^(<<<<<<<|>>>>>>>|=======)$" README.md docs/current-usable-scope.md docs/deployment-readiness-audit.md docs/changelog-dev.md CLAUDE.md docs/WORK_CYCLE.md`
 
+## 37. 이번 사이클 기록 (2026-02-17, staging ops cycle + mobile store readiness)
+
+### 목표
+- 우선순위 1~3 항목(스테이징 수동 스모크 정례화, preflight 무스킵 유지, 모바일 스토어 배포 준비)을 한 사이클로 구현/검증/PR/머지까지 완료한다.
+
+### 범위
+- 포함: 운영 사이클 자동화 스크립트 + preflight/status 하드닝 + 모바일 릴리즈 readiness 워크플로우 및 서명 설정 + 문서 동기화
+- 제외: 실제 AWS 자격증명 재발급, 실제 앱스토어 업로드
+
+### 수행 작업
+1. 운영 사이클 자동화
+- `scripts/staging-ops-cycle.ps1` 추가
+- preflight + 최신 배포 게이트 + `docs/staging-smoke-log.md` 로그 적재를 일괄 수행
+
+2. preflight/status 하드닝
+- `scripts/staging-preflight.ps1`: 세션 만료/자격증명/프로필 오류 메시지 가시성 강화
+- `scripts/staging-latest-status.ps1`: 진행 중 job의 `completedAt=0001-01-01` 케이스에서 duration 음수 계산 방지
+- `-PreferCompleted` 옵션 추가로 최신 완료 run 기준 점검 지원
+
+3. 모바일 스토어 readiness
+- `apps/mobile/android/app/build.gradle.kts`
+  - `key.properties` 기반 release signing 지원
+  - 미구성 시 debug signing fallback 유지
+- `apps/mobile/android/key.properties.example` 추가
+- `.github/workflows/mobile-store-release.yml` 추가
+  - manual target 선택(`android|ios|both`)
+  - Android signed AAB build
+  - iOS release no-codesign build
+
+4. 문서 동기화
+- 운영 문서: `docs/staging-smoke-checklist.md`, `docs/staging-feedback-checklist.md`, `docs/runbook.md`, `infra/aws/README.md`
+- 모바일 문서: `apps/mobile/README.md`, `docs/mobile/README.md`
+- 기준 문서: `README.md`, `docs/current-usable-scope.md`, `docs/deployment-readiness-audit.md`, `docs/changelog-dev.md`, `CLAUDE.md`, `docs/WORK_CYCLE.md`
+
+### 검증
+- `powershell -NoProfile -File .\\scripts\\staging-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn`
+- `aws sts get-caller-identity` (현재 환경: session expired 확인)
+- `powershell -NoProfile -File .\\scripts\\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -AsJson`
+- `powershell -NoProfile -File .\\scripts\\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner codex`
+- `rg -n "staging-ops-cycle|session expired|22119056042|mobile-store-release|key.properties.example" scripts docs README.md CLAUDE.md apps/mobile`
+- `rg -n "^(<<<<<<<|>>>>>>>|=======)$" .github/workflows/mobile-store-release.yml apps/mobile/android/app/build.gradle.kts scripts/staging-preflight.ps1 scripts/staging-latest-status.ps1 scripts/staging-ops-cycle.ps1 docs/staging-smoke-checklist.md docs/staging-feedback-checklist.md docs/runbook.md docs/staging-smoke-log.md docs/mobile/README.md apps/mobile/README.md docs/current-usable-scope.md docs/deployment-readiness-audit.md docs/changelog-dev.md CLAUDE.md docs/WORK_CYCLE.md README.md infra/aws/README.md`
+

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,24 @@
 
 ## 2026-02-17
 
+### Staging 운영 사이클 자동화 + Mobile store readiness
+- 스테이징 운영 사이클 자동 점검 스크립트 추가
+  - `scripts/staging-ops-cycle.ps1`
+  - preflight + 최신 deploy 게이트 + 로그 기록(`docs/staging-smoke-log.md`) 일괄 실행
+- 스크립트 안정화
+  - `scripts/staging-preflight.ps1`: AWS 세션 만료 케이스를 `session expired`로 명확히 안내
+  - `scripts/staging-latest-status.ps1`: 진행 중 job의 `completedAt=0001-01-01` 처리로 음수 duration 방지
+- 스모크/운영 문서 동기화
+  - `docs/staging-smoke-checklist.md`, `docs/staging-feedback-checklist.md`, `docs/runbook.md`, `infra/aws/README.md`
+  - 실행 기록: `deploy-staging` run `22119056042` 게이트 PASS, preflight는 AWS 세션 만료로 HOLD
+- 모바일 배포 준비도 보강
+  - Android release signing 설정(`apps/mobile/android/app/build.gradle.kts`) 개선
+  - `apps/mobile/android/key.properties.example` 추가
+  - `.github/workflows/mobile-store-release.yml` 추가 (manual: android signed AAB / ios no-codesign)
+  - 모바일 문서 동기화 (`apps/mobile/README.md`, `docs/mobile/README.md`)
+- 기준 문서 동기화
+  - `README.md`, `docs/current-usable-scope.md`, `docs/deployment-readiness-audit.md`, `CLAUDE.md`, `docs/WORK_CYCLE.md`
+
 ### 문서 최신화 동기화
 - 기준 범위 문서 최신화
   - `docs/current-usable-scope.md` 기준 커밋을 `c578c3f`로 갱신

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -18,6 +18,7 @@
   - Android release signing 설정(`apps/mobile/android/app/build.gradle.kts`) 개선
   - `apps/mobile/android/key.properties.example` 추가
   - `.github/workflows/mobile-store-release.yml` 추가 (manual: android signed AAB / ios no-codesign)
+  - PR 리뷰 코멘트 반영: Android keystore 생성 경로를 `android/app/keystore`로 수정
   - 모바일 문서 동기화 (`apps/mobile/README.md`, `docs/mobile/README.md`)
 - 기준 문서 동기화
   - `README.md`, `docs/current-usable-scope.md`, `docs/deployment-readiness-audit.md`, `CLAUDE.md`, `docs/WORK_CYCLE.md`

--- a/docs/current-usable-scope.md
+++ b/docs/current-usable-scope.md
@@ -2,9 +2,9 @@
 
 - 작성일: 2026-02-17
 - 기준 브랜치: `develop` (통합/배포 기준)
-- 기준 커밋: `c578c3f` (2026-02-16 15:36:26 +09:00 기준 `develop` HEAD)
+- 기준 커밋: `ee49a0e` (2026-02-17 22:57:13 UTC 기준 `develop` HEAD)
 - 근거 문서: `README.md`, `CLAUDE.md`, `docs/WORK_CYCLE.md`
-- 근거 PR: #91, #90, #89, #88, #87, #56, #55, #54, #53, #52, #49, #48, #47, #46, #45, #43, #42, #41, #40, #38, #37, #36, #31
+- 근거 PR: #92, #91, #90, #89, #88, #87, #56, #55, #54, #53, #52, #49, #48, #47, #46, #45, #43, #42, #41, #40, #38, #37, #36, #31
 
 ## 1. 요약
 
@@ -12,10 +12,10 @@
 
 - 로컬 기능: 관리자 웹(Admin) + 백엔드 API + 모바일 앱(MVP + 모바일 고도화 3건) 사용 가능
 - 배포 기능: AWS 스테이징 자동 배포 파이프라인 코드 구성 완료
-- CI 기능: API/Admin/Mobile 검증 + Mobile release APK 검증 워크플로우 구성 완료
+- CI 기능: API/Admin/Mobile 검증 + Mobile release APK 검증 + Mobile store readiness(수동) 워크플로우 구성 완료
 - 스테이징 리허설/롤백/복구 자동 실행 증빙 확보(run `22010284332`, `22010387328`, `22010470389`)
 - 현재 우선 과제: 운영 PC 기준 preflight 무스킵 통과 환경 유지 + Admin/Mobile 수동 스모크 정례화
-- 모바일 배포 상태: Android release APK 빌드 검증 경로(CI) 확보, 앱스토어 배포(Android/iOS)는 별도 준비가 필요
+- 모바일 배포 상태: Android signed AAB/iOS no-codesign 수동 readiness 워크플로우 추가, 스토어 업로드 파이프라인은 추가 준비 필요
 
 ## 2. 지금 바로 검증 가능한 범위 (로컬)
 
@@ -83,6 +83,7 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
 - `develop` push 트리거
 - API 테스트 + Admin 타입체크/빌드 + Mobile analyze/test
 - Mobile release APK 빌드 검증(`mobile-release-check.yml`)
+- Mobile store release readiness 수동 검증(`mobile-store-release.yml`)
 - API/Admin Docker 이미지 ECR push
 - EC2 SSH 배포 및 헬스체크
 
@@ -91,6 +92,7 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
 - `.github/workflows/deploy-staging.yml`
 - `.github/workflows/mobile-ci.yml`
 - `.github/workflows/mobile-release-check.yml`
+- `.github/workflows/mobile-store-release.yml`
 - `infra/aws/*`
 - `apps/admin/Dockerfile`
 - `apps/admin/nginx.conf`
@@ -103,13 +105,16 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
 - [x] EC2 접근 가능 상태 및 배포 계정 권한 확인
 - [x] 배포 서버 `.env` 준비 (`DEPLOY_ENV_FILE` 기반)
 - [x] `develop` 배포 후 헬스체크 통과 (`deploy` verify 단계 성공)
-- [x] `develop` 최신 자동 배포 성공 (`deploy-staging.yml`, run `22052664286`, commit `c578c3f`)
+- [x] `develop` 최신 자동 배포 성공 (`deploy-staging.yml`, run `22119056042`, commit `ee49a0e`)
 - [x] Android release APK 빌드 검증 성공 (`mobile-release-check.yml`, run `22052482140`, commit `35569af`)
+- [x] 운영 사이클 자동 점검 스크립트 추가 및 실행 (`scripts/staging-ops-cycle.ps1`, `docs/staging-smoke-log.md`)
+- [ ] preflight 무스킵 통과 회복 필요 (`aws sts get-caller-identity`: session expired)
 - [x] `docs/staging-smoke-checklist.md` 및 `docs/staging-rehearsal-log.md`에 결과 기록
 - [ ] Admin/Mobile 런타임 수동 스모크(실기기/실계정) 주기 실행
 
 실행 상태 확인:
 - 사전 점검: `scripts/staging-preflight.ps1`
+- 운영 사이클 점검: `scripts/staging-ops-cycle.ps1`
 - 시크릿 동기화: `scripts/staging-sync-secrets.ps1`
 - IAM 권한 샘플: `infra/aws/terraform-deployer-iam-policy.json`
 

--- a/docs/deployment-readiness-audit.md
+++ b/docs/deployment-readiness-audit.md
@@ -1,13 +1,14 @@
 # 배포 준비도 점검 리포트
 
 - 작성일: 2026-02-17
-- 점검 브랜치: `feat/docs-sync-latest-20260217` (base: `develop`)
+- 점검 브랜치: `feat/staging-ops-cycle-and-mobile-store-readiness` (base: `develop`)
 - 점검 목적: "현재 개발 상태가 문서와 일치하는지"와 "실제 배포 가능 여부"를 코드/실행 기준으로 확인
 
 ## 1. 결론 요약
 
 - 로컬 개발/검증: **가능**
 - 스테이징 자동배포/모바일 release 검증 파이프라인: **코드 구성 완료 (조건부 가능)**
+- 모바일 스토어 readiness 파이프라인(android signed AAB / ios no-codesign): **수동 실행 경로 구성 완료**
 - 스테이징 실가동: **조건부 가능** (배포/롤백/복구 리허설 성공, 수동 스모크 정례화 필요)
 - 프로덕션 배포: **준비 전**
 - 모바일 스토어 배포(Android/iOS): **준비 전**
@@ -51,11 +52,11 @@
   - 로컬 compose 파싱 통과
   - 스테이징 compose는 `.env` 파일 없이 실행 불가 (`infra/aws/docker-compose.prod.yml`에서 `env_file: .env` 요구)
 
-### 2.5 GitHub Actions 최신 실행 증빙 (2026-02-16)
+### 2.5 GitHub Actions 최신 실행 증빙 (2026-02-17)
 
-- `deploy-staging.yml` (`develop`, commit `c578c3f`) 성공
-  - run: `22052664286`
-  - URL: `https://github.com/V4N1LLA/Eunhye_Hymn/actions/runs/22052664286`
+- `deploy-staging.yml` (`develop`, commit `ee49a0e`) 성공
+  - run: `22119056042`
+  - URL: `https://github.com/V4N1LLA/Eunhye_Hymn/actions/runs/22119056042`
 - `mobile-release-check.yml` (`develop`, commit `35569af`) 성공
   - run: `22052482140`
   - URL: `https://github.com/V4N1LLA/Eunhye_Hymn/actions/runs/22052482140`
@@ -73,9 +74,10 @@
 ### 3.1 후속 반영 (2026-02-14 ~ 2026-02-17)
 - 아래 항목을 문서에 반영 완료:
   - `docs/data-model.md`: events 인덱스(`V7__events_admin_indexes.sql`) 반영
-  - `docs/current-usable-scope.md`: 기준 커밋(`c578c3f`)/근거 PR(#91~#87 포함) 최신화
+  - `docs/current-usable-scope.md`: 기준 커밋(`ee49a0e`)/근거 PR(#92~#87 포함) 최신화
   - `docs/mobile/README.md`: 모바일 배포 범위/운영 연계 체크포인트 보강
   - `README.md`: CI/CD 설명에 `mobile-release-check.yml` 및 staging 자동 배포 반영
+  - `docs/staging-smoke-log.md`: 운영 사이클 실행 로그 누적 기록 추가
 
 ## 4. 실배포 전 필수 체크리스트
 
@@ -144,6 +146,19 @@
   - Mobile Android release APK 빌드 검증 성공
     - run `22052482140` (commit `35569af`)
 - 잔여:
+  - Admin/Mobile 런타임 수동 스모크 정기 수행 및 결과 문서화
+
+### 4.4 2026-02-17 진행 업데이트 (기록)
+
+- 완료:
+  - 운영 사이클 자동 점검 스크립트 추가: `scripts/staging-ops-cycle.ps1`
+  - 최신 자동 배포 성공 확인
+    - run `22119056042` (commit `ee49a0e`)
+- 확인된 리스크:
+  - `staging-preflight.ps1` 무스킵 실행 시 AWS 세션 만료로 실패
+    - `aws sts get-caller-identity`: `session expired (run aws sso login / aws login)`
+- 잔여:
+  - AWS 재인증 후 preflight 무스킵 통과 상태 회복
   - Admin/Mobile 런타임 수동 스모크 정기 수행 및 결과 문서화
 
 ## 5. 현재 판단 (Go/No-Go)

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -124,9 +124,31 @@ cd apps/mobile
 ..\..\scripts\flutterw.ps1 build apk --release --dart-define=API_BASE_URL=https://example.com/api/v1
 ```
 
+## 6.2 Store release readiness
+
+- 워크플로우: `.github/workflows/mobile-store-release.yml`
+- 트리거: 수동 실행(`workflow_dispatch`)
+- 입력:
+  - `target`: `android` | `ios` | `both`
+  - `api_base_url`: 릴리즈 빌드 시 주입할 API URL
+- Android 경로:
+  - 서명형 AAB 빌드(`flutter build appbundle --release`)
+  - 필요한 Secrets:
+    - `MOBILE_ANDROID_KEYSTORE_BASE64`
+    - `MOBILE_ANDROID_KEY_ALIAS`
+    - `MOBILE_ANDROID_KEY_PASSWORD`
+    - `MOBILE_ANDROID_STORE_PASSWORD`
+- iOS 경로:
+  - 무서명 릴리즈 빌드(`flutter build ios --release --no-codesign`)
+  - 코드서명/배포는 Apple 계정/인증서 준비 후 별도 단계에서 수행
+- Android 서명 설정:
+  - `apps/mobile/android/key.properties.example`를 기준으로 `apps/mobile/android/key.properties` 구성
+  - `key.properties`가 없으면 로컬 릴리즈 체크는 debug signing fallback을 사용
+
 ## 7. 운영 연계 체크포인트
 
 - 스테이징 스모크 테스트는 `docs/staging-smoke-checklist.md` 기준으로 수행한다.
+- 운영 사이클 자동 점검은 `scripts/staging-ops-cycle.ps1`를 사용하고 결과를 `docs/staging-smoke-log.md`에 누적한다.
 - 모바일 결과(로그인/재생/동기화/Kakao fallback)는 `docs/runbook.md` 배포 기록과 함께 남긴다.
 - CI(`flutter analyze`, `flutter test`) 결과를 배포 승인 근거로 포함한다.
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -13,6 +13,7 @@
 ## 3. 참조 문서
 - `docs/staging-smoke-checklist.md`
 - `docs/staging-rehearsal-log.md`
+- `docs/staging-smoke-log.md`
 - `docs/deployment-readiness-audit.md`
 - `docs/staging-admin-login.md`
 - `infra/aws/README.md`
@@ -28,6 +29,9 @@
 - [ ] 배포 리허설 자동 실행(권장)
   - `.\scripts\staging-rehearsal.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref develop [-AwsProfile <profile>]`
   - 로컬 확인만 필요하면 `-DryRun` 사용
+- [ ] 운영 사이클 자동 점검(권장)
+  - `.\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner <담당자>`
+  - preflight + 최신 배포 게이트 + `docs/staging-smoke-log.md` 기록을 일괄 수행
 - [ ] GitHub Actions 필수 Secrets 등록 확인
   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `ECR_REGISTRY`, `EC2_HOST`, `EC2_SSH_KEY`, `DEPLOY_ENV_FILE`
 - [ ] GitHub Actions 배포 워크플로 최신 성공 이력 확인
@@ -50,7 +54,7 @@
    - `curl http://<EC2_HOST>/api/v1/ping`
 5. `docs/staging-smoke-checklist.md` 전 항목 수행
 6. 결과 기록
-   - 성공: 배포 시각, 커밋, 수행자, 체크 결과를 문서/티켓에 기록 (`docs/staging-rehearsal-log.md` 포함)
+   - 성공: 배포 시각, 커밋, 수행자, 체크 결과를 문서/티켓에 기록 (`docs/staging-rehearsal-log.md`, `docs/staging-smoke-log.md` 포함)
    - 실패: 즉시 롤백 후 장애 대응 절차로 전환
 
 ## 6. 롤백 절차
@@ -89,5 +93,6 @@
 
 ## 9. 정기 점검 (권장)
 - 주 1회 스테이징 배포 리허설 + 스모크 체크리스트 1회 수행
+- 주 1회 `staging-ops-cycle.ps1` 실행 결과를 기준으로 Go/Hold 근거를 `docs/staging-smoke-log.md`에 누적
 - 월 1회 시크릿 교체 상태 점검
 - 월 1회 롤백 시나리오 점검

--- a/docs/staging-feedback-checklist.md
+++ b/docs/staging-feedback-checklist.md
@@ -53,6 +53,7 @@
 
 - [ ] 최종 결정(`Ship | Hold | Rollback`)을 명확히 기록했다.
 - [ ] 남은 이슈의 우선순위와 다음 액션을 정리했다.
+- [ ] `docs/staging-smoke-log.md`의 동일 사이클 행(runId/판정/근거 URL)과 교차 확인했다.
 - [ ] 관련 문서(`docs/WORK_CYCLE.md`, 필요 시 `CLAUDE.md`)를 동기화했다.
 
 

--- a/docs/staging-smoke-checklist.md
+++ b/docs/staging-smoke-checklist.md
@@ -10,6 +10,9 @@
 - [ ] GitHub Actions 배포 워크플로가 정상 완료되었는지 확인
   - `.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 120`
   - 기록용 표가 필요하면 `-AsMarkdown` 옵션 사용
+- [ ] 운영 사이클 자동 점검 실행 (권장)
+  - `.\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner <담당자>`
+  - 결과는 `docs/staging-smoke-log.md`에 자동 기록
 - [ ] 점검 대상 커밋 SHA/배포 시각/담당자 확정
 - [ ] 자동 리허설 로그(`docs/staging-rehearsal-log.md`) 최신 행 확인
 - [ ] 관리자 계정 및 모바일 테스트 계정 준비
@@ -97,3 +100,16 @@
 1. `docs/runbook.md`의 롤백 절차 수행
 2. 장애 원인/영향 범위/복구 시각 기록
 3. `docs/changelog-dev.md`에 후속 조치 추가
+
+## 8. 운영 사이클 실행 기록 (2026-02-17)
+
+- 실행 명령:
+  - `.\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner codex`
+  - `.\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner codex -SkipPreflight`
+- 결과:
+  - 배포 게이트: PASS (`run 22119056042`, `deploy/verify success`)
+  - preflight: FAIL (`aws sts get-caller-identity`: session expired)
+  - 판정: `HOLD` (수동 스모크 시작 전 AWS 재인증 필요)
+  - `-SkipPreflight` 실행 시 판정: `CONDITIONAL_GO` (수동 스모크 `PENDING`)
+- 로그 문서:
+  - `docs/staging-smoke-log.md`

--- a/docs/staging-smoke-log.md
+++ b/docs/staging-smoke-log.md
@@ -1,0 +1,9 @@
+﻿# Staging Smoke Cycle Log
+
+Operational cycle log (Preflight + deploy gates + manual smoke result).
+
+| UTC Time | Repo | Branch | RunId | HeadSha | Preflight | Run | Deploy | Verify | AgeMin | Decision | Manual Smoke | Evidence | Owner | Notes |
+|----------|------|--------|-------|---------|-----------|-----|--------|--------|--------|----------|--------------|----------|-------|-------|
+| 2026-02-17T23:07:44Z | V4N1LLA/Eunhye_Hymn | develop | 22119056042 | ee49a0efaa2838d697e9f6b09101a1c826e77d29 | FAIL | PASS | PASS | PASS | 10.5 | HOLD | BLOCKED | https://github.com/V4N1LLA/Eunhye_Hymn/actions/runs/22119056042 | codex | preflight failed |
+| 2026-02-17T23:08:49Z | V4N1LLA/Eunhye_Hymn | develop | 22119056042 | ee49a0efaa2838d697e9f6b09101a1c826e77d29 | FAIL | PASS | PASS | PASS | 11.6 | HOLD | BLOCKED | https://github.com/V4N1LLA/Eunhye_Hymn/actions/runs/22119056042 | codex | preflight session expired; preflight failed |
+| 2026-02-17T23:13:51Z | V4N1LLA/Eunhye_Hymn | develop | 22119056042 | ee49a0efaa2838d697e9f6b09101a1c826e77d29 | SKIPPED | PASS | PASS | PASS | 16.6 | CONDITIONAL_GO | PENDING | https://github.com/V4N1LLA/Eunhye_Hymn/actions/runs/22119056042 | codex |  |

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -153,6 +153,17 @@ Terraform 적용 후 아래 스크립트로 필수 Secrets를 한 번에 동기�
 
 로컬 문법/파라미터 검증만 필요하면 `-DryRun` 옵션을 사용한다.
 
+운영 사이클 자동 점검(권장):
+
+```powershell
+.\scripts\staging-ops-cycle.ps1 `
+  -Repo V4N1LLA/Eunhye_Hymn `
+  -Branch develop `
+  -Owner <operator>
+```
+
+이 스크립트는 preflight와 최신 배포 게이트를 함께 확인하고 `docs/staging-smoke-log.md`에 판정(`CONDITIONAL_GO`/`HOLD`)을 기록한다.
+
 최신 배포 run 상태(특히 deploy/verify 성공 여부) 확인:
 
 ```powershell

--- a/scripts/staging-latest-status.ps1
+++ b/scripts/staging-latest-status.ps1
@@ -5,6 +5,7 @@ param(
   [string]$Event = "",
   [int]$Limit = 1,
   [switch]$Wait,
+  [switch]$PreferCompleted,
   [int]$WatchIntervalSeconds = 10,
   [int]$MaxAgeMinutes = 0,
   [switch]$RequireSuccess,
@@ -49,8 +50,15 @@ function Get-DurationSeconds {
     return $null
   }
 
+  if ($CompletedAt -like "0001-01-01T00:00:00*") {
+    return $null
+  }
+
   $start = ([DateTime]$StartedAt).ToUniversalTime()
   $end = ([DateTime]$CompletedAt).ToUniversalTime()
+  if ($end -lt $start) {
+    return $null
+  }
   return [math]::Round(($end - $start).TotalSeconds, 1)
 }
 
@@ -117,7 +125,16 @@ if ($null -eq $runs -or $runs.Count -eq 0) {
   throw "No workflow runs found for $Repo / $Workflow (branch='$Branch', event='$Event')"
 }
 
-$selectedRun = $runs[0]
+$selectedRun = if ($PreferCompleted) {
+  $runs | Where-Object { $_.status -eq "completed" } | Select-Object -First 1
+} else {
+  $runs[0]
+}
+
+if ($null -eq $selectedRun) {
+  throw "No completed workflow runs found for $Repo / $Workflow (branch='$Branch', event='$Event')"
+}
+
 $runId = "$($selectedRun.databaseId)"
 
 if ($Wait -and $selectedRun.status -ne "completed") {

--- a/scripts/staging-ops-cycle.ps1
+++ b/scripts/staging-ops-cycle.ps1
@@ -1,0 +1,251 @@
+param(
+  [string]$Repo = "V4N1LLA/Eunhye_Hymn",
+  [string]$Branch = "develop",
+  [int]$MaxAgeMinutes = 120,
+  [string]$AwsProfile = "",
+  [string]$Owner = "codex",
+  [string]$LogFile = "docs/staging-smoke-log.md",
+  [switch]$SkipPreflight,
+  [switch]$SkipTerraformPlan,
+  [switch]$WaitForCompletion
+)
+
+$ErrorActionPreference = "Stop"
+
+function Escape-MarkdownCell {
+  param([string]$Value)
+
+  if ($null -eq $Value) {
+    return ""
+  }
+
+  return $Value.Replace("|", "\|").Trim()
+}
+
+function Ensure-LogFile {
+  param([string]$Path)
+
+  if (Test-Path $Path) {
+    return
+  }
+
+  @"
+# Staging Smoke Cycle Log
+
+Operational cycle log (Preflight + deploy gates + manual smoke result).
+
+| UTC Time | Repo | Branch | RunId | HeadSha | Preflight | Run | Deploy | Verify | AgeMin | Decision | Manual Smoke | Evidence | Owner | Notes |
+|----------|------|--------|-------|---------|-----------|-----|--------|--------|--------|----------|--------------|----------|-------|-------|
+"@ | Set-Content -Path $Path -Encoding utf8
+}
+
+function Append-LogRow {
+  param(
+    [string]$Path,
+    [hashtable]$Row
+  )
+
+  Ensure-LogFile -Path $Path
+
+  $line = "| {0} | {1} | {2} | {3} | {4} | {5} | {6} | {7} | {8} | {9} | {10} | {11} | {12} | {13} | {14} |" -f `
+    (Escape-MarkdownCell $Row.UtcTime),
+    (Escape-MarkdownCell $Row.Repo),
+    (Escape-MarkdownCell $Row.Branch),
+    (Escape-MarkdownCell $Row.RunId),
+    (Escape-MarkdownCell $Row.HeadSha),
+    (Escape-MarkdownCell $Row.Preflight),
+    (Escape-MarkdownCell $Row.RunGate),
+    (Escape-MarkdownCell $Row.DeployGate),
+    (Escape-MarkdownCell $Row.VerifyGate),
+    (Escape-MarkdownCell $Row.AgeMin),
+    (Escape-MarkdownCell $Row.Decision),
+    (Escape-MarkdownCell $Row.ManualSmoke),
+    (Escape-MarkdownCell $Row.Evidence),
+    (Escape-MarkdownCell $Row.Owner),
+    (Escape-MarkdownCell $Row.Notes)
+
+  Add-Content -Path $Path -Value $line -Encoding utf8
+}
+
+function Invoke-PowerShellFile {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ScriptPath,
+    [string[]]$Arguments = @()
+  )
+
+  $output = & powershell.exe -NoProfile -File $ScriptPath @Arguments 2>&1
+  return [PSCustomObject]@{
+    ExitCode = $LASTEXITCODE
+    Output = ($output -join "`n")
+  }
+}
+
+if ($MaxAgeMinutes -lt 0) {
+  throw "MaxAgeMinutes must be >= 0"
+}
+
+$preflightState = "SKIPPED"
+$notes = @()
+
+if (-not $SkipPreflight) {
+  $preflightScript = Join-Path $PSScriptRoot "staging-preflight.ps1"
+  if (-not (Test-Path $preflightScript)) {
+    throw "staging-preflight.ps1 not found: $preflightScript"
+  }
+
+  $preflightArgs = @("-Repo", $Repo)
+  if (-not [string]::IsNullOrWhiteSpace($AwsProfile)) {
+    $preflightArgs += @("-AwsProfile", $AwsProfile)
+  }
+  if ($SkipTerraformPlan) {
+    $preflightArgs += "-SkipTerraformPlan"
+  }
+
+  $preflightResult = Invoke-PowerShellFile -ScriptPath $preflightScript -Arguments $preflightArgs
+  if ($preflightResult.ExitCode -eq 0) {
+    $preflightState = "PASS"
+  } else {
+    $preflightState = "FAIL"
+    if ($preflightResult.Output -match "session expired") {
+      $notes += "preflight session expired"
+    } elseif ($preflightResult.Output -match "credentials missing") {
+      $notes += "preflight credentials missing"
+    } elseif ($preflightResult.Output -match "aws profile not found") {
+      $notes += "preflight profile not found"
+    } else {
+      $notes += "preflight failed"
+    }
+  }
+}
+
+$statusScript = Join-Path $PSScriptRoot "staging-latest-status.ps1"
+if (-not (Test-Path $statusScript)) {
+  throw "staging-latest-status.ps1 not found: $statusScript"
+}
+
+$statusArgs = @(
+  "-Repo", $Repo,
+  "-Branch", $Branch,
+  "-Limit", "10",
+  "-PreferCompleted",
+  "-AsJson"
+)
+if ($WaitForCompletion) {
+  $statusArgs += "-Wait"
+}
+
+$statusResult = Invoke-PowerShellFile -ScriptPath $statusScript -Arguments $statusArgs
+if ($statusResult.ExitCode -ne 0) {
+  $tail = if ([string]::IsNullOrWhiteSpace($statusResult.Output)) { "status command failed" } else { $statusResult.Output.Split("`n")[-1].Trim() }
+  Append-LogRow -Path $LogFile -Row @{
+    UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    Repo = $Repo
+    Branch = $Branch
+    RunId = "-"
+    HeadSha = "-"
+    Preflight = $preflightState
+    RunGate = "FAIL"
+    DeployGate = "FAIL"
+    VerifyGate = "FAIL"
+    AgeMin = "-"
+    Decision = "HOLD"
+    ManualSmoke = "NOT_STARTED"
+    Evidence = "-"
+    Owner = $Owner
+    Notes = "status error: $tail"
+  }
+  throw "staging status check failed: $tail"
+}
+
+try {
+  $statusPayload = $statusResult.Output | ConvertFrom-Json
+} catch {
+  Append-LogRow -Path $LogFile -Row @{
+    UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    Repo = $Repo
+    Branch = $Branch
+    RunId = "-"
+    HeadSha = "-"
+    Preflight = $preflightState
+    RunGate = "FAIL"
+    DeployGate = "FAIL"
+    VerifyGate = "FAIL"
+    AgeMin = "-"
+    Decision = "HOLD"
+    ManualSmoke = "NOT_STARTED"
+    Evidence = "-"
+    Owner = $Owner
+    Notes = "status output is not valid json"
+  }
+  throw "failed to parse status json output"
+}
+
+$summary = $statusPayload.summary
+$runGate = ($summary.Conclusion -eq "success")
+$deployGate = ($summary.DeployJobConclusion -eq "success")
+$verifyGate = ($summary.VerifyStepConclusion -eq "success")
+$ageGate = ($MaxAgeMinutes -eq 0 -or [double]$summary.RunAgeMinutes -le $MaxAgeMinutes)
+$preflightGate = ($preflightState -ne "FAIL")
+
+$decision = if ($runGate -and $deployGate -and $verifyGate -and $ageGate -and $preflightGate) {
+  "CONDITIONAL_GO"
+} else {
+  "HOLD"
+}
+
+$manualSmoke = if ($decision -eq "CONDITIONAL_GO") { "PENDING" } else { "BLOCKED" }
+
+if (-not $ageGate) {
+  $notes += "run too old(age=$($summary.RunAgeMinutes), max=$MaxAgeMinutes)"
+}
+if (-not $runGate) {
+  $notes += "run conclusion=$($summary.Conclusion)"
+}
+if (-not $deployGate) {
+  $notes += "deploy=$($summary.DeployJobConclusion)"
+}
+if (-not $verifyGate) {
+  $notes += "verify=$($summary.VerifyStepConclusion)"
+}
+if (-not $preflightGate) {
+  $notes += "preflight failed"
+}
+
+Append-LogRow -Path $LogFile -Row @{
+  UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+  Repo = $Repo
+  Branch = $Branch
+  RunId = "$($summary.RunId)"
+  HeadSha = "$($summary.HeadSha)"
+  Preflight = $preflightState
+  RunGate = $(if ($runGate) { "PASS" } else { "FAIL" })
+  DeployGate = $(if ($deployGate) { "PASS" } else { "FAIL" })
+  VerifyGate = $(if ($verifyGate) { "PASS" } else { "FAIL" })
+  AgeMin = "$($summary.RunAgeMinutes)"
+  Decision = $decision
+  ManualSmoke = $manualSmoke
+  Evidence = "$($summary.Url)"
+  Owner = $Owner
+  Notes = ($notes -join "; ")
+}
+
+Write-Host "== Staging Ops Cycle =="
+Write-Host ("Repo: {0}" -f $Repo)
+Write-Host ("Branch: {0}" -f $Branch)
+Write-Host ("RunId: {0}" -f $summary.RunId)
+Write-Host ("HeadSha: {0}" -f $summary.HeadSha)
+Write-Host ("Preflight: {0}" -f $preflightState)
+Write-Host ("Gate(run/deploy/verify/age): {0}/{1}/{2}/{3}" -f $runGate, $deployGate, $verifyGate, $ageGate)
+Write-Host ("Decision: {0}" -f $decision)
+Write-Host ("Log: {0}" -f $LogFile)
+Write-Host ""
+Write-Host "Update manual smoke results in:"
+Write-Host "- docs/staging-smoke-checklist.md"
+Write-Host "- docs/staging-feedback-checklist.md"
+
+if ($decision -eq "CONDITIONAL_GO") {
+  exit 0
+}
+
+exit 1

--- a/scripts/staging-preflight.ps1
+++ b/scripts/staging-preflight.ps1
@@ -55,6 +55,37 @@ function Run-CommandCapture {
   }
 }
 
+function Get-FirstUsefulLine {
+  param([string]$Output)
+
+  if ([string]::IsNullOrWhiteSpace($Output)) {
+    return ""
+  }
+
+  $lines = $Output -split "`r?`n" | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  if ($null -eq $lines -or $lines.Count -eq 0) {
+    return ""
+  }
+
+  foreach ($line in $lines) {
+    if ($line -eq "System.Management.Automation.RemoteException") {
+      continue
+    }
+    if ($line -like "At line:*") {
+      continue
+    }
+    if ($line -like "+ CategoryInfo:*") {
+      continue
+    }
+    if ($line -like "+ FullyQualifiedErrorId:*") {
+      continue
+    }
+    return $line
+  }
+
+  return $lines[0]
+}
+
 function Test-AwsPermission {
   param(
     [string]$Name,
@@ -72,7 +103,11 @@ function Test-AwsPermission {
     return
   }
 
-  Add-Check $Name $false ("failed: " + $result.Output.Split("`n")[0])
+  $detailLine = Get-FirstUsefulLine -Output $result.Output
+  if ([string]::IsNullOrWhiteSpace($detailLine)) {
+    $detailLine = "command failed"
+  }
+  Add-Check $Name $false ("failed: " + $detailLine)
 }
 
 function Build-AwsCommand {
@@ -98,10 +133,16 @@ if ($identityResult.ExitCode -ne 0) {
   $identityDetail = "failed"
   if ($identityResult.Output -match "Unable to locate credentials|NoCredentialProviders") {
     $identityDetail = "credentials missing (run aws configure / aws configure sso / aws login)"
+  } elseif ($identityResult.Output -match "Your session has expired|ExpiredToken|Token has expired and refresh failed|The SSO session associated with this profile has expired") {
+    $identityDetail = "session expired (run aws sso login / aws login)"
   } elseif ($identityResult.Output -match "The config profile .* could not be found") {
     $identityDetail = "aws profile not found"
   } elseif (-not [string]::IsNullOrWhiteSpace($identityResult.Output)) {
-    $identityDetail = "failed: " + $identityResult.Output.Split("`n")[0]
+    $detailLine = Get-FirstUsefulLine -Output $identityResult.Output
+    if ([string]::IsNullOrWhiteSpace($detailLine)) {
+      $detailLine = "command failed"
+    }
+    $identityDetail = "failed: " + $detailLine
   }
 
   Add-Check "aws sts get-caller-identity" $false $identityDetail


### PR DESCRIPTION
﻿## 요약
우선순위 1~3 작업을 한 사이클로 반영했습니다.

1) 스테이징 수동 스모크 정례화
- `scripts/staging-ops-cycle.ps1` 추가
  - preflight + 최신 deploy 게이트(run/deploy/verify/age) + 로그 적재 자동화
- `docs/staging-smoke-log.md` 추가 및 실행 로그 누적
- 운영 문서 동기화
  - `docs/staging-smoke-checklist.md`
  - `docs/staging-feedback-checklist.md`
  - `docs/runbook.md`
  - `infra/aws/README.md`

2) preflight 무스킵 유지(가시성/안정성 보강)
- `scripts/staging-preflight.ps1`
  - `aws sts get-caller-identity` 실패 상세 메시지 개선
  - 세션 만료를 `session expired (run aws sso login / aws login)`로 명확히 표시
- `scripts/staging-latest-status.ps1`
  - 진행 중 job의 `completedAt=0001-01-01` 케이스 duration 음수 버그 수정
  - `-PreferCompleted` 옵션 추가

3) 모바일 배포 준비도
- Android release signing 설정 개선
  - `apps/mobile/android/app/build.gradle.kts`
  - `apps/mobile/android/key.properties.example` 추가
- 스토어 readiness 수동 워크플로우 추가
  - `.github/workflows/mobile-store-release.yml`
  - Android signed AAB + iOS no-codesign release build
- 모바일 문서 동기화
  - `docs/mobile/README.md`
  - `apps/mobile/README.md`

## 문서 동기화
- `README.md`
- `docs/current-usable-scope.md`
- `docs/deployment-readiness-audit.md`
- `docs/changelog-dev.md`
- `docs/WORK_CYCLE.md`
- `CLAUDE.md`

## 검증
- `powershell -NoProfile -File .\scripts\staging-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn`
  - 결과: fail (현재 로컬 AWS 세션 만료)
  - 메시지: `session expired (run aws sso login / aws login)` 확인
- `powershell -NoProfile -File .\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -AsJson`
  - 결과: success
  - 근거 run: `22119056042` (`deploy/verify success`)
- `powershell -NoProfile -File .\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -PreferCompleted -AsJson`
  - 결과: success
- `powershell -NoProfile -File .\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner codex`
  - 결과: HOLD (preflight fail)
- `powershell -NoProfile -File .\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner codex -SkipPreflight`
  - 결과: CONDITIONAL_GO
- `cd apps/mobile/android && .\gradlew.bat :app:tasks --all`
  - 결과: success
- `rg -n "^(<<<<<<<|>>>>>>>|=======)$" ...` (변경 파일 범위)
  - 결과: no conflict markers

## 리스크/후속
- preflight 무스킵은 로컬 AWS 세션 만료 상태 해소(`aws sso login` 또는 `aws login`)가 필요합니다.
