### PR TITLE
fix(api): keep invite code compatibility across casing

### DIFF
--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/InviteCodeJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/InviteCodeJpaRepository.java
@@ -1,11 +1,13 @@
 package com.eunhyehymn.infrastructure.persistence;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface InviteCodeJpaRepository extends JpaRepository<InviteCodeEntity, String> {
+    Optional<InviteCodeEntity> findFirstByCodeIgnoreCaseOrderByCreatedAtAsc(String code);
 
     @Modifying
     @Query("UPDATE InviteCodeEntity e SET e.usedCount = e.usedCount + 1 " +

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/InviteCodeRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/InviteCodeRepositoryAdapter.java
@@ -23,7 +23,7 @@ public class InviteCodeRepositoryAdapter implements InviteCodeRepository {
 
     @Override
     public Optional<InviteCode> findByCode(String code) {
-        return jpaRepository.findById(code).map(InviteCodeMapper::toDomain);
+        return findExistingEntityByCode(code).map(InviteCodeMapper::toDomain);
     }
 
     @Override
@@ -35,6 +35,16 @@ public class InviteCodeRepositoryAdapter implements InviteCodeRepository {
 
     @Override
     public boolean incrementUsedCount(String code) {
-        return jpaRepository.incrementUsedCount(code) > 0;
+        return findExistingEntityByCode(code)
+            .map(entity -> jpaRepository.incrementUsedCount(entity.getCode()) > 0)
+            .orElse(false);
+    }
+
+    private Optional<InviteCodeEntity> findExistingEntityByCode(String code) {
+        if (code == null) {
+            return Optional.empty();
+        }
+        return jpaRepository.findById(code)
+            .or(() -> jpaRepository.findFirstByCodeIgnoreCaseOrderByCreatedAtAsc(code));
     }
 }

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminInviteCodeApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AdminInviteCodeApiTest.java
@@ -13,6 +13,7 @@ import com.eunhyehymn.infrastructure.persistence.AuthIdentityJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.EventJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.HymnJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.HymnNoteJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.InviteCodeEntity;
 import com.eunhyehymn.infrastructure.persistence.InviteCodeJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.RefreshTokenJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.UserEntity;
@@ -132,6 +133,20 @@ class AdminInviteCodeApiTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(payload))
             .andExpect(status().isOk());
+
+        mockMvc.perform(post("/admin/invite-codes")
+                .header("Authorization", "Bearer " + adminToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isConflict());
+    }
+
+    @Test
+    void duplicateCodeReturnsConflictEvenWhenLegacyCodeHasDifferentCase() throws Exception {
+        inviteCodeJpaRepository.save(new InviteCodeEntity(
+            "legacy-code", null, "legacy", null, 0, true, null, Instant.now()
+        ));
+        String payload = objectMapper.writeValueAsString(Map.of("code", "LEGACY-CODE"));
 
         mockMvc.perform(post("/admin/invite-codes")
                 .header("Authorization", "Bearer " + adminToken)

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/SocialLoginApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/SocialLoginApiTest.java
@@ -220,4 +220,28 @@ class SocialLoginApiTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.newUser").value(true));
     }
+
+    @Test
+    void legacyLowercaseInviteCodeStillWorksAfterNormalization() throws Exception {
+        inviteCodeJpaRepository.save(new InviteCodeEntity(
+            "legacy-code", null, "legacy", null, 0, true, null, Instant.now()
+        ));
+
+        when(socialTokenVerifier.verify(eq("KAKAO"), eq("legacy-token")))
+            .thenReturn(new SocialUserInfo("legacy-sub", "legacy@kakao.com", "Legacy User"));
+
+        Map<String, String> request = new HashMap<>();
+        request.put("provider", "KAKAO");
+        request.put("token", "legacy-token");
+        request.put("inviteCode", "  LEGACY-CODE  ");
+
+        mockMvc.perform(post("/auth/social")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.newUser").value(true));
+
+        InviteCodeEntity updated = inviteCodeJpaRepository.findById("legacy-code").orElseThrow();
+        assertThat(updated.getUsedCount()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
## Summary
- preserve legacy lowercase/mixed-case invite codes by adding case-insensitive fallback lookup in invite code repository adapter
- make invite-code usage increment resolve canonical stored code first, then update atomically on that exact key
- add regression tests for social login with legacy lowercase stored code and admin duplicate prevention across case variants

## Why
PR #97 introduced uppercase normalization in use cases, but repository operations were exact-key only. Existing legacy codes could fail validation/login and duplicate logical codes could be created with different casing.

## Validation
- apps/api: .\\gradlew.bat test --no-daemon (targeted classes: AdminInviteCodeApiTest, SocialLoginApiTest)
