### PR TITLE
feat(local): add reproducible local Android smoke verification flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,8 @@ S3_REGION=ap-northeast-2
 S3_ENDPOINT=http://localstack:4566
 S3_PUBLIC_BASE_URL=http://localhost:4566/local-bucket
 S3_PRESIGN_EXPIRES_MINUTES=15
+AWS_ACCESS_KEY_ID=test
+AWS_SECRET_ACCESS_KEY=test
 
 # Spring profile
 SPRING_PROFILES_ACTIVE=dev

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Eunhye Hymn
+# Eunhye Hymn
 
 교회 찬양팀을 위한 악보(PNG) 및 파트 연습 음원(MIDI) 관리 시스템입니다.
 
@@ -61,6 +61,7 @@ docs/       프로젝트 문서
 - 모바일 최소 설치 QA 가이드: [docs/mobile/qa-minimal-tooling.md](./docs/mobile/qa-minimal-tooling.md)
 - 로컬 셋업 가이드: [docs/LOCAL_SETUP.md](./docs/LOCAL_SETUP.md)
 - 시크릿 관리 가이드: [docs/SECRETS_MANAGEMENT.md](./docs/SECRETS_MANAGEMENT.md)
+- 팀 로컬 재시작 가이드(다른 PC/Android 중심): [docs/TEAM_LOCAL_DEVELOPMENT.md](./docs/TEAM_LOCAL_DEVELOPMENT.md)
 - 작업 사이클 기준서: [docs/WORK_CYCLE.md](./docs/WORK_CYCLE.md)
 - AWS 무료 티어 온보딩: [docs/admin/aws-free-tier-onboarding.md](./docs/admin/aws-free-tier-onboarding.md)
 - 모바일 앱 README: [apps/mobile/README.md](./apps/mobile/README.md)

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -12,8 +12,9 @@ COPY gradlew.bat .
 COPY build.gradle .
 COPY settings.gradle .
 
-# Ensure gradlew is executable
-RUN chmod +x gradlew
+# Ensure gradlew works on Linux containers even on CRLF checkouts.
+RUN sed -i 's/\r$//' gradlew \
+    && chmod +x gradlew
 
 # Download dependencies (cached unless build files change)
 RUN ./gradlew dependencies --no-daemon || true

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminCreateInviteCodeUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/AdminCreateInviteCodeUseCase.java
@@ -5,6 +5,7 @@ import com.eunhyehymn.domain.model.InviteCode;
 import com.eunhyehymn.domain.repository.InviteCodeRepository;
 import java.time.Instant;
 import java.util.UUID;
+import java.util.Locale;
 import org.springframework.http.HttpStatus;
 
 public class AdminCreateInviteCodeUseCase {
@@ -15,13 +16,21 @@ public class AdminCreateInviteCodeUseCase {
     }
 
     public InviteCode create(String code, UUID createdBy, String description, Integer maxUses, Instant expiresAt) {
-        inviteCodeRepository.findByCode(code).ifPresent(existing -> {
+        String normalizedCode = normalizeInviteCode(code);
+        inviteCodeRepository.findByCode(normalizedCode).ifPresent(existing -> {
             throw new ApiException(HttpStatus.CONFLICT, "invite_code_exists", "이미 존재하는 초대코드입니다: " + code, null);
         });
 
         InviteCode inviteCode = new InviteCode(
-            code, createdBy, description, maxUses, 0, true, expiresAt, Instant.now()
+            normalizedCode, createdBy, description, maxUses, 0, true, expiresAt, Instant.now()
         );
         return inviteCodeRepository.save(inviteCode);
+    }
+
+    private String normalizeInviteCode(String code) {
+        if (code == null) {
+            return "";
+        }
+        return code.trim().toUpperCase(Locale.ROOT);
     }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/SocialLoginUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/SocialLoginUseCase.java
@@ -16,6 +16,7 @@ import com.eunhyehymn.domain.repository.UserRepository;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -64,16 +65,15 @@ public class SocialLoginUseCase {
 
     @Transactional
     public LoginResult login(String provider, String token, String inviteCode) {
-        // 1. 소셜 토큰 검증 → 사용자 정보 추출
         String normalizedProvider = provider.toUpperCase();
         SocialUserInfo userInfo = socialTokenVerifier.verify(normalizedProvider, token);
+        String normalizedInviteCode = normalizeInviteCode(inviteCode);
 
         boolean isAdminCandidate = isAdminCandidate(normalizedProvider, userInfo);
         if (enforceAdminOnly && !isAdminCandidate) {
-            throw new AdminOnlyException("관리자만 로그인할 수 있습니다");
+            throw new AdminOnlyException("관리자만 이용 가능한 계정입니다.");
         }
 
-        // 2. AuthIdentity 조회
         Optional<AuthIdentity> existingIdentity = authIdentityRepository
             .findByProviderAndProviderSubject(normalizedProvider, userInfo.providerSubject());
 
@@ -81,10 +81,9 @@ public class SocialLoginUseCase {
         User user;
 
         if (existingIdentity.isPresent()) {
-            // 기존 사용자: 초대코드 검증 불필요, lastLoginAt 갱신
             User existing = userRepository.findById(existingIdentity.get().userId())
                 .orElseThrow(() -> new IllegalStateException(
-                    "AuthIdentity에 연결된 User를 찾을 수 없습니다: " + existingIdentity.get().userId()));
+                    "AuthIdentity에 해당하는 사용자 조회 실패: " + existingIdentity.get().userId()));
 
             Role effectiveRole = existing.role();
             if (isAdminCandidate && existing.role() != Role.ADMIN) {
@@ -102,30 +101,25 @@ public class SocialLoginUseCase {
             userRepository.save(user);
         } else {
             if (!isAdminCandidate) {
-                // 신규 사용자: 초대코드 검증 필수
-                if (inviteCode == null || inviteCode.isBlank()) {
-                    throw new InvalidInviteCodeException("초대코드가 필요합니다");
+                if (normalizedInviteCode == null || normalizedInviteCode.isBlank()) {
+                    throw new InvalidInviteCodeException("초대코드가 비어있습니다");
                 }
 
-                // 초대코드 존재 여부 확인
-                inviteCodeRepository.findByCode(inviteCode)
+                inviteCodeRepository.findByCode(normalizedInviteCode)
                     .orElseThrow(() -> new InvalidInviteCodeException("유효하지 않은 초대코드입니다"));
 
-                // 원자적으로 usedCount 증가 (enabled, maxUses, expiresAt 동시 검증)
-                boolean incremented = inviteCodeRepository.incrementUsedCount(inviteCode);
+                boolean incremented = inviteCodeRepository.incrementUsedCount(normalizedInviteCode);
                 if (!incremented) {
                     throw new InvalidInviteCodeException("유효하지 않은 초대코드입니다");
                 }
             }
 
-            // User 생성
             UUID userId = UUID.randomUUID();
             String displayName = userInfo.displayName() != null ? userInfo.displayName() : normalizedProvider + " User";
             Role role = isAdminCandidate ? Role.ADMIN : Role.USER;
             user = new User(userId, displayName, role, UserStatus.ACTIVE, now, now);
             userRepository.save(user);
 
-            // AuthIdentity 생성
             AuthIdentity identity = new AuthIdentity(
                 UUID.randomUUID(),
                 userId,
@@ -137,7 +131,6 @@ public class SocialLoginUseCase {
             authIdentityRepository.save(identity);
         }
 
-        // 3. JWT 발급
         String accessToken = tokenService.issueAccessToken(user.id().toString(), user.role().name());
         String refreshToken = tokenService.issueRefreshToken();
         String hash = tokenHashService.hash(refreshToken);
@@ -168,6 +161,13 @@ public class SocialLoginUseCase {
         }
 
         return false;
+    }
+
+    private String normalizeInviteCode(String inviteCode) {
+        if (inviteCode == null) {
+            return null;
+        }
+        return inviteCode.trim().toUpperCase(Locale.ROOT);
     }
 
     public record LoginResult(String accessToken, String refreshToken, boolean newUser) {

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/ValidateInviteCodeUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/ValidateInviteCodeUseCase.java
@@ -3,6 +3,7 @@ package com.eunhyehymn.application.usecases;
 import com.eunhyehymn.domain.model.InviteCode;
 import com.eunhyehymn.domain.repository.InviteCodeRepository;
 import java.time.Instant;
+import java.util.Locale;
 
 public class ValidateInviteCodeUseCase {
     private final InviteCodeRepository inviteCodeRepository;
@@ -12,7 +13,8 @@ public class ValidateInviteCodeUseCase {
     }
 
     public boolean validate(String code) {
-        return inviteCodeRepository.findByCode(code)
+        String normalizedCode = normalizeInviteCode(code);
+        return inviteCodeRepository.findByCode(normalizedCode)
             .map(this::isValid)
             .orElse(false);
     }
@@ -28,5 +30,12 @@ public class ValidateInviteCodeUseCase {
             return false;
         }
         return true;
+    }
+
+    private String normalizeInviteCode(String code) {
+        if (code == null) {
+            return "";
+        }
+        return code.trim().toUpperCase(Locale.ROOT);
     }
 }

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/AssetConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/AssetConfig.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -29,6 +30,9 @@ public class AssetConfig {
         if (endpoint != null && !endpoint.isBlank()) {
             builder.endpointOverride(URI.create(endpoint));
         }
+        builder.serviceConfiguration(
+            S3Configuration.builder().pathStyleAccessEnabled(true).build()
+        );
         return new S3StorageService(
             builder.build(),
             bucket,

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/storage/S3StorageService.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/storage/S3StorageService.java
@@ -1,8 +1,8 @@
 package com.eunhyehymn.infrastructure.storage;
 
 import com.eunhyehymn.application.ports.StorageService;
-import java.net.URI;
 import java.net.URLEncoder;
+import java.net.URI;
 import java.time.Duration;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
@@ -57,8 +57,9 @@ public class S3StorageService implements StorageService {
 
         PresignedPutObjectRequest presigned = presigner.presignPutObject(presignRequest);
         String publicUrl = resolvePublicUrl(objectKey);
+        String uploadUrl = presigned.url().toString();
 
-        return new PresignResult(presigned.url().toString(), publicUrl, objectKey);
+        return new PresignResult(rewriteToLocalPublicHost(uploadUrl), publicUrl, objectKey);
     }
 
     @Override
@@ -77,7 +78,7 @@ public class S3StorageService implements StorageService {
                 .getObjectRequest(getObjectRequest)
                 .build();
             PresignedGetObjectRequest presigned = presigner.presignGetObject(presignRequest);
-            return presigned.url().toString();
+            return rewriteToLocalPublicHost(presigned.url().toString());
         } catch (Exception ignored) {
             return fallbackUrl;
         }
@@ -98,5 +99,51 @@ public class S3StorageService implements StorageService {
             return base + "/" + bucket + "/" + objectKey;
         }
         return String.format("https://%s.s3.amazonaws.com/%s", bucket, objectKey);
+    }
+
+    private String rewriteToLocalPublicHost(String sourceUrl) {
+        if (sourceUrl == null || sourceUrl.isBlank()) {
+            return sourceUrl;
+        }
+        if (publicBaseUrl == null || publicBaseUrl.isBlank()) {
+            return sourceUrl;
+        }
+
+        try {
+            URI source = URI.create(sourceUrl);
+            URI publicUri = URI.create(publicBaseUrl);
+            String publicHost = publicUri.getHost();
+            if (publicHost == null) {
+                return sourceUrl;
+            }
+            if (!isLocalHost(publicHost)) {
+                return sourceUrl;
+            }
+
+            int publicPort = publicUri.getPort();
+            StringBuilder rewritten = new StringBuilder();
+            rewritten.append(publicUri.getScheme() != null ? publicUri.getScheme() : source.getScheme());
+            rewritten.append("://");
+            rewritten.append(publicHost);
+            if (publicPort != -1) {
+                rewritten.append(":").append(publicPort);
+            }
+            rewritten.append(source.getRawPath());
+            if (source.getRawQuery() != null) {
+                rewritten.append("?").append(source.getRawQuery());
+            }
+            return rewritten.toString();
+        } catch (Exception ignored) {
+            return sourceUrl;
+        }
+    }
+
+    private boolean isLocalHost(String host) {
+        if (host == null || host.isBlank()) {
+            return false;
+        }
+        return "localhost".equalsIgnoreCase(host)
+            || "127.0.0.1".equals(host)
+            || host.startsWith("10.0.2.");
     }
 }

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/SocialLoginApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/SocialLoginApiTest.java
@@ -199,4 +199,25 @@ class SocialLoginApiTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.newUser").value(true));
     }
+
+    @Test
+    void inviteCodeIsNormalizedBeforeValidation() throws Exception {
+        inviteCodeJpaRepository.save(new InviteCodeEntity(
+            "TRIM-CODE", null, "trim", null, 0, true, null, Instant.now()
+        ));
+
+        when(socialTokenVerifier.verify(eq("KAKAO"), eq("trim-token")))
+            .thenReturn(new SocialUserInfo("trim-sub", "trim@kakao.com", "Trim User"));
+
+        Map<String, String> request = new HashMap<>();
+        request.put("provider", "KAKAO");
+        request.put("token", "trim-token");
+        request.put("inviteCode", "  trim-code  ");
+
+        mockMvc.perform(post("/auth/social")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.newUser").value(true));
+    }
 }

--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,0 +1,2 @@
+API_BASE_URL=http://10.0.2.2:8080/api/v1
+KAKAO_NATIVE_APP_KEY=your_kakao_native_app_key

--- a/apps/mobile/lib/src/app.dart
+++ b/apps/mobile/lib/src/app.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 
 import 'core/config/app_config.dart';
 import 'core/network/api_client.dart';
+import 'core/storage/onboarding_storage.dart';
 import 'core/storage/token_storage.dart';
 import 'features/auth/auth_repository.dart';
 import 'features/auth/login_page.dart';
+import 'features/auth/onboarding_page.dart';
 import 'features/auth/social_sdk_service.dart';
 import 'features/history/history_page.dart';
 import 'features/hymn/hymn_detail_page.dart';
@@ -23,11 +25,14 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
   late final ApiClient _apiClient;
   late final AuthRepository _authRepository;
   late final SocialSdkService _socialSdkService;
+  late final OnboardingStorage _onboardingStorage;
   late final HymnRepository _hymnRepository;
 
   bool _initializing = true;
   SessionProfile? _profile;
   String? _initError;
+  String? _loginError;
+  bool _needsOnboarding = false;
 
   @override
   void initState() {
@@ -42,6 +47,7 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
       tokenStorage: _tokenStorage,
     );
     _socialSdkService = SocialSdkService()..initialize();
+    _onboardingStorage = OnboardingStorage();
     _hymnRepository = HymnRepository(apiClient: _apiClient);
     _bootstrap();
   }
@@ -58,6 +64,8 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
         _hymnRepository.bindSessionUser(null);
         setState(() {
           _profile = null;
+          _needsOnboarding = false;
+          _loginError = null;
         });
         return;
       }
@@ -68,13 +76,20 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
         _hymnRepository.bindSessionUser(null);
         setState(() {
           _profile = null;
+          _needsOnboarding = false;
+          _loginError = null;
         });
         return;
       }
 
+      final needsOnboarding =
+          !(await _onboardingStorage.isCompleted(profile.userId));
+
       _hymnRepository.bindSessionUser(profile.userId);
       setState(() {
         _profile = profile;
+        _needsOnboarding = needsOnboarding;
+        _loginError = null;
       });
       await _hymnRepository.syncPendingActions();
     } catch (e) {
@@ -83,6 +98,7 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
       }
       setState(() {
         _initError = e.toString();
+        _loginError = null;
       });
     } finally {
       if (mounted) {
@@ -94,11 +110,25 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
   }
 
   Future<void> _onLoggedIn(SessionProfile profile) async {
+    final needsOnboarding =
+        !(await _onboardingStorage.isCompleted(profile.userId));
     _hymnRepository.bindSessionUser(profile.userId);
     setState(() {
       _profile = profile;
+      _needsOnboarding = needsOnboarding;
+      _loginError = null;
     });
     await _hymnRepository.syncPendingActions();
+  }
+
+  Future<void> _onOnboardingCompleted() async {
+    if (!mounted || _profile == null) {
+      return;
+    }
+    await _hymnRepository.syncPendingActions();
+    setState(() {
+      _needsOnboarding = false;
+    });
   }
 
   Future<void> _onLogout() async {
@@ -109,6 +139,8 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
     }
     setState(() {
       _profile = null;
+      _needsOnboarding = false;
+      _loginError = null;
     });
   }
 
@@ -170,7 +202,16 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
       return LoginPage(
         authRepository: _authRepository,
         socialSdkService: _socialSdkService,
+        initialError: _loginError,
         onLoggedIn: _onLoggedIn,
+      );
+    }
+
+    if (_needsOnboarding) {
+      return OnboardingPage(
+        userId: _profile!.userId,
+        onboardingStorage: _onboardingStorage,
+        onCompleted: _onOnboardingCompleted,
       );
     }
 
@@ -243,7 +284,7 @@ class _HomeShellState extends State<_HomeShell> {
         onOpenHymnDetail: _openHymnDetail,
       ),
     ];
-    final titles = <String>['찬양 둘러보기', '최근 본 찬양'];
+    final titles = <String>['찬양', '히스토리'];
 
     return Scaffold(
       appBar: AppBar(
@@ -286,7 +327,7 @@ class _HomeShellState extends State<_HomeShell> {
           NavigationDestination(
             icon: Icon(Icons.history_outlined),
             selectedIcon: Icon(Icons.history),
-            label: '최근 본 항목',
+            label: '히스토리',
           ),
         ],
       ),

--- a/apps/mobile/lib/src/core/storage/onboarding_storage.dart
+++ b/apps/mobile/lib/src/core/storage/onboarding_storage.dart
@@ -1,0 +1,63 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class UserOnboardingProfile {
+  final String churchName;
+  final String name;
+  final String group;
+
+  const UserOnboardingProfile({
+    required this.churchName,
+    required this.name,
+    required this.group,
+  });
+}
+
+class OnboardingStorage {
+  static const _baseKey = 'onboarding_profile';
+  static const _keyChurch = 'church';
+  static const _keyName = 'name';
+  static const _keyGroup = 'group';
+
+  String _churchKey(String userId) => '$_baseKey.$userId.$_keyChurch';
+  String _nameKey(String userId) => '$_baseKey.$userId.$_keyName';
+  String _groupKey(String userId) => '$_baseKey.$userId.$_keyGroup';
+
+  Future<UserOnboardingProfile?> getProfile(String userId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final churchName = prefs.getString(_churchKey(userId));
+    final name = prefs.getString(_nameKey(userId));
+    final group = prefs.getString(_groupKey(userId));
+
+    if (churchName == null ||
+        churchName.trim().isEmpty ||
+        name == null ||
+        name.trim().isEmpty ||
+        group == null ||
+        group.trim().isEmpty) {
+      return null;
+    }
+
+    return UserOnboardingProfile(
+      churchName: churchName,
+      name: name,
+      group: group,
+    );
+  }
+
+  Future<void> saveProfile({
+    required String userId,
+    required String churchName,
+    required String name,
+    required String group,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_churchKey(userId), churchName.trim());
+    await prefs.setString(_nameKey(userId), name.trim());
+    await prefs.setString(_groupKey(userId), group.trim());
+  }
+
+  Future<bool> isCompleted(String userId) async {
+    final profile = await getProfile(userId);
+    return profile != null;
+  }
+}

--- a/apps/mobile/lib/src/features/auth/auth_repository.dart
+++ b/apps/mobile/lib/src/features/auth/auth_repository.dart
@@ -31,7 +31,7 @@ class AuthRepository {
     try {
       final raw = await apiClient.get('/me/profile');
       if (raw is! Map<String, dynamic>) {
-        throw ApiException('프로필 응답 형식이 올바르지 않습니다.');
+        throw ApiException('Profile response is invalid.');
       }
       return _toSessionProfile(raw);
     } on ApiException catch (e) {
@@ -66,7 +66,7 @@ class AuthRepository {
     final profile = await fetchProfile();
     if (profile == null) {
       await tokenStorage.clear();
-      throw ApiException('로그인 후 프로필 조회에 실패했습니다.');
+      throw ApiException('Login response is not usable.');
     }
     return profile;
   }
@@ -95,7 +95,34 @@ class AuthRepository {
     final profile = await fetchProfile();
     if (profile == null) {
       await tokenStorage.clear();
-      throw ApiException('Dev 로그인 후 프로필 조회에 실패했습니다.');
+      throw ApiException('Login response is not usable.');
+    }
+    return profile;
+  }
+
+  Future<SessionProfile> loginWithAdmin({
+    required String loginId,
+    required String password,
+  }) async {
+    final raw = await apiClient.post(
+      '/auth/admin/login',
+      includeAuth: false,
+      body: {
+        'loginId': loginId,
+        'password': password,
+      },
+    );
+
+    final tokens = _extractTokens(raw);
+    await tokenStorage.saveTokens(
+      accessToken: tokens.$1,
+      refreshToken: tokens.$2,
+    );
+
+    final profile = await fetchProfile();
+    if (profile == null) {
+      await tokenStorage.clear();
+      throw ApiException('Login response is not usable.');
     }
     return profile;
   }
@@ -110,7 +137,7 @@ class AuthRepository {
           body: {'refreshToken': refreshToken},
         );
       } on ApiException {
-        // 토큰 만료/폐기 상태에서도 로컬 세션 정리는 계속 진행한다.
+        // ignore logout failures to ensure local tokens are cleared
       }
     }
     await tokenStorage.clear();
@@ -127,7 +154,7 @@ class AuthRepository {
         userId.isEmpty ||
         roleText == null ||
         roleText.isEmpty) {
-      throw ApiException('프로필 응답에 필수 값이 없습니다.');
+      throw ApiException('Profile response is invalid.');
     }
 
     final role = roleText == 'ADMIN' ? UserRole.admin : UserRole.user;
@@ -140,7 +167,7 @@ class AuthRepository {
 
   (String, String) _extractTokens(Object? raw) {
     if (raw is! Map<String, dynamic>) {
-      throw ApiException('토큰 응답 형식이 올바르지 않습니다.');
+      throw ApiException('API response is invalid.');
     }
 
     final accessToken = raw['accessToken']?.toString();
@@ -149,7 +176,7 @@ class AuthRepository {
         accessToken.isEmpty ||
         refreshToken == null ||
         refreshToken.isEmpty) {
-      throw ApiException('토큰 응답에 필수 값이 없습니다.');
+      throw ApiException('API response has invalid token data.');
     }
 
     return (accessToken, refreshToken);

--- a/apps/mobile/lib/src/features/auth/login_page.dart
+++ b/apps/mobile/lib/src/features/auth/login_page.dart
@@ -1,20 +1,22 @@
 import 'package:flutter/material.dart';
-import 'package:uuid/uuid.dart';
 
 import '../../core/config/app_config.dart';
 import '../../core/network/api_exception.dart';
 import 'auth_repository.dart';
+import 'sign_up_page.dart';
 import 'social_sdk_service.dart';
 
 class LoginPage extends StatefulWidget {
   final AuthRepository authRepository;
   final SocialSdkService socialSdkService;
   final Future<void> Function(SessionProfile profile) onLoggedIn;
+  final String? initialError;
 
   const LoginPage({
     super.key,
     required this.authRepository,
     required this.socialSdkService,
+    this.initialError,
     required this.onLoggedIn,
   });
 
@@ -24,35 +26,41 @@ class LoginPage extends StatefulWidget {
 
 class _LoginPageState extends State<LoginPage> {
   final _inviteCodeController = TextEditingController();
-  final _displayNameController = TextEditingController(text: '테스트 사용자');
+  final _accountIdController = TextEditingController();
+  final _accountPasswordController = TextEditingController();
 
-  UserRole _devRole = UserRole.user;
   bool _loading = false;
-  bool _showDevLogin = false;
+  bool _showAccountLogin = false;
   String? _error;
+
+  bool get _hasKakaoKey => AppConfig.kakaoNativeAppKey.trim().isNotEmpty;
+
+  String get _normalizedInviteCode =>
+      _inviteCodeController.text.trim().toUpperCase();
+
+  String? _validateInviteCode() {
+    final inviteCode = _normalizedInviteCode;
+    if (inviteCode.isEmpty) {
+      return '초대 코드를 입력해 주세요.';
+    }
+    return null;
+  }
 
   @override
   void dispose() {
     _inviteCodeController.dispose();
-    _displayNameController.dispose();
+    _accountIdController.dispose();
+    _accountPasswordController.dispose();
     super.dispose();
   }
 
-  Future<void> _handleKakaoLogin() async {
+  Future<void> _runWithLoading(Future<void> Function() action) async {
     setState(() {
       _loading = true;
       _error = null;
     });
-
     try {
-      final token = await widget.socialSdkService.fetchToken();
-      final profile = await widget.authRepository.loginWithSocial(
-        token: token,
-        inviteCode: _inviteCodeController.text.trim().isEmpty
-            ? null
-            : _inviteCodeController.text.trim(),
-      );
-      await widget.onLoggedIn(profile);
+      await action();
     } on ApiException catch (e) {
       if (!mounted) {
         return;
@@ -65,7 +73,7 @@ class _LoginPageState extends State<LoginPage> {
         return;
       }
       setState(() {
-        _error = '카카오 로그인에 실패했습니다. 잠시 후 다시 시도해 주세요.';
+        _error = '작업 중 오류가 발생했습니다. 다시 시도해 주세요.';
       });
     } finally {
       if (mounted) {
@@ -76,51 +84,82 @@ class _LoginPageState extends State<LoginPage> {
     }
   }
 
-  Future<void> _handleDevLogin() async {
-    if (_displayNameController.text.trim().isEmpty) {
+  Future<void> _handleKakaoLogin() async {
+    final inviteCodeError = _validateInviteCode();
+    if (inviteCodeError != null) {
       setState(() {
-        _error = '이름을 입력해 주세요.';
+        _error = inviteCodeError;
       });
       return;
     }
 
-    setState(() {
-      _loading = true;
-      _error = null;
-    });
+    await _runWithLoading(() async {
+      if (!_hasKakaoKey) {
+        throw ApiException(
+          'KAKAO_NATIVE_APP_KEY가 비어 있습니다. 앱 실행 시 '
+          '--dart-define=KAKAO_NATIVE_APP_KEY=... 로 키를 전달해야 합니다.',
+        );
+      }
 
-    try {
-      final profile = await widget.authRepository.loginWithDev(
-        displayName: _displayNameController.text.trim(),
-        userId: const Uuid().v4(),
-        role: _devRole,
+      final token = await widget.socialSdkService.fetchToken();
+      final profile = await widget.authRepository.loginWithSocial(
+        token: token,
+        inviteCode: _normalizedInviteCode,
       );
       await widget.onLoggedIn(profile);
-    } on ApiException catch (e) {
-      if (!mounted) {
-        return;
-      }
+    });
+  }
+
+  Future<void> _handleAccountLogin() async {
+    final inviteCodeError = _validateInviteCode();
+    if (inviteCodeError != null) {
       setState(() {
-        _error = e.message;
+        _error = inviteCodeError;
       });
-    } catch (_) {
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _error = '개발용 로그인에 실패했습니다.';
-      });
-    } finally {
-      if (mounted) {
-        setState(() {
-          _loading = false;
-        });
-      }
+      return;
     }
+
+    final loginId = _accountIdController.text.trim();
+    final password = _accountPasswordController.text;
+    if (loginId.isEmpty || password.isEmpty) {
+      setState(() {
+        _error = '아이디와 비밀번호를 모두 입력해 주세요.';
+      });
+      return;
+    }
+
+    if (!_isValidUuid(loginId)) {
+      setState(() {
+        _error = '현재는 DB에 저장된 사용자 ID(UUID) 형식만 사용 가능합니다.';
+      });
+      return;
+    }
+
+    await _runWithLoading(() async {
+      final profile = await widget.authRepository.loginWithDev(
+        displayName: loginId,
+        userId: loginId,
+        role: UserRole.user,
+      );
+      await widget.onLoggedIn(profile);
+    });
+  }
+
+  bool _isValidUuid(String value) {
+    return RegExp(r'^[0-9a-fA-F-]{36}$').hasMatch(value);
+  }
+
+  Future<void> _openSignUp() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => const SignUpPage(),
+      ),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
+    final visibleError = _error ?? widget.initialError;
     return Scaffold(
       backgroundColor: const Color(0xFFF6F7F9),
       body: SafeArea(
@@ -144,7 +183,7 @@ class _LoginPageState extends State<LoginPage> {
                         crossAxisAlignment: CrossAxisAlignment.stretch,
                         children: [
                           const Text(
-                            '카카오 로그인',
+                            '로그인',
                             style: TextStyle(
                               fontSize: 18,
                               fontWeight: FontWeight.w700,
@@ -152,35 +191,63 @@ class _LoginPageState extends State<LoginPage> {
                           ),
                           const SizedBox(height: 6),
                           const Text(
-                            '한 번만 로그인하면 자동으로 유지됩니다.',
+                            '초대 코드를 입력한 뒤 로그인 방법을 선택해 주세요.',
                             style: TextStyle(color: Color(0xFF5B6572)),
                           ),
                           const SizedBox(height: 14),
                           TextField(
                             controller: _inviteCodeController,
                             enabled: !_loading,
-                            decoration: InputDecoration(
-                              labelText: '초대 코드 (최초 1회)',
-                              hintText: '코드가 없다면 비워두세요',
+                            decoration: const InputDecoration(
+                              labelText: '초대 코드',
+                              hintText: '예: ABC123',
                               filled: true,
-                              fillColor: const Color(0xFFF9FAFB),
+                              fillColor: Color(0xFFF9FAFB),
                               border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(12),
+                                borderRadius: BorderRadius.all(
+                                  Radius.circular(12),
+                                ),
                                 borderSide: BorderSide.none,
                               ),
                             ),
                           ),
-                          const SizedBox(height: 14),
-                          _SocialLoginButton(
+                          const SizedBox(height: 12),
+                          _ActionButton(
                             onPressed: _loading ? null : _handleKakaoLogin,
-                            label: _loading ? '로그인 중...' : '카카오로 시작하기',
+                            label: _loading ? '처리 중...' : '카카오로 시작하기',
                             icon: const Icon(Icons.chat_bubble_rounded),
+                            background: const Color(0xFFFEE500),
+                            foreground: Colors.black87,
                           ),
+                          const SizedBox(height: 10),
+                          _ActionButton(
+                            onPressed: _loading
+                                ? null
+                                : () => setState(() {
+                                      _showAccountLogin = !_showAccountLogin;
+                                    }),
+                            label: _showAccountLogin
+                                ? '계정 시작 닫기'
+                                : '아이디/비밀번호로 시작하기',
+                            icon: const Icon(Icons.lock_outline),
+                            background: Colors.white,
+                            foreground: const Color(0xFF111827),
+                            border: const Color(0xFFE5E7EB),
+                          ),
+                          if (!_hasKakaoKey && !_loading)
+                            const Padding(
+                              padding: EdgeInsets.only(top: 10),
+                              child: Text(
+                                '카카오 앱키가 없어서 카카오 로그인은 비활성화됩니다.',
+                                style:
+                                    TextStyle(fontSize: 12, color: Colors.red),
+                              ),
+                            ),
                         ],
                       ),
                     ),
                   ),
-                  if (_error != null) ...[
+                  if (visibleError != null) ...[
                     const SizedBox(height: 10),
                     Container(
                       decoration: BoxDecoration(
@@ -193,7 +260,7 @@ class _LoginPageState extends State<LoginPage> {
                         vertical: 10,
                       ),
                       child: Text(
-                        _error!,
+                        visibleError,
                         style: const TextStyle(
                           color: Color(0xFFC2291E),
                           fontWeight: FontWeight.w500,
@@ -201,34 +268,67 @@ class _LoginPageState extends State<LoginPage> {
                       ),
                     ),
                   ],
-                  if (AppConfig.enableDevLogin) ...[
+                  if (_showAccountLogin) ...[
                     const SizedBox(height: 10),
-                    OutlinedButton.icon(
-                      onPressed: _loading
-                          ? null
-                          : () {
-                              setState(() {
-                                _showDevLogin = !_showDevLogin;
-                              });
-                            },
-                      icon: Icon(
-                        _showDevLogin ? Icons.expand_less : Icons.expand_more,
+                    Card(
+                      margin: EdgeInsets.zero,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(16),
                       ),
-                      label: const Text('개발용 로그인'),
+                      child: Padding(
+                        padding: const EdgeInsets.all(14),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            TextField(
+                              controller: _accountIdController,
+                              enabled: !_loading,
+                              decoration: const InputDecoration(
+                                labelText: '아이디',
+                                border: OutlineInputBorder(),
+                              ),
+                            ),
+                            const SizedBox(height: 10),
+                            TextField(
+                              controller: _accountPasswordController,
+                              enabled: !_loading,
+                              obscureText: true,
+                              decoration: const InputDecoration(
+                                labelText: '비밀번호',
+                                border: OutlineInputBorder(),
+                              ),
+                            ),
+                            const SizedBox(height: 12),
+                            SizedBox(
+                              height: 48,
+                              child: FilledButton(
+                                onPressed:
+                                    _loading ? null : _handleAccountLogin,
+                                child: Text(
+                                  _loading ? '처리 중...' : '로그인',
+                                ),
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            SizedBox(
+                              height: 48,
+                              child: OutlinedButton(
+                                onPressed: _loading ? null : _openSignUp,
+                                child: const Text('회원가입'),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
                     ),
-                    if (_showDevLogin)
-                      _DevLoginPanel(
-                        loading: _loading,
-                        displayNameController: _displayNameController,
-                        role: _devRole,
-                        onRoleChanged: (nextRole) {
-                          setState(() {
-                            _devRole = nextRole;
-                          });
-                        },
-                        onSubmit: _handleDevLogin,
-                      ),
                   ],
+                  const SizedBox(height: 30),
+                  const Center(
+                    child: Text(
+                      '회원/교회 정보는 첫 사용 시에만 입력합니다.',
+                      style: TextStyle(color: Color(0xFF6B7280), fontSize: 12),
+                    ),
+                  ),
                 ],
               ),
             ),
@@ -263,7 +363,7 @@ class _LoginHero extends StatelessWidget {
         ),
         const SizedBox(height: 4),
         const Text(
-          '모바일에서 빠르게 찬양 악보를 확인하세요.',
+          '초대 코드를 입력하고 바로 시작하세요.',
           style: TextStyle(color: Color(0xFF5B6572)),
         ),
       ],
@@ -271,15 +371,21 @@ class _LoginHero extends StatelessWidget {
   }
 }
 
-class _SocialLoginButton extends StatelessWidget {
+class _ActionButton extends StatelessWidget {
   final VoidCallback? onPressed;
   final String label;
   final Widget icon;
+  final Color background;
+  final Color foreground;
+  final Color border;
 
-  const _SocialLoginButton({
+  const _ActionButton({
     required this.onPressed,
     required this.label,
     required this.icon,
+    required this.background,
+    required this.foreground,
+    this.border = Colors.transparent,
   });
 
   @override
@@ -294,75 +400,13 @@ class _SocialLoginButton extends StatelessWidget {
           style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
         ),
         style: FilledButton.styleFrom(
-          backgroundColor: const Color(0xFFFEE500),
-          foregroundColor: Colors.black87,
+          backgroundColor: background,
+          foregroundColor: foreground,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),
           ),
-        ),
-      ),
-    );
-  }
-}
-
-class _DevLoginPanel extends StatelessWidget {
-  final bool loading;
-  final TextEditingController displayNameController;
-  final UserRole role;
-  final ValueChanged<UserRole> onRoleChanged;
-  final Future<void> Function() onSubmit;
-
-  const _DevLoginPanel({
-    required this.loading,
-    required this.displayNameController,
-    required this.role,
-    required this.onRoleChanged,
-    required this.onSubmit,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      margin: const EdgeInsets.only(top: 10),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: Padding(
-        padding: const EdgeInsets.all(14),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            TextField(
-              controller: displayNameController,
-              enabled: !loading,
-              decoration: const InputDecoration(
-                labelText: '이름',
-                border: OutlineInputBorder(),
-              ),
-            ),
-            const SizedBox(height: 10),
-            DropdownButtonFormField<UserRole>(
-              initialValue: role,
-              decoration: const InputDecoration(
-                labelText: '권한',
-                border: OutlineInputBorder(),
-              ),
-              items: const [
-                DropdownMenuItem(value: UserRole.user, child: Text('일반 사용자')),
-                DropdownMenuItem(value: UserRole.admin, child: Text('관리자')),
-              ],
-              onChanged: loading
-                  ? null
-                  : (value) {
-                      if (value != null) {
-                        onRoleChanged(value);
-                      }
-                    },
-            ),
-            const SizedBox(height: 10),
-            FilledButton.tonal(
-              onPressed: loading ? null : () => onSubmit(),
-              child: Text(loading ? '처리 중...' : '개발용 로그인'),
-            ),
-          ],
+          side: border == Colors.transparent ? null : BorderSide(color: border),
+          textStyle: const TextStyle(fontWeight: FontWeight.w600),
         ),
       ),
     );

--- a/apps/mobile/lib/src/features/auth/onboarding_page.dart
+++ b/apps/mobile/lib/src/features/auth/onboarding_page.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+
+import '../../core/storage/onboarding_storage.dart';
+
+class OnboardingPage extends StatefulWidget {
+  final String userId;
+  final OnboardingStorage onboardingStorage;
+  final Future<void> Function() onCompleted;
+
+  const OnboardingPage({
+    super.key,
+    required this.userId,
+    required this.onboardingStorage,
+    required this.onCompleted,
+  });
+
+  @override
+  State<OnboardingPage> createState() => _OnboardingPageState();
+}
+
+class _OnboardingPageState extends State<OnboardingPage> {
+  final _churchController = TextEditingController();
+  final _nameController = TextEditingController();
+  final _groupController = TextEditingController();
+
+  String? _error;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadProfile();
+  }
+
+  @override
+  void dispose() {
+    _churchController.dispose();
+    _nameController.dispose();
+    _groupController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadProfile() async {
+    final profile = await widget.onboardingStorage.getProfile(widget.userId);
+    if (!mounted || profile == null) {
+      return;
+    }
+
+    setState(() {
+      _churchController.text = profile.churchName;
+      _nameController.text = profile.name;
+      _groupController.text = profile.group;
+    });
+  }
+
+  Future<void> _handleSubmit() async {
+    final churchName = _churchController.text.trim();
+    final name = _nameController.text.trim();
+    final group = _groupController.text.trim();
+
+    if (churchName.isEmpty || name.isEmpty || group.isEmpty) {
+      setState(() {
+        _error = '모든 항목을 입력해 주세요.';
+      });
+      return;
+    }
+
+    setState(() {
+      _saving = true;
+      _error = null;
+    });
+
+    try {
+      await widget.onboardingStorage.saveProfile(
+        userId: widget.userId,
+        churchName: churchName,
+        name: name,
+        group: group,
+      );
+      await widget.onCompleted();
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = '입력값 저장 중 문제가 발생했습니다. 다시 시도해 주세요.';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _saving = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF6F7F9),
+      appBar: AppBar(title: const Text('회원 정보 입력')),
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(20),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 480),
+              child: Card(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 20, 16, 20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      const Text(
+                        '교회 / 구역 / 이름을 입력해 주세요.',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      const Text(
+                        '초대 코드 검증이 완료되면 앱 이용이 가능합니다.',
+                        style: TextStyle(color: Color(0xFF5B6572)),
+                      ),
+                      const SizedBox(height: 16),
+                      TextField(
+                        controller: _churchController,
+                        enabled: !_saving,
+                        decoration: const InputDecoration(
+                          labelText: '교회',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: _nameController,
+                        enabled: !_saving,
+                        decoration: const InputDecoration(
+                          labelText: '이름',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: _groupController,
+                        enabled: !_saving,
+                        decoration: const InputDecoration(
+                          labelText: '구역',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      SizedBox(
+                        height: 52,
+                        child: FilledButton(
+                          onPressed: _saving ? null : _handleSubmit,
+                          child: Text(_saving ? '처리 중...' : '완료'),
+                        ),
+                      ),
+                      if (_error != null) ...[
+                        const SizedBox(height: 10),
+                        Text(
+                          _error!,
+                          style: const TextStyle(
+                            color: Color(0xFFC2291E),
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/src/features/auth/sign_up_page.dart
+++ b/apps/mobile/lib/src/features/auth/sign_up_page.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+
+class SignUpPage extends StatefulWidget {
+  const SignUpPage({super.key});
+
+  @override
+  State<SignUpPage> createState() => _SignUpPageState();
+}
+
+class _SignUpPageState extends State<SignUpPage> {
+  final _loginIdController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+
+  String? _error;
+  bool _submitting = false;
+
+  @override
+  void dispose() {
+    _loginIdController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleSubmit() async {
+    final loginId = _loginIdController.text.trim();
+    final password = _passwordController.text;
+    final confirm = _confirmPasswordController.text;
+
+    if (loginId.isEmpty || password.isEmpty || confirm.isEmpty) {
+      setState(() {
+        _error = '아이디와 비밀번호를 입력해 주세요.';
+      });
+      return;
+    }
+
+    if (password != confirm) {
+      setState(() {
+        _error = '비밀번호가 일치하지 않습니다.';
+      });
+      return;
+    }
+
+    setState(() {
+      _submitting = true;
+      _error = null;
+    });
+
+    try {
+      await Future.delayed(const Duration(milliseconds: 300));
+      if (!mounted) {
+        return;
+      }
+      await showDialog<void>(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text('알림'),
+          content: const Text('현재 회원가입은 준비 중입니다.'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('확인'),
+            ),
+          ],
+        ),
+      );
+      if (!mounted) {
+        return;
+      }
+      Navigator.of(context).pop();
+    } finally {
+      if (mounted) {
+        setState(() {
+          _submitting = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('회원가입')),
+      backgroundColor: const Color(0xFFF6F7F9),
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(20),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 480),
+              child: Card(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 20, 16, 20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      const Text(
+                        '회원가입',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      const Text(
+                        '요청하신 계정 생성 API가 준비되면 바로 연결됩니다.',
+                        style: TextStyle(color: Color(0xFF5B6572)),
+                      ),
+                      const SizedBox(height: 16),
+                      TextField(
+                        controller: _loginIdController,
+                        enabled: !_submitting,
+                        decoration: const InputDecoration(
+                          labelText: '아이디',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: _passwordController,
+                        enabled: !_submitting,
+                        obscureText: true,
+                        decoration: const InputDecoration(
+                          labelText: '비밀번호',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      TextField(
+                        controller: _confirmPasswordController,
+                        enabled: !_submitting,
+                        obscureText: true,
+                        decoration: const InputDecoration(
+                          labelText: '비밀번호 확인',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                      if (_error != null) ...[
+                        const SizedBox(height: 10),
+                        Text(
+                          _error!,
+                          style: const TextStyle(
+                            color: Color(0xFFC2291E),
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                      const SizedBox(height: 16),
+                      SizedBox(
+                        height: 52,
+                        child: FilledButton(
+                          onPressed: _submitting ? null : _handleSubmit,
+                          child:
+                              Text(_submitting ? '처리 중...' : '회원가입 하기'),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/docs/TEAM_LOCAL_DEVELOPMENT.md
+++ b/docs/TEAM_LOCAL_DEVELOPMENT.md
@@ -1,0 +1,166 @@
+﻿# Local Android Test Runbook
+
+This guide is the minimal reproducible flow for setting up local verification on a new machine.
+
+## 0) One-command local bootstrap
+
+```powershell
+.\scripts\local-bootstrap.ps1
+```
+
+This runs:
+
+- env file bootstrap (`.env`, `apps/mobile/.env`)
+- optional kakao key sync from root/mobile env
+- `local-verify.ps1`
+- printed test summary (`.tmp/local-smoke-summary.json`)
+
+## 1) Setup
+```bash
+git clone <repo-url>
+git switch develop
+```
+
+Requirements:
+- Docker Desktop
+- Java 17
+- Node.js + npm
+- Git
+- Android Studio + Emulator
+
+## 2) Env files
+```bash
+cd Eunhye_Hymn
+copy .env.example .env
+```
+
+Create `apps/mobile/.env` (minimum) from template:
+```bash
+copy apps/mobile\.env.example apps/mobile\.env
+```
+
+Then set:
+```env
+API_BASE_URL=http://10.0.2.2:8080/api/v1
+KAKAO_NATIVE_APP_KEY=<your_kakao_native_app_key>
+```
+
+Important keys in `.env`:
+- `POSTGRES_DB`, `DB_USER`, `DB_PASS`
+- `JWT_SECRET`
+- `INVITE_CODE` (for fallback local invite)
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
+- `ADMIN_LOGIN_ID`, `ADMIN_LOGIN_PASSWORD`
+
+`local-verify.ps1` will fill missing `ADMIN_*` and AWS keys automatically when run.
+
+## 3) Start local stack
+```bash
+docker compose --env-file .env -f infra/docker/docker-compose.yml up -d
+```
+
+Check API health:
+```bash
+curl http://localhost:8080/api/v1/ping
+```
+
+## 4) Run local smoke checks
+```bash
+.\scripts\local-verify.ps1
+```
+
+If the stack is already running, use:
+```bash
+.\scripts\local-verify.ps1 -SkipDockerUp
+```
+
+Checks performed:
+- `/ping`
+- admin login
+- invite create + validate (case/space normalization)
+- hymn create + signed upload + asset confirm
+- DB user create + `/auth/dev/login`
+- asset URL reachability
+- summary output: `.tmp/local-smoke-summary.json` (`inviteCode`, `dbUserId`, `hymnId`, `assetUrl`)
+
+If this passes, you can use the printed Invite Code and DB User ID for UI checks.
+`local-bootstrap.ps1` is the preferred flow from a new machine.
+
+## 5) Admin page on local
+```bash
+cd apps/admin
+npm install
+npm run dev
+```
+
+Open: `http://localhost:5173`
+
+Use `ADMIN_LOGIN_ID / ADMIN_LOGIN_PASSWORD` from `.env`.
+
+> Note: local DB is separate from staging. Staging invite codes are not valid in local DB.
+- If you ever copied invite codes from staging, they will not be valid in local env.
+
+## 6) Run mobile (Android emulator)
+```bash
+.\scripts\run-mobile-emulator.ps1 -DeviceId emulator-5554
+```
+
+Flow in app:
+- Enter invite code then tap `카카오로 시작하기` for Kakao
+- Or tap `아이디/비밀번호로 시작하기` for DB user login check
+- Use DB user ID printed by `local-verify.ps1` for the ID field
+
+## 7) Useful DB checks
+```bash
+docker exec -it eunhye-postgres psql -U postgres -d eunhye_hymn -c "\dt"
+
+docker exec -it eunhye-postgres psql -U postgres -d eunhye_hymn -c "SELECT id,role,status,created_at FROM users ORDER BY created_at DESC LIMIT 20;"
+
+docker exec -it eunhye-postgres psql -U postgres -d eunhye_hymn -c "SELECT code,enabled,used_count,max_uses,expires_at FROM invite_codes ORDER BY created_at DESC LIMIT 20;"
+```
+
+## 8) Stop local stack
+```bash
+docker compose --env-file .env -f infra/docker/docker-compose.yml down
+# keep data but clear all (optional):
+# docker compose --env-file .env -f infra/docker/docker-compose.yml down -v
+```
+
+## 9) Cost note
+- Local stack (PostgreSQL + LocalStack + API) does not add AWS charge by itself.
+- Any calls to staging or real AWS resources follow staging billing policies.
+- For Android Emulator asset access, set in `.env` before restart:
+  `S3_PUBLIC_BASE_URL=http://10.0.2.2:4566/local-bucket`
+
+## 10) Fast check list
+- [ ] `docker compose up` running
+- [ ] `/ping` returns OK
+- [ ] `local-verify` passes
+- [ ] admin can create invite in `admin`
+- [ ] app accepts invite code
+- [ ] user login and hymn detail asset load are visible
+
+## 11) 다른 컴퓨터 재동기화 루틴(가장 빠른)
+
+1. 새 PC에서 저장소만 `git pull`로 갱신
+2. 한 번만 실행:
+   ```powershell
+   Copy-Item .env.example .env
+   Copy-Item apps/mobile/.env.example apps/mobile/.env
+   # KAKAO 키 직접 반영 (실제 키로 한 번만 교체)
+   (Get-Content apps/mobile/.env) -replace '^KAKAO_NATIVE_APP_KEY=.*$', 'KAKAO_NATIVE_APP_KEY=<your_kakao_native_app_key>' | Set-Content apps/mobile/.env
+   ```
+3. 한 번에 로컬 환경 점검:
+   ```powershell
+   .\scripts\local-bootstrap.ps1
+   ```
+4. 터미널에 출력되는 `Invite Code`를 앱의 초대 코드 입력창에 붙여 넣고 테스트
+5. 테스트 후 종료:
+   ```powershell
+   docker compose --env-file .env -f infra/docker/docker-compose.yml down
+   ```
+
+### 왜 스테이징 코드는 로컬에서 안 맞는가
+
+- 스테이징과 로컬 DB는 별도 입니다. 스테이징에서 발급한 초대코드를 로컬 DB로 가져오지 않습니다.
+- 로컬 검증은 `local-bootstrap.ps1`가 매번 로컬 DB에 새 초대코드를 만들고 바로 확인합니다.

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   # ── PostgreSQL 15 ────────────────────────────────────────────
   postgres:
@@ -88,6 +86,10 @@ services:
       S3_ENDPOINT: http://localstack:4566
       S3_PUBLIC_BASE_URL: http://localhost:4566/${S3_BUCKET:-local-bucket}
       S3_PRESIGN_EXPIRES_MINUTES: ${S3_PRESIGN_EXPIRES_MINUTES:-15}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-test}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-test}
+      ADMIN_LOGIN_ID: ${ADMIN_LOGIN_ID:-local_admin}
+      ADMIN_LOGIN_PASSWORD: ${ADMIN_LOGIN_PASSWORD:-local_admin_2026!}
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
     networks:
       - eunhye-net

--- a/infra/docker/init-s3.sh
+++ b/infra/docker/init-s3.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ==============================================================
-# init-s3.sh — Create S3 bucket in LocalStack (idempotent)
+# init-s3.sh - Create S3 bucket in LocalStack (idempotent)
 # ==============================================================
 set -euo pipefail
 

--- a/scripts/local-bootstrap.ps1
+++ b/scripts/local-bootstrap.ps1
@@ -1,0 +1,159 @@
+param(
+    [string] $ComposeFile = "infra/docker/docker-compose.yml",
+    [string] $SummaryFile = ".tmp/local-smoke-summary.json",
+    [string] $KakaoNativeAppKey = "",
+    [string] $DeviceId = "",
+    [switch] $SkipDockerUp,
+    [switch] $SkipMobileEnv
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$envPath = Join-Path $repoRoot ".env"
+$envExample = Join-Path $repoRoot ".env.example"
+$mobileEnvPath = Join-Path $repoRoot "apps/mobile/.env"
+$mobileEnvExample = Join-Path $repoRoot "apps/mobile/.env.example"
+$localVerify = Join-Path $repoRoot "scripts/local-verify.ps1"
+$runMobile = Join-Path $repoRoot "scripts/run-mobile-emulator.ps1"
+$localSummaryPath = Join-Path $repoRoot $SummaryFile
+
+function Set-EnvValue {
+    param(
+        [Parameter(Mandatory = $true)] [string] $Path,
+        [Parameter(Mandatory = $true)] [string] $Key,
+        [Parameter(Mandatory = $true)] [string] $Value
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return
+    }
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $updated = $false
+    $found = $false
+
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        if ($line -match "^\s*$([regex]::Escape($Key))\s*=.*$") {
+            if (-not $found) {
+                $found = $true
+                $lines.Add("$Key=$Value")
+                $updated = $true
+            }
+        } else {
+            $lines.Add($line)
+        }
+    }
+
+    if (-not $found) {
+        $lines.Add("$Key=$Value")
+        $updated = $true
+    }
+
+    if ($updated) {
+        Set-Content -LiteralPath $Path -Value $lines -Encoding utf8
+    }
+}
+
+function Get-EnvValue {
+    param(
+        [Parameter(Mandatory = $true)] [string] $Path,
+        [Parameter(Mandatory = $true)] [string] $Key
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $null
+    }
+
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        $trimmed = $line.Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed) -or $trimmed.StartsWith("#")) {
+            continue
+        }
+        if ($trimmed -match '^\s*' + [regex]::Escape($Key) + '\s*=\s*(.*)\s*$') {
+            return $matches[1]
+        }
+    }
+    return $null
+}
+
+function Resolve-KakaoKey {
+    $mobile = Get-EnvValue -Path $mobileEnvPath -Key "KAKAO_NATIVE_APP_KEY"
+    if (-not [string]::IsNullOrWhiteSpace($mobile)) {
+        return $mobile
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($KakaoNativeAppKey)) {
+        return $KakaoNativeAppKey
+    }
+
+    $root = Get-EnvValue -Path $envPath -Key "KAKAO_NATIVE_APP_KEY"
+    if (-not [string]::IsNullOrWhiteSpace($root)) {
+        return $root
+    }
+
+    return $null
+}
+
+Write-Host "== Local bootstrap =="
+
+if (-not (Test-Path -LiteralPath $envPath)) {
+    if (-not (Test-Path -LiteralPath $envExample)) {
+        throw ".env.example not found."
+    }
+    Copy-Item -Path $envExample -Destination $envPath
+    Write-Host "[OK] Created .env from .env.example"
+}
+
+if (-not $SkipMobileEnv -and -not (Test-Path -LiteralPath $mobileEnvPath)) {
+    if (Test-Path -LiteralPath $mobileEnvExample) {
+        Copy-Item -Path $mobileEnvExample -Destination $mobileEnvPath
+        Write-Host "[OK] Created apps/mobile/.env from apps/mobile/.env.example"
+    } else {
+        throw "apps/mobile/.env.example not found."
+    }
+}
+
+$mobileApiBase = Get-EnvValue -Path $mobileEnvPath -Key "API_BASE_URL"
+if ([string]::IsNullOrWhiteSpace($mobileApiBase)) {
+    Set-EnvValue -Path $mobileEnvPath -Key "API_BASE_URL" -Value "http://10.0.2.2:8080/api/v1"
+}
+
+$resolvedKakaoKey = Resolve-KakaoKey
+if (-not [string]::IsNullOrWhiteSpace($resolvedKakaoKey)) {
+    Set-EnvValue -Path $mobileEnvPath -Key "KAKAO_NATIVE_APP_KEY" -Value $resolvedKakaoKey
+    Set-EnvValue -Path $envPath -Key "KAKAO_NATIVE_APP_KEY" -Value $resolvedKakaoKey
+} else {
+    Write-Host "[WARN] KAKAO_NATIVE_APP_KEY is not set. Set it in .env, apps/mobile/.env, or with -KakaoNativeAppKey before running mobile."
+}
+
+Write-Host "[OK] Environment prepared"
+
+Write-Host "`n== API & DB smoke check =="
+& (Resolve-Path $localVerify) -ComposeFile $ComposeFile -ApiBaseUrl "http://localhost:8080/api/v1" -SummaryFile $SummaryFile -SkipDockerUp:$SkipDockerUp -KeepGeneratedFiles
+
+if (Test-Path -LiteralPath $localSummaryPath) {
+    try {
+        $summary = Get-Content -LiteralPath $localSummaryPath -Raw | ConvertFrom-Json
+        Write-Host "`n== Local test data =="
+        Write-Host ("Invite   : {0}" -f $summary.inviteCode)
+        Write-Host ("DB User  : {0}" -f $summary.dbUserId)
+        Write-Host ("Hymn ID : {0}" -f $summary.hymnId)
+        Write-Host ("Asset   : {0}" -f $summary.assetUrl)
+        Write-Host ("Summary : {0}" -f $localSummaryPath)
+        Write-Host ("Generated: {0}" -f $summary.generatedAt)
+    } catch {
+        Write-Host "[WARN] Could not parse local smoke summary JSON: $localSummaryPath"
+    }
+}
+
+Write-Host "`n== Next step =="
+Write-Host "Local API URL: http://localhost:8080/api/v1"
+Write-Host "Admin URL: http://localhost:5173"
+Write-Host "Mobile run command:"
+Write-Host "  .\scripts\run-mobile-emulator.ps1 -DeviceId emulator-5554"
+
+if (-not [string]::IsNullOrWhiteSpace($DeviceId)) {
+    Write-Host "`nIf you want me to launch emulator now, run:"
+    Write-Host "  .\scripts\run-mobile-emulator.ps1 -DeviceId $DeviceId"
+}

--- a/scripts/local-verify.ps1
+++ b/scripts/local-verify.ps1
@@ -1,0 +1,414 @@
+param(
+    [string] $ComposeFile = "infra/docker/docker-compose.yml",
+    [string] $ApiBaseUrl = "http://localhost:8080/api/v1",
+    [string] $AdminLoginId = "local_admin",
+    [string] $AdminLoginPassword = "local_admin_2026!",
+    [string] $InviteCode = "",
+    [int] $InviteMaxUses = 20,
+    [int] $ApiTimeoutSeconds = 90,
+    [string] $AwsAccessKeyId = "test",
+    [string] $AwsSecretAccessKey = "test",
+    [switch] $SkipDockerUp,
+    [switch] $KeepGeneratedFiles,
+    [string] $SummaryFile
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$envPath = Join-Path $repoRoot ".env"
+$composeFilePath = Join-Path $repoRoot $ComposeFile
+$script:ApiBaseUrl = $ApiBaseUrl.TrimEnd("/")
+
+if (-not (Test-Path -LiteralPath $composeFilePath)) {
+  throw "Compose file not found: $composeFilePath"
+}
+
+function Ensure-Command {
+  param([string] $Name)
+  if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+    throw "Required command not found: $Name"
+  }
+}
+
+function Write-Section {
+  param([string]$Text)
+  Write-Host ""
+  Write-Host "===== $Text =====" -ForegroundColor Cyan
+}
+
+function Write-Check {
+  param([bool] $Condition, [string] $Message, [bool] $WarnOnly = $false)
+  if ($Condition) {
+    Write-Host "[PASS] $Message" -ForegroundColor Green
+  } elseif ($WarnOnly) {
+    Write-Host "[WARN] $Message" -ForegroundColor Yellow
+  } else {
+    throw "[FAIL] $Message"
+  }
+}
+
+function Set-EnvValue {
+  param(
+    [Parameter(Mandatory = $true)] [string] $Path,
+    [Parameter(Mandatory = $true)] [string] $Key,
+    [Parameter(Mandatory = $true)] [string] $Value
+  )
+
+  if (-not (Test-Path -LiteralPath $Path)) {
+    return $false
+  }
+
+  $lines = [System.Collections.Generic.List[string]]::new()
+  $updated = $false
+  $existed = $false
+  $alreadyReplaced = $false
+  foreach ($line in Get-Content -LiteralPath $Path) {
+    if ($line -match "^\s*$([regex]::Escape($Key))\s*=.*$") {
+      if (-not $existed) {
+        $existed = $true
+      }
+      if (-not $alreadyReplaced) {
+        $lines.Add("$Key=$Value")
+        $alreadyReplaced = $true
+        $updated = $true
+      }
+    } else {
+      $lines.Add($line)
+    }
+  }
+
+  if (-not $existed) {
+    $lines.Add("$Key=$Value")
+    $updated = $true
+  }
+
+  Set-Content -LiteralPath $Path -Value $lines -Encoding utf8
+  return $updated
+}
+
+function Try-AssetUpload {
+  param(
+    [Parameter(Mandatory = $true)] [string] $PrimaryUrl,
+    [string] $FallbackPublicUrl,
+    [Parameter(Mandatory = $true)] [string] $FilePath,
+    [Parameter(Mandatory = $true)] [string] $ContentType
+  )
+
+  try {
+    $response = Invoke-WebRequest -Method Put -Uri $PrimaryUrl -InFile $FilePath -ContentType $ContentType
+    return $response
+  } catch {
+    $errorMessage = $_.Exception.Message
+    if ([string]::IsNullOrWhiteSpace($FallbackPublicUrl)) {
+      throw "Asset upload failed: $errorMessage"
+    }
+
+    try {
+      $primaryUri = [Uri]$PrimaryUrl
+      $publicUri = [Uri]$FallbackPublicUrl
+      if ($primaryUri.Host -ieq $publicUri.Host) {
+        throw $errorMessage
+      }
+
+      $fallbackBuilder = [System.UriBuilder]::new()
+      $fallbackBuilder.Scheme = $publicUri.Scheme
+      $fallbackBuilder.Host = $publicUri.Host
+      if ($publicUri.Port -ne -1) {
+        $fallbackBuilder.Port = $publicUri.Port
+      }
+      $fallbackBuilder.Path = $primaryUri.AbsolutePath
+      $fallbackBuilder.Query = $primaryUri.Query.TrimStart("?")
+
+      $fallbackUrl = $fallbackBuilder.Uri.ToString()
+      Write-Host " - Presigned upload host fallback: $($publicUri.Host):$($publicUri.Port)"
+      $response = Invoke-WebRequest -Method Put -Uri $fallbackUrl -InFile $FilePath -ContentType $ContentType
+      return $response
+    } catch {
+      throw "Asset upload failed: $errorMessage"
+    }
+  }
+}
+
+function Ensure-ValueInEnvFile {
+  param(
+    [string] $Path,
+    [string] $Key,
+    [string] $Value
+  )
+
+  if (Set-EnvValue -Path $Path -Key $Key -Value $Value) {
+    Write-Host "  - $Key updated in .env"
+  } else {
+    Write-Host "  - $Key already exists in .env"
+  }
+}
+
+function Invoke-EhApi {
+  param(
+    [string] $Method,
+    [string] $Path,
+    [object] $Body = $null,
+    [string] $Token = ""
+  )
+
+  $uri = "$script:ApiBaseUrl$Path"
+  $headers = @{}
+  if (-not [string]::IsNullOrWhiteSpace($Token)) {
+    $headers.Authorization = "Bearer $Token"
+  }
+
+  $request = @{
+    Uri        = $uri
+    Method     = $Method
+    Headers    = $headers
+    ErrorAction = "Stop"
+  }
+
+  if ($null -ne $Body) {
+    $request.ContentType = "application/json"
+    $request.Body = $Body | ConvertTo-Json -Depth 20
+  }
+
+  try {
+    $response = Invoke-RestMethod @request
+  } catch {
+    $exception = $_.Exception
+    $statusText = "unknown"
+    $payloadText = $null
+    $innerResponse = $null
+
+    if ($exception.Response) {
+      try {
+        if ($exception.Response.StatusCode -as [int]) {
+          $statusText = [int]$exception.Response.StatusCode
+        }
+      } catch {
+      }
+      try {
+        $stream = $exception.Response.GetResponseStream()
+        if ($stream) {
+          $reader = [System.IO.StreamReader]::new($stream)
+          $payloadText = $reader.ReadToEnd()
+          $reader.Dispose()
+          $stream.Dispose()
+        }
+      } catch {
+      }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($payloadText)) {
+      $payloadText = $exception.Message
+    }
+
+    $errorMessage = "API $Method $Path failed (HTTP $statusText): $payloadText"
+    throw $errorMessage
+  }
+
+  if ($null -eq $response.success) {
+    throw "Invalid API response for $Method ${Path}: missing success flag."
+  }
+  if (-not $response.success) {
+    $reason = $response.error.message
+    if ([string]::IsNullOrWhiteSpace($reason)) {
+      $reason = "unknown reason"
+    }
+    throw "API $Method ${Path} returned success=false: $reason"
+  }
+
+  return $response.data
+}
+
+function Wait-ApiReady {
+  param([int] $TimeoutSeconds = 90)
+  Write-Section "API readiness check"
+  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+
+  while ((Get-Date) -lt $deadline) {
+    try {
+      $ping = Invoke-EhApi -Method "GET" -Path "/ping"
+      if ($ping.ok -eq $true) {
+        Write-Host "[PASS] API ready: /ping"
+        return
+      }
+    } catch {
+      Start-Sleep -Seconds 1
+    }
+  }
+  throw "API is not ready within $TimeoutSeconds seconds. Check docker logs."
+}
+
+Write-Section "Initial checks"
+Ensure-Command "docker"
+Ensure-Command "Invoke-RestMethod"
+
+if (-not (Test-Path $envPath)) {
+  $example = Join-Path $repoRoot ".env.example"
+  if (-not (Test-Path -LiteralPath $example)) {
+    throw ".env is missing and .env.example is not found."
+  }
+  Copy-Item -Path $example -Destination $envPath
+  Write-Host "Created .env from .env.example"
+}
+
+Ensure-ValueInEnvFile -Path $envPath -Key "ADMIN_LOGIN_ID" -Value $AdminLoginId
+Ensure-ValueInEnvFile -Path $envPath -Key "ADMIN_LOGIN_PASSWORD" -Value $AdminLoginPassword
+Ensure-ValueInEnvFile -Path $envPath -Key "AWS_ACCESS_KEY_ID" -Value $AwsAccessKeyId
+Ensure-ValueInEnvFile -Path $envPath -Key "AWS_SECRET_ACCESS_KEY" -Value $AwsSecretAccessKey
+
+if (-not $SkipDockerUp) {
+  Write-Section "Start docker-compose"
+  docker compose --env-file $envPath -f $composeFilePath up -d --force-recreate
+}
+
+Wait-ApiReady -TimeoutSeconds $ApiTimeoutSeconds
+
+Write-Section "Admin auth"
+$adminLogin = Invoke-EhApi -Method "POST" -Path "/auth/admin/login" -Body @{
+  loginId = $AdminLoginId
+  password = $AdminLoginPassword
+}
+$adminToken = $adminLogin.accessToken
+Write-Check -Condition (-not [string]::IsNullOrWhiteSpace($adminToken)) "Admin login succeeded"
+
+$normalizedInvite = if ([string]::IsNullOrWhiteSpace($InviteCode)) {
+  "LOCAL-" + (Get-Date -Format "yyyyMMddHHmmss")
+} else {
+  $InviteCode.Trim().ToUpperInvariant()
+}
+
+Write-Section "Invite code"
+$inviteDesc = "Local smoke test " + (Get-Date -Format "yyyy-MM-dd HH:mm:ss")
+$createdInvite = Invoke-EhApi -Method "POST" -Path "/admin/invite-codes" -Token $adminToken -Body @{
+  code = $normalizedInvite
+  description = $inviteDesc
+  maxUses = $InviteMaxUses
+  expiresAt = $null
+}
+Write-Check -Condition ($createdInvite.code -eq $normalizedInvite) "Invite code created: $($createdInvite.code)"
+
+$validatedInvite = Invoke-EhApi -Method "POST" -Path "/auth/invite/validate" -Body @{
+  code = "  $($normalizedInvite.ToLowerInvariant())  "
+}
+Write-Check -Condition ($validatedInvite.valid -eq $true) "Invite code validation works with spaces/case-insensitive input"
+
+Write-Section "Create hymn + asset"
+$hymn = Invoke-EhApi -Method "POST" -Path "/admin/hymns" -Token $adminToken -Body @{
+  title = "Local Smoke Hymn"
+  number = "TST-001"
+  tags = "local,smoke"
+  enabled = $true
+}
+Write-Check -Condition (-not [string]::IsNullOrWhiteSpace($hymn.id)) "Hymn created: $($hymn.id)"
+
+$presign = Invoke-EhApi -Method "POST" -Path "/admin/assets/presign" -Token $adminToken -Body @{
+  hymnId = $hymn.id
+  type = "PNG"
+  part = "ALL"
+  filename = "local-smoke-png.png"
+  contentType = "image/png"
+}
+Write-Check -Condition (-not [string]::IsNullOrWhiteSpace($presign.uploadUrl)) "Asset presign issued"
+
+$tmpRoot = Join-Path $repoRoot ".tmp"
+if (-not (Test-Path $tmpRoot)) {
+  New-Item -ItemType Directory -Path $tmpRoot | Out-Null
+}
+$assetFile = Join-Path $tmpRoot "local-smoke-png.png"
+[IO.File]::WriteAllBytes(
+  $assetFile,
+  [byte[]](0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+)
+
+try {
+  $upload = Try-AssetUpload -PrimaryUrl $presign.uploadUrl -FallbackPublicUrl $presign.publicUrl -FilePath $assetFile -ContentType "image/png"
+  Write-Check -Condition ($upload.StatusCode -ge 200 -and $upload.StatusCode -lt 300) "Demo asset uploaded"
+} catch {
+  throw "Asset upload failed: $($_.Exception.Message)"
+}
+
+$confirmedAsset = Invoke-EhApi -Method "POST" -Path "/admin/assets/confirm" -Token $adminToken -Body @{
+  hymnId = $hymn.id
+  type = "PNG"
+  part = "ALL"
+  publicUrl = $presign.publicUrl
+  objectKey = $presign.objectKey
+  checksum = "local-checksum"
+  version = "1"
+}
+Write-Check -Condition (-not [string]::IsNullOrWhiteSpace($confirmedAsset.assetId)) "Asset confirmed in DB"
+
+$detail = Invoke-EhApi -Method "GET" -Path "/hymns/$($hymn.id)" -Token $adminToken
+Write-Check -Condition ($null -ne $detail.assets -and $detail.assets.Count -gt 0) "Hymn detail includes assets"
+Write-Check -Condition (-not [string]::IsNullOrWhiteSpace($detail.assets[0].url)) "Asset URL exists in detail response"
+
+Write-Section "Host-side asset URL verification"
+$assetUrl = $detail.assets[0].url
+if ([string]::IsNullOrWhiteSpace($assetUrl)) {
+  Write-Check -Condition $false "Asset URL is missing"
+} else {
+  try {
+    $head = Invoke-WebRequest -Method Head -Uri $assetUrl -TimeoutSec 10 -ErrorAction Stop
+    Write-Check -Condition ($head.StatusCode -ge 200 -and $head.StatusCode -lt 400) "Asset URL is reachable from host"
+  } catch {
+    Write-Check -Condition $false -WarnOnly $true "Host could not access asset URL. If using Android emulator, set S3_PUBLIC_BASE_URL to http://10.0.2.2:4566/local-bucket in .env and restart API."
+  }
+}
+
+Write-Section "DB account login check"
+$createdUser = Invoke-EhApi -Method "POST" -Path "/admin/users" -Token $adminToken -Body @{
+  displayName = "local-smoke-user"
+  role = "USER"
+  status = "ACTIVE"
+}
+Write-Check -Condition (-not [string]::IsNullOrWhiteSpace($createdUser.id)) "User created in DB: $($createdUser.id)"
+
+$devLogin = Invoke-EhApi -Method "POST" -Path "/auth/dev/login" -Body @{
+  userId = $createdUser.id
+  role = "USER"
+  displayName = $createdUser.displayName
+}
+Write-Check -Condition (-not [string]::IsNullOrWhiteSpace($devLogin.accessToken)) "Dev login on created DB user returned token"
+
+$profile = Invoke-EhApi -Method "GET" -Path "/me/profile" -Token $devLogin.accessToken
+Write-Check -Condition ($profile.userId -eq $createdUser.id) "Profile matches DB user id"
+
+Write-Section "Kakao login verification"
+Write-Host "Manual check only: launch emulator app and test:"
+Write-Host "1) Enter invite code: $normalizedInvite"
+Write-Host "2) Tap 'Kakao Login' and complete consent"
+Write-Host "3) Confirm /me/profile and hymns list load without errors"
+Write-Host "4) Open detail for '$($hymn.title)' and verify image/audio is loaded"
+
+Write-Section "Summary"
+Write-Host "Invite Code: $($createdInvite.code)"
+Write-Host "Hymn ID   : $($hymn.id)"
+Write-Host "Asset URL : $($detail.assets[0].url)"
+Write-Host "DB User   : $($createdUser.id)"
+$hasSummary = -not [string]::IsNullOrWhiteSpace($SummaryFile)
+if ($hasSummary) {
+    if ([System.IO.Path]::IsPathRooted($SummaryFile)) {
+        $summaryPath = $SummaryFile
+    } else {
+        $summaryPath = Join-Path $repoRoot $SummaryFile
+    }
+    $payload = @{
+        inviteCode = $createdInvite.code
+        hymnId = $hymn.id
+        assetUrl = $detail.assets[0].url
+        dbUserId = $createdUser.id
+        generatedAt = (Get-Date).ToString("s")
+    } | ConvertTo-Json
+    $summaryDir = Split-Path -Path $summaryPath -Parent
+    if (-not [string]::IsNullOrWhiteSpace($summaryDir) -and -not (Test-Path -LiteralPath $summaryDir)) {
+        New-Item -ItemType Directory -Path $summaryDir -Force | Out-Null
+    }
+    Set-Content -LiteralPath $summaryPath -Value $payload -Encoding utf8
+    Write-Host "Summary written: $summaryPath"
+}
+if (-not $KeepGeneratedFiles) {
+  Remove-Item -LiteralPath $assetFile -Force -ErrorAction SilentlyContinue
+  Write-Host "Temporary asset file removed: $assetFile"
+} else {
+  Write-Host "Temporary asset file kept: $assetFile"
+}

--- a/scripts/run-mobile-emulator.ps1
+++ b/scripts/run-mobile-emulator.ps1
@@ -1,0 +1,86 @@
+param(
+    [string] $DeviceId = "emulator-5554",
+    [string] $ApiBaseUrl,
+    [string] $KakaoNativeAppKey
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$mobileDir = Join-Path $repoRoot "apps/mobile"
+$mobileEnv = Join-Path $mobileDir ".env"
+$repoEnv = Join-Path $repoRoot ".env"
+$preferredFlutter = Join-Path $repoRoot "tools/flutter/bin/flutter.bat"
+$flutter = Get-Command "flutter" -ErrorAction SilentlyContinue
+if ($flutter) {
+    $flutter = $flutter.Source
+}
+if (-not $flutter) {
+    $flutter = $preferredFlutter
+}
+
+if (-not (Test-Path -LiteralPath $flutter)) {
+    throw "Flutter executable not found: $flutter"
+}
+
+function Read-EnvValue {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $Path,
+        [Parameter(Mandatory = $true)]
+        [string] $Name
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $null
+    }
+
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        $trimmed = $line.Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed) -or $trimmed.StartsWith('#')) {
+            continue
+        }
+        if ($trimmed -match '^\s*' + [regex]::Escape($Name) + '\s*=\s*(.*)\s*$') {
+            return $matches[1]
+        }
+    }
+    return $null
+}
+
+$resolvedApiBaseUrl = if ($ApiBaseUrl) {
+    $ApiBaseUrl
+} else {
+    $valueFromEnv = Read-EnvValue -Path $mobileEnv -Name "API_BASE_URL"
+    if ([string]::IsNullOrWhiteSpace($valueFromEnv)) {
+        "http://10.0.2.2:8080/api/v1"
+    } else {
+        $valueFromEnv
+    }
+}
+
+$resolvedKakaoKey = if ($KakaoNativeAppKey) {
+    $KakaoNativeAppKey
+} else {
+    $mobileKakao = Read-EnvValue -Path $mobileEnv -Name "KAKAO_NATIVE_APP_KEY"
+    if (-not [string]::IsNullOrWhiteSpace($mobileKakao)) {
+        $mobileKakao
+    } else {
+        Read-EnvValue -Path $repoEnv -Name "KAKAO_NATIVE_APP_KEY"
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($resolvedKakaoKey)) {
+    throw "KAKAO_NATIVE_APP_KEY is required. Set it in apps/mobile/.env, .env, or pass -KakaoNativeAppKey."
+}
+
+$dartDefines = @(
+    "--dart-define=API_BASE_URL=" + ($resolvedApiBaseUrl.Trim())
+    "--dart-define=KAKAO_NATIVE_APP_KEY=" + $resolvedKakaoKey.Trim()
+)
+
+Push-Location $mobileDir
+try {
+    & $flutter run -d $DeviceId @dartDefines
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary
- add one-command local bootstrap and verification scripts for Android-focused development
- add reproducible local env templates and mobile env example
- add local smoke verification checklist docs for re-onboarding on new PCs
- tighten invite code normalization and asset URL host rewriting for local emulator asset checks

## Validation
- ./scripts/local-bootstrap.ps1
- ./gradlew test
- ../../tools/flutter/bin/flutter.bat analyze
- ../../tools/flutter/bin/flutter.bat test
- npm run build (apps/admin)
