### PR TITLE
feat(android): add Play upload mode for store workflow

### DIFF
--- a/.github/workflows/mobile-store-release.yml
+++ b/.github/workflows/mobile-store-release.yml
@@ -12,6 +12,43 @@ on:
           - android
           - ios
           - both
+      android_distribution_mode:
+        description: "Android path: build-only or Google Play upload"
+        required: true
+        default: build_only
+        type: choice
+        options:
+          - build_only
+          - play_upload
+      android_package_name:
+        description: "Optional Android package name override (if empty, secret GOOGLE_PLAY_PACKAGE_NAME is used)"
+        required: false
+        default: ""
+      android_track:
+        description: "Google Play track for upload mode"
+        required: true
+        default: internal
+        type: choice
+        options:
+          - internal
+          - alpha
+          - beta
+          - production
+      android_release_status:
+        description: "Google Play release status for upload mode"
+        required: true
+        default: draft
+        type: choice
+        options:
+          - draft
+          - completed
+          - inProgress
+          - halted
+      android_changes_not_sent_for_review:
+        description: "Google Play: keep changes pending review submission"
+        required: true
+        default: true
+        type: boolean
       ios_distribution_mode:
         description: "iOS path: build-only or TestFlight upload"
         required: true
@@ -50,6 +87,8 @@ jobs:
       MOBILE_ANDROID_KEY_ALIAS: ${{ secrets.MOBILE_ANDROID_KEY_ALIAS }}
       MOBILE_ANDROID_KEY_PASSWORD: ${{ secrets.MOBILE_ANDROID_KEY_PASSWORD }}
       MOBILE_ANDROID_STORE_PASSWORD: ${{ secrets.MOBILE_ANDROID_STORE_PASSWORD }}
+      GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+      ANDROID_PACKAGE_NAME: ${{ inputs.android_package_name || secrets.GOOGLE_PLAY_PACKAGE_NAME }}
     steps:
       - uses: actions/checkout@v4
 
@@ -71,6 +110,10 @@ jobs:
           : "${MOBILE_ANDROID_KEY_ALIAS:?Missing MOBILE_ANDROID_KEY_ALIAS secret}"
           : "${MOBILE_ANDROID_KEY_PASSWORD:?Missing MOBILE_ANDROID_KEY_PASSWORD secret}"
           : "${MOBILE_ANDROID_STORE_PASSWORD:?Missing MOBILE_ANDROID_STORE_PASSWORD secret}"
+          if [[ "${{ inputs.android_distribution_mode }}" == "play_upload" ]]; then
+            : "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON:?Missing GOOGLE_PLAY_SERVICE_ACCOUNT_JSON secret for play_upload mode}"
+            : "${ANDROID_PACKAGE_NAME:?Missing android_package_name input or GOOGLE_PLAY_PACKAGE_NAME secret for play_upload mode}"
+          fi
 
       - name: Prepare Android keystore
         run: |
@@ -95,6 +138,17 @@ jobs:
           name: mobile-android-release-aab
           path: apps/mobile/build/app/outputs/bundle/release/app-release.aab
           if-no-files-found: error
+
+      - name: Upload Android AAB to Google Play
+        if: ${{ inputs.android_distribution_mode == 'play_upload' }}
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: ${{ env.ANDROID_PACKAGE_NAME }}
+          releaseFiles: apps/mobile/build/app/outputs/bundle/release/app-release.aab
+          track: ${{ inputs.android_track }}
+          status: ${{ inputs.android_release_status }}
+          changesNotSentForReview: ${{ inputs.android_changes_not_sent_for_review }}
 
   ios-release-no-codesign:
     if: ${{ (inputs.target == 'ios' || inputs.target == 'both') && inputs.ios_distribution_mode == 'build_only' }}

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -83,12 +83,24 @@ lib/
   - Builds `app-release.apk` and uploads artifact.
 - Store release readiness (Android only for now): `.github/workflows/mobile-store-release.yml` (manual)
   - signed AAB build (`flutter build appbundle --release`)
-  - input: `api_base_url`
+  - `android_distribution_mode=build_only`: build artifact only
+  - `android_distribution_mode=play_upload`: Google Play upload after AAB build
+  - required inputs for play upload:
+    - `android_track`: `internal | alpha | beta | production`
+    - `android_release_status`: `draft | completed | inProgress | halted`
+    - `android_changes_not_sent_for_review`: `true | false`
+  - optional input:
+    - `android_package_name` (empty -> `GOOGLE_PLAY_PACKAGE_NAME` secret)
+  - common input: `api_base_url`
 
 Android signing config:
 - Copy `apps/mobile/android/key.properties.example` to `apps/mobile/android/key.properties`.
 - Fill `storeFile`, `storePassword`, `keyAlias`, `keyPassword`.
 - `key.properties` and keystore files are ignored by git.
+
+Google Play upload secrets:
+- `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`
+- `GOOGLE_PLAY_PACKAGE_NAME`
 
 See also:
 - Minimal-tooling QA guide: `docs/mobile/qa-minimal-tooling.md`

--- a/docs/SECRETS_MANAGEMENT.md
+++ b/docs/SECRETS_MANAGEMENT.md
@@ -45,6 +45,10 @@ Android signing (`.github/workflows/mobile-store-release.yml`):
 - `MOBILE_ANDROID_KEY_PASSWORD`
 - `MOBILE_ANDROID_STORE_PASSWORD`
 
+Android Google Play upload (`.github/workflows/mobile-store-release.yml`):
+- `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`
+- `GOOGLE_PLAY_PACKAGE_NAME`
+
 iOS TestFlight upload (`.github/workflows/mobile-store-release.yml`):
 - `MOBILE_IOS_BUNDLE_ID`
 - `MOBILE_IOS_TEAM_ID`

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -129,14 +129,23 @@ cd apps/mobile
 - 워크플로우: `.github/workflows/mobile-store-release.yml`
 - 트리거: 수동 실행(`workflow_dispatch`)
 - 입력:
+  - `target`: `android` | `ios` | `both`
+  - `android_distribution_mode`: `build_only` | `play_upload`
+  - `android_package_name`: Android package name 1회 오버라이드(미입력 시 `GOOGLE_PLAY_PACKAGE_NAME` 사용)
+  - `android_track`: `internal` | `alpha` | `beta` | `production` (play upload 시)
+  - `android_release_status`: `draft` | `completed` | `inProgress` | `halted` (play upload 시)
+  - `android_changes_not_sent_for_review`: `true` | `false` (play upload 시)
   - `api_base_url`: 릴리즈 빌드 시 주입할 API URL
 - Android 경로:
   - 서명형 AAB 빌드(`flutter build appbundle --release`)
+  - `android_distribution_mode=play_upload`면 AAB 업로드 후 Google Play에 배포 편집 생성
   - 필요한 Secrets:
     - `MOBILE_ANDROID_KEYSTORE_BASE64`
     - `MOBILE_ANDROID_KEY_ALIAS`
     - `MOBILE_ANDROID_KEY_PASSWORD`
     - `MOBILE_ANDROID_STORE_PASSWORD`
+    - `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` (play upload 시)
+    - `GOOGLE_PLAY_PACKAGE_NAME` (입력 미지정 시)
 - Android 서명 설정:
   - `apps/mobile/android/key.properties.example`를 기준으로 `apps/mobile/android/key.properties` 구성
   - `key.properties`가 없으면 로컬 릴리즈 체크는 debug signing fallback을 사용

--- a/docs/mobile/qa-minimal-tooling.md
+++ b/docs/mobile/qa-minimal-tooling.md
@@ -1,4 +1,4 @@
-# Android QA With Minimal Local Tooling
+﻿# Android QA With Minimal Local Tooling
 
 ## Goal
 
@@ -45,6 +45,8 @@ adb install -r .tmp/mobile-apk/app-release.apk
 
 ```powershell
 gh workflow run mobile-store-release.yml `
+  -f target=android `
+  -f android_distribution_mode=build_only `
   -f api_base_url=http://13.209.200.12
 ```
 
@@ -62,7 +64,17 @@ Recommended sequence:
 
 1. Run `mobile-release-check.yml` with production `api_base_url` to verify APK release build.
 2. Run `mobile-store-release.yml` with production `api_base_url` to generate signed AAB.
-3. Complete Go/Hold decision in checklist and runbook.
+3. If you also want Play Console upload automation, run:
+
+```powershell
+gh workflow run mobile-store-release.yml `
+  -f target=android `
+  -f android_distribution_mode=play_upload `
+  -f android_track=internal `
+  -f android_release_status=draft `
+  -f android_changes_not_sent_for_review=true `
+  -f api_base_url=https://<prod-domain>
+```
 
 ## Notes
 
@@ -71,4 +83,6 @@ Recommended sequence:
   - `MOBILE_ANDROID_KEY_ALIAS`
   - `MOBILE_ANDROID_KEY_PASSWORD`
   - `MOBILE_ANDROID_STORE_PASSWORD`
-- iOS는 현재 문서 범위에서 제외하고 추후 별도 가이드로 분리한다.
+- Google Play upload secrets:
+  - `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`
+  - `GOOGLE_PLAY_PACKAGE_NAME`


### PR DESCRIPTION
## Summary
- add Android play_upload mode to .github/workflows/mobile-store-release.yml
- add Google Play workflow inputs (track/status/review flag/package override)
- upload AAB to Google Play via 0adkll/upload-google-play@v1 when play_upload mode is selected
- update Android release docs and secret guide

## Ops updates done
- registered Android signing secrets in repo:
  - MOBILE_ANDROID_KEYSTORE_BASE64
  - MOBILE_ANDROID_KEY_ALIAS
  - MOBILE_ANDROID_KEY_PASSWORD
  - MOBILE_ANDROID_STORE_PASSWORD
- set GOOGLE_PLAY_PACKAGE_NAME (current app id placeholder)

## Note
- GOOGLE_PLAY_SERVICE_ACCOUNT_JSON still needs real service-account JSON to run Play upload mode.
