### PR TITLE
feat(auth): 운영 계정 로그인/회원가입 플로우 추가

### DIFF
--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/UserPasswordLoginUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/UserPasswordLoginUseCase.java
@@ -1,0 +1,100 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.application.ports.TokenHashService;
+import com.eunhyehymn.application.ports.TokenService;
+import com.eunhyehymn.domain.model.AuthIdentity;
+import com.eunhyehymn.domain.model.RefreshToken;
+import com.eunhyehymn.domain.model.User;
+import com.eunhyehymn.domain.model.UserPasswordCredential;
+import com.eunhyehymn.domain.repository.AuthIdentityRepository;
+import com.eunhyehymn.domain.repository.RefreshTokenRepository;
+import com.eunhyehymn.domain.repository.UserPasswordCredentialRepository;
+import com.eunhyehymn.domain.repository.UserRepository;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+public class UserPasswordLoginUseCase {
+    private final AuthIdentityRepository authIdentityRepository;
+    private final UserPasswordCredentialRepository userPasswordCredentialRepository;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenService tokenService;
+    private final TokenHashService tokenHashService;
+    private final PasswordEncoder passwordEncoder;
+    private final long refreshTokenTtlSeconds;
+
+    public UserPasswordLoginUseCase(
+        AuthIdentityRepository authIdentityRepository,
+        UserPasswordCredentialRepository userPasswordCredentialRepository,
+        UserRepository userRepository,
+        RefreshTokenRepository refreshTokenRepository,
+        TokenService tokenService,
+        TokenHashService tokenHashService,
+        PasswordEncoder passwordEncoder,
+        long refreshTokenTtlSeconds
+    ) {
+        this.authIdentityRepository = authIdentityRepository;
+        this.userPasswordCredentialRepository = userPasswordCredentialRepository;
+        this.userRepository = userRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.tokenService = tokenService;
+        this.tokenHashService = tokenHashService;
+        this.passwordEncoder = passwordEncoder;
+        this.refreshTokenTtlSeconds = refreshTokenTtlSeconds;
+    }
+
+    @Transactional
+    public LoginResult login(String loginId, String password) {
+        String normalizedLoginId = UserPasswordSignupUseCase.normalizeLookupLoginId(loginId);
+        String normalizedPassword = password == null ? "" : password;
+
+        AuthIdentity identity = authIdentityRepository
+            .findByProviderAndProviderSubject(UserPasswordSignupUseCase.PROVIDER_LOCAL_USER, normalizedLoginId)
+            .orElseThrow(() -> new InvalidCredentialsException("로그인 ID 또는 비밀번호가 올바르지 않습니다."));
+
+        UserPasswordCredential credential = userPasswordCredentialRepository.findByUserId(identity.userId())
+            .orElseThrow(() -> new InvalidCredentialsException("로그인 ID 또는 비밀번호가 올바르지 않습니다."));
+
+        if (!passwordEncoder.matches(normalizedPassword, credential.passwordHash())) {
+            throw new InvalidCredentialsException("로그인 ID 또는 비밀번호가 올바르지 않습니다.");
+        }
+
+        Instant now = Instant.now();
+        User existing = userRepository.findById(identity.userId())
+            .orElseThrow(() -> new IllegalStateException("LOCAL_USER identity user not found: " + identity.userId()));
+        User user = new User(
+            existing.id(),
+            existing.displayName(),
+            existing.role(),
+            existing.status(),
+            existing.createdAt(),
+            now
+        );
+        userRepository.save(user);
+
+        String accessToken = tokenService.issueAccessToken(user.id().toString(), user.role().name());
+        String refreshToken = tokenService.issueRefreshToken();
+        String hash = tokenHashService.hash(refreshToken);
+        refreshTokenRepository.save(new RefreshToken(
+            UUID.randomUUID(),
+            user.id(),
+            hash,
+            now.plusSeconds(refreshTokenTtlSeconds),
+            null,
+            now
+        ));
+
+        return new LoginResult(accessToken, refreshToken, false);
+    }
+
+    public record LoginResult(String accessToken, String refreshToken, boolean newUser) {
+    }
+
+    public static class InvalidCredentialsException extends RuntimeException {
+        public InvalidCredentialsException(String message) {
+            super(message);
+        }
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/UserPasswordSignupUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/UserPasswordSignupUseCase.java
@@ -69,12 +69,12 @@ public class UserPasswordSignupUseCase {
             throw new InvalidInviteCodeException("초대코드가 비어있습니다");
         }
 
+        inviteCodeRepository.findByCode(normalizedInviteCode)
+            .orElseThrow(() -> new InvalidInviteCodeException("유효하지 않은 초대코드입니다"));
+
         if (authIdentityRepository.findByProviderAndProviderSubject(PROVIDER_LOCAL_USER, normalizedLoginId).isPresent()) {
             throw new DuplicateLoginIdException("이미 사용 중인 로그인 ID입니다.");
         }
-
-        inviteCodeRepository.findByCode(normalizedInviteCode)
-            .orElseThrow(() -> new InvalidInviteCodeException("유효하지 않은 초대코드입니다"));
 
         boolean incremented = inviteCodeRepository.incrementUsedCount(normalizedInviteCode);
         if (!incremented) {

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/UserPasswordSignupUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/UserPasswordSignupUseCase.java
@@ -1,0 +1,171 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.application.ports.TokenHashService;
+import com.eunhyehymn.application.ports.TokenService;
+import com.eunhyehymn.domain.model.AuthIdentity;
+import com.eunhyehymn.domain.model.RefreshToken;
+import com.eunhyehymn.domain.model.Role;
+import com.eunhyehymn.domain.model.User;
+import com.eunhyehymn.domain.model.UserPasswordCredential;
+import com.eunhyehymn.domain.model.UserStatus;
+import com.eunhyehymn.domain.repository.AuthIdentityRepository;
+import com.eunhyehymn.domain.repository.InviteCodeRepository;
+import com.eunhyehymn.domain.repository.RefreshTokenRepository;
+import com.eunhyehymn.domain.repository.UserPasswordCredentialRepository;
+import com.eunhyehymn.domain.repository.UserRepository;
+import java.time.Instant;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+public class UserPasswordSignupUseCase {
+    static final String PROVIDER_LOCAL_USER = "LOCAL_USER";
+    private static final Pattern LOGIN_ID_PATTERN = Pattern.compile("^[a-z0-9._-]{3,100}$");
+    private static final int MIN_PASSWORD_LENGTH = 8;
+
+    private final AuthIdentityRepository authIdentityRepository;
+    private final UserPasswordCredentialRepository userPasswordCredentialRepository;
+    private final UserRepository userRepository;
+    private final InviteCodeRepository inviteCodeRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenService tokenService;
+    private final TokenHashService tokenHashService;
+    private final PasswordEncoder passwordEncoder;
+    private final long refreshTokenTtlSeconds;
+
+    public UserPasswordSignupUseCase(
+        AuthIdentityRepository authIdentityRepository,
+        UserPasswordCredentialRepository userPasswordCredentialRepository,
+        UserRepository userRepository,
+        InviteCodeRepository inviteCodeRepository,
+        RefreshTokenRepository refreshTokenRepository,
+        TokenService tokenService,
+        TokenHashService tokenHashService,
+        PasswordEncoder passwordEncoder,
+        long refreshTokenTtlSeconds
+    ) {
+        this.authIdentityRepository = authIdentityRepository;
+        this.userPasswordCredentialRepository = userPasswordCredentialRepository;
+        this.userRepository = userRepository;
+        this.inviteCodeRepository = inviteCodeRepository;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.tokenService = tokenService;
+        this.tokenHashService = tokenHashService;
+        this.passwordEncoder = passwordEncoder;
+        this.refreshTokenTtlSeconds = refreshTokenTtlSeconds;
+    }
+
+    @Transactional
+    public LoginResult signup(String loginId, String password, String inviteCode) {
+        String rawLoginId = normalizeRawLoginId(loginId);
+        String normalizedLoginId = normalizeLookupLoginId(rawLoginId);
+        String normalizedInviteCode = normalizeInviteCode(inviteCode);
+        validateCredentialFormat(normalizedLoginId, password);
+
+        if (normalizedInviteCode == null || normalizedInviteCode.isBlank()) {
+            throw new InvalidInviteCodeException("초대코드가 비어있습니다");
+        }
+
+        if (authIdentityRepository.findByProviderAndProviderSubject(PROVIDER_LOCAL_USER, normalizedLoginId).isPresent()) {
+            throw new DuplicateLoginIdException("이미 사용 중인 로그인 ID입니다.");
+        }
+
+        inviteCodeRepository.findByCode(normalizedInviteCode)
+            .orElseThrow(() -> new InvalidInviteCodeException("유효하지 않은 초대코드입니다"));
+
+        boolean incremented = inviteCodeRepository.incrementUsedCount(normalizedInviteCode);
+        if (!incremented) {
+            throw new InvalidInviteCodeException("유효하지 않은 초대코드입니다");
+        }
+
+        Instant now = Instant.now();
+        UUID userId = UUID.randomUUID();
+        User user = new User(userId, rawLoginId, Role.USER, UserStatus.ACTIVE, now, now);
+        userRepository.save(user);
+
+        try {
+            authIdentityRepository.save(new AuthIdentity(
+                UUID.randomUUID(),
+                userId,
+                PROVIDER_LOCAL_USER,
+                normalizedLoginId,
+                null,
+                now
+            ));
+        } catch (DataIntegrityViolationException ex) {
+            throw new DuplicateLoginIdException("이미 사용 중인 로그인 ID입니다.");
+        }
+
+        userPasswordCredentialRepository.save(new UserPasswordCredential(
+            userId,
+            passwordEncoder.encode(password),
+            now,
+            now
+        ));
+
+        String accessToken = tokenService.issueAccessToken(user.id().toString(), user.role().name());
+        String refreshToken = tokenService.issueRefreshToken();
+        String hash = tokenHashService.hash(refreshToken);
+        refreshTokenRepository.save(new RefreshToken(
+            UUID.randomUUID(),
+            user.id(),
+            hash,
+            now.plusSeconds(refreshTokenTtlSeconds),
+            null,
+            now
+        ));
+
+        return new LoginResult(accessToken, refreshToken, true);
+    }
+
+    private void validateCredentialFormat(String loginId, String password) {
+        if (!LOGIN_ID_PATTERN.matcher(loginId).matches()) {
+            throw new InvalidCredentialFormatException("로그인 ID는 영문/숫자/._- 조합 3-100자여야 합니다.");
+        }
+        if (password == null || password.length() < MIN_PASSWORD_LENGTH) {
+            throw new InvalidCredentialFormatException("비밀번호는 최소 8자 이상이어야 합니다.");
+        }
+    }
+
+    static String normalizeRawLoginId(String loginId) {
+        return loginId == null ? "" : loginId.trim();
+    }
+
+    static String normalizeLookupLoginId(String loginId) {
+        if (loginId == null) {
+            return "";
+        }
+        return loginId.trim().toLowerCase(Locale.ROOT);
+    }
+
+    static String normalizeInviteCode(String inviteCode) {
+        if (inviteCode == null) {
+            return null;
+        }
+        return inviteCode.trim().toUpperCase(Locale.ROOT);
+    }
+
+    public record LoginResult(String accessToken, String refreshToken, boolean newUser) {
+    }
+
+    public static class InvalidInviteCodeException extends RuntimeException {
+        public InvalidInviteCodeException(String message) {
+            super(message);
+        }
+    }
+
+    public static class DuplicateLoginIdException extends RuntimeException {
+        public DuplicateLoginIdException(String message) {
+            super(message);
+        }
+    }
+
+    public static class InvalidCredentialFormatException extends RuntimeException {
+        public InvalidCredentialFormatException(String message) {
+            super(message);
+        }
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/AuthConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/AuthConfig.java
@@ -9,10 +9,13 @@ import com.eunhyehymn.application.usecases.LogoutUseCase;
 import com.eunhyehymn.application.usecases.RefreshTokenUseCase;
 import com.eunhyehymn.application.usecases.SocialLoginUseCase;
 import com.eunhyehymn.application.usecases.UpdateAdminPasswordCredentialUseCase;
+import com.eunhyehymn.application.usecases.UserPasswordLoginUseCase;
+import com.eunhyehymn.application.usecases.UserPasswordSignupUseCase;
 import com.eunhyehymn.domain.repository.AdminPasswordCredentialRepository;
 import com.eunhyehymn.domain.repository.AuthIdentityRepository;
 import com.eunhyehymn.domain.repository.InviteCodeRepository;
 import com.eunhyehymn.domain.repository.RefreshTokenRepository;
+import com.eunhyehymn.domain.repository.UserPasswordCredentialRepository;
 import com.eunhyehymn.domain.repository.UserRepository;
 import com.eunhyehymn.infrastructure.security.JwtAuthenticationFilter;
 import com.eunhyehymn.infrastructure.security.JwtService;
@@ -170,6 +173,54 @@ public class AuthConfig {
             refreshTokenTtlSeconds,
             loginId,
             loginPassword
+        );
+    }
+
+    @Bean
+    UserPasswordSignupUseCase userPasswordSignupUseCase(
+        AuthIdentityRepository authIdentityRepository,
+        UserPasswordCredentialRepository userPasswordCredentialRepository,
+        UserRepository userRepository,
+        InviteCodeRepository inviteCodeRepository,
+        RefreshTokenRepository refreshTokenRepository,
+        TokenService tokenService,
+        TokenHashService tokenHashService,
+        PasswordEncoder passwordEncoder,
+        @Value("${security.jwt.refresh-token-ttl-seconds}") long refreshTokenTtlSeconds
+    ) {
+        return new UserPasswordSignupUseCase(
+            authIdentityRepository,
+            userPasswordCredentialRepository,
+            userRepository,
+            inviteCodeRepository,
+            refreshTokenRepository,
+            tokenService,
+            tokenHashService,
+            passwordEncoder,
+            refreshTokenTtlSeconds
+        );
+    }
+
+    @Bean
+    UserPasswordLoginUseCase userPasswordLoginUseCase(
+        AuthIdentityRepository authIdentityRepository,
+        UserPasswordCredentialRepository userPasswordCredentialRepository,
+        UserRepository userRepository,
+        RefreshTokenRepository refreshTokenRepository,
+        TokenService tokenService,
+        TokenHashService tokenHashService,
+        PasswordEncoder passwordEncoder,
+        @Value("${security.jwt.refresh-token-ttl-seconds}") long refreshTokenTtlSeconds
+    ) {
+        return new UserPasswordLoginUseCase(
+            authIdentityRepository,
+            userPasswordCredentialRepository,
+            userRepository,
+            refreshTokenRepository,
+            tokenService,
+            tokenHashService,
+            passwordEncoder,
+            refreshTokenTtlSeconds
         );
     }
 

--- a/apps/api/src/main/java/com/eunhyehymn/domain/model/UserPasswordCredential.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/model/UserPasswordCredential.java
@@ -1,0 +1,12 @@
+package com.eunhyehymn.domain.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserPasswordCredential(
+    UUID userId,
+    String passwordHash,
+    Instant createdAt,
+    Instant updatedAt
+) {
+}

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/UserPasswordCredentialRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/UserPasswordCredentialRepository.java
@@ -1,0 +1,11 @@
+package com.eunhyehymn.domain.repository;
+
+import com.eunhyehymn.domain.model.UserPasswordCredential;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserPasswordCredentialRepository {
+    Optional<UserPasswordCredential> findByUserId(UUID userId);
+
+    UserPasswordCredential save(UserPasswordCredential credential);
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserPasswordCredentialEntity.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserPasswordCredentialEntity.java
@@ -1,0 +1,56 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_password_credentials")
+public class UserPasswordCredentialEntity {
+    @Id
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected UserPasswordCredentialEntity() {
+    }
+
+    public UserPasswordCredentialEntity(
+        UUID userId,
+        String passwordHash,
+        Instant createdAt,
+        Instant updatedAt
+    ) {
+        this.userId = userId;
+        this.passwordHash = passwordHash;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserPasswordCredentialJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserPasswordCredentialJpaRepository.java
@@ -1,0 +1,8 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserPasswordCredentialJpaRepository
+    extends JpaRepository<UserPasswordCredentialEntity, UUID> {
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserPasswordCredentialRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserPasswordCredentialRepositoryAdapter.java
@@ -1,0 +1,29 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import com.eunhyehymn.domain.model.UserPasswordCredential;
+import com.eunhyehymn.domain.repository.UserPasswordCredentialRepository;
+import com.eunhyehymn.infrastructure.persistence.mapper.UserPasswordCredentialMapper;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class UserPasswordCredentialRepositoryAdapter implements UserPasswordCredentialRepository {
+    private final UserPasswordCredentialJpaRepository jpaRepository;
+
+    public UserPasswordCredentialRepositoryAdapter(UserPasswordCredentialJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public Optional<UserPasswordCredential> findByUserId(UUID userId) {
+        return jpaRepository.findById(userId).map(UserPasswordCredentialMapper::toDomain);
+    }
+
+    @Override
+    public UserPasswordCredential save(UserPasswordCredential credential) {
+        return UserPasswordCredentialMapper.toDomain(
+            jpaRepository.save(UserPasswordCredentialMapper.toEntity(credential))
+        );
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/mapper/UserPasswordCredentialMapper.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/mapper/UserPasswordCredentialMapper.java
@@ -1,0 +1,27 @@
+package com.eunhyehymn.infrastructure.persistence.mapper;
+
+import com.eunhyehymn.domain.model.UserPasswordCredential;
+import com.eunhyehymn.infrastructure.persistence.UserPasswordCredentialEntity;
+
+public final class UserPasswordCredentialMapper {
+    private UserPasswordCredentialMapper() {
+    }
+
+    public static UserPasswordCredential toDomain(UserPasswordCredentialEntity entity) {
+        return new UserPasswordCredential(
+            entity.getUserId(),
+            entity.getPasswordHash(),
+            entity.getCreatedAt(),
+            entity.getUpdatedAt()
+        );
+    }
+
+    public static UserPasswordCredentialEntity toEntity(UserPasswordCredential credential) {
+        return new UserPasswordCredentialEntity(
+            credential.userId(),
+            credential.passwordHash(),
+            credential.createdAt(),
+            credential.updatedAt()
+        );
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AuthController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AuthController.java
@@ -4,6 +4,8 @@ import com.eunhyehymn.application.usecases.AdminPasswordLoginUseCase;
 import com.eunhyehymn.application.usecases.LogoutUseCase;
 import com.eunhyehymn.application.usecases.RefreshTokenUseCase;
 import com.eunhyehymn.application.usecases.SocialLoginUseCase;
+import com.eunhyehymn.application.usecases.UserPasswordLoginUseCase;
+import com.eunhyehymn.application.usecases.UserPasswordSignupUseCase;
 import com.eunhyehymn.application.usecases.ValidateInviteCodeUseCase;
 import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.common.response.ApiResponse;
@@ -25,19 +27,25 @@ public class AuthController {
     private final LogoutUseCase logoutUseCase;
     private final ValidateInviteCodeUseCase validateInviteCodeUseCase;
     private final SocialLoginUseCase socialLoginUseCase;
+    private final UserPasswordSignupUseCase userPasswordSignupUseCase;
+    private final UserPasswordLoginUseCase userPasswordLoginUseCase;
 
     public AuthController(
         AdminPasswordLoginUseCase adminPasswordLoginUseCase,
         RefreshTokenUseCase refreshTokenUseCase,
         LogoutUseCase logoutUseCase,
         ValidateInviteCodeUseCase validateInviteCodeUseCase,
-        SocialLoginUseCase socialLoginUseCase
+        SocialLoginUseCase socialLoginUseCase,
+        UserPasswordSignupUseCase userPasswordSignupUseCase,
+        UserPasswordLoginUseCase userPasswordLoginUseCase
     ) {
         this.adminPasswordLoginUseCase = adminPasswordLoginUseCase;
         this.refreshTokenUseCase = refreshTokenUseCase;
         this.logoutUseCase = logoutUseCase;
         this.validateInviteCodeUseCase = validateInviteCodeUseCase;
         this.socialLoginUseCase = socialLoginUseCase;
+        this.userPasswordSignupUseCase = userPasswordSignupUseCase;
+        this.userPasswordLoginUseCase = userPasswordLoginUseCase;
     }
 
     @PostMapping("/admin/login")
@@ -77,6 +85,45 @@ public class AuthController {
         }
     }
 
+    @PostMapping("/signup")
+    public ApiResponse<SocialLoginResponse> signup(@RequestBody @Validated UserPasswordSignupRequest request) {
+        try {
+            UserPasswordSignupUseCase.LoginResult result = userPasswordSignupUseCase.signup(
+                request.loginId(),
+                request.password(),
+                request.inviteCode()
+            );
+            return ApiResponse.success(new SocialLoginResponse(
+                result.accessToken(),
+                result.refreshToken(),
+                result.newUser()
+            ));
+        } catch (UserPasswordSignupUseCase.InvalidInviteCodeException e) {
+            throw new ApiException(HttpStatus.FORBIDDEN, "invalid_invite_code", e.getMessage(), null);
+        } catch (UserPasswordSignupUseCase.DuplicateLoginIdException e) {
+            throw new ApiException(HttpStatus.CONFLICT, "login_id_exists", e.getMessage(), null);
+        } catch (UserPasswordSignupUseCase.InvalidCredentialFormatException e) {
+            throw new ApiException(HttpStatus.BAD_REQUEST, "invalid_credential_format", e.getMessage(), null);
+        }
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<SocialLoginResponse> login(@RequestBody @Validated UserPasswordLoginRequest request) {
+        try {
+            UserPasswordLoginUseCase.LoginResult result = userPasswordLoginUseCase.login(
+                request.loginId(),
+                request.password()
+            );
+            return ApiResponse.success(new SocialLoginResponse(
+                result.accessToken(),
+                result.refreshToken(),
+                result.newUser()
+            ));
+        } catch (UserPasswordLoginUseCase.InvalidCredentialsException e) {
+            throw new ApiException(HttpStatus.UNAUTHORIZED, "user_login_failed", e.getMessage(), null);
+        }
+    }
+
     @PostMapping("/refresh")
     public ApiResponse<TokenResponse> refresh(@RequestBody @Validated RefreshRequest request) {
         RefreshTokenUseCase.TokenPair pair = refreshTokenUseCase.refresh(request.refreshToken());
@@ -106,6 +153,19 @@ public class AuthController {
     }
 
     public record AdminPasswordLoginRequest(
+        @NotBlank String loginId,
+        @NotBlank String password
+    ) {
+    }
+
+    public record UserPasswordSignupRequest(
+        @NotBlank String loginId,
+        @NotBlank String password,
+        @NotBlank String inviteCode
+    ) {
+    }
+
+    public record UserPasswordLoginRequest(
         @NotBlank String loginId,
         @NotBlank String password
     ) {

--- a/apps/api/src/main/resources/db/migration/V12__user_password_credentials.sql
+++ b/apps/api/src/main/resources/db/migration/V12__user_password_credentials.sql
@@ -1,0 +1,8 @@
+CREATE TABLE user_password_credentials (
+    user_id UUID PRIMARY KEY,
+    password_hash VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    CONSTRAINT fk_user_password_credentials_user
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/UserPasswordAuthApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/UserPasswordAuthApiTest.java
@@ -108,6 +108,25 @@ class UserPasswordAuthApiTest {
     }
 
     @Test
+    void signupWithInvalidInviteCodeDoesNotExposeLoginIdExistence() throws Exception {
+        inviteCodeJpaRepository.save(new InviteCodeEntity(
+            "VALID-CODE", null, "valid", null, 0, true, null, Instant.now()
+        ));
+
+        signup("member.one", "password-123!", "VALID-CODE");
+
+        mockMvc.perform(post("/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of(
+                    "loginId", "member.one",
+                    "password", "password-123!",
+                    "inviteCode", "INVALID-CODE"
+                ))))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.error.code").value("invalid_invite_code"));
+    }
+
+    @Test
     void loginWithCreatedCredentialIssuesTokens() throws Exception {
         inviteCodeJpaRepository.save(new InviteCodeEntity(
             "LOGIN-CODE", null, "login", null, 0, true, null, Instant.now()

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/UserPasswordAuthApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/UserPasswordAuthApiTest.java
@@ -1,0 +1,161 @@
+package com.eunhyehymn.presentation.controllers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.eunhyehymn.infrastructure.persistence.AssetJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.AuthIdentityEntity;
+import com.eunhyehymn.infrastructure.persistence.AuthIdentityJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.EventJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.HymnJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.HymnNoteJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.InviteCodeEntity;
+import com.eunhyehymn.infrastructure.persistence.InviteCodeJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.RefreshTokenJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.UserHymnStateJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.UserJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.UserPasswordCredentialJpaRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class UserPasswordAuthApiTest {
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserJpaRepository userJpaRepository;
+    @Autowired private HymnJpaRepository hymnJpaRepository;
+    @Autowired private AssetJpaRepository assetJpaRepository;
+    @Autowired private HymnNoteJpaRepository hymnNoteJpaRepository;
+    @Autowired private UserHymnStateJpaRepository userHymnStateJpaRepository;
+    @Autowired private EventJpaRepository eventJpaRepository;
+    @Autowired private AuthIdentityJpaRepository authIdentityJpaRepository;
+    @Autowired private RefreshTokenJpaRepository refreshTokenJpaRepository;
+    @Autowired private InviteCodeJpaRepository inviteCodeJpaRepository;
+    @Autowired private UserPasswordCredentialJpaRepository userPasswordCredentialJpaRepository;
+
+    @BeforeEach
+    void setUp() {
+        inviteCodeJpaRepository.deleteAll();
+        eventJpaRepository.deleteAll();
+        userHymnStateJpaRepository.deleteAll();
+        hymnNoteJpaRepository.deleteAll();
+        assetJpaRepository.deleteAll();
+        authIdentityJpaRepository.deleteAll();
+        userPasswordCredentialJpaRepository.deleteAll();
+        refreshTokenJpaRepository.deleteAll();
+        hymnJpaRepository.deleteAll();
+        userJpaRepository.deleteAll();
+    }
+
+    @Test
+    void signupWithInviteCodeCreatesLocalUserAndIssuesTokens() throws Exception {
+        inviteCodeJpaRepository.save(new InviteCodeEntity(
+            "SIGNUP-CODE", null, "signup", null, 0, true, null, Instant.now()
+        ));
+
+        String response = signup("Member.One", "password-123!", "  signup-code  ");
+        JsonNode data = objectMapper.readTree(response).path("data");
+        String accessToken = data.path("accessToken").asText();
+
+        mockMvc.perform(get("/me/profile")
+                .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.role").value("USER"));
+
+        assertThat(data.path("newUser").asBoolean()).isTrue();
+        assertThat(userJpaRepository.count()).isEqualTo(1);
+        assertThat(authIdentityJpaRepository.count()).isEqualTo(1);
+        assertThat(userPasswordCredentialJpaRepository.count()).isEqualTo(1);
+
+        AuthIdentityEntity identity = authIdentityJpaRepository.findAll().get(0);
+        assertThat(identity.getProvider()).isEqualTo("LOCAL_USER");
+        assertThat(identity.getProviderSubject()).isEqualTo("member.one");
+        assertThat(inviteCodeJpaRepository.findById("SIGNUP-CODE").orElseThrow().getUsedCount()).isEqualTo(1);
+    }
+
+    @Test
+    void signupRejectsDuplicateLoginIdIgnoringCase() throws Exception {
+        inviteCodeJpaRepository.save(new InviteCodeEntity(
+            "CODE-1", null, "code1", null, 0, true, null, Instant.now()
+        ));
+
+        signup("Member.One", "password-123!", "code-1");
+
+        mockMvc.perform(post("/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of(
+                    "loginId", "member.one",
+                    "password", "password-123!",
+                    "inviteCode", "code-1"
+                ))))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.error.code").value("login_id_exists"));
+    }
+
+    @Test
+    void loginWithCreatedCredentialIssuesTokens() throws Exception {
+        inviteCodeJpaRepository.save(new InviteCodeEntity(
+            "LOGIN-CODE", null, "login", null, 0, true, null, Instant.now()
+        ));
+        signup("service.user", "password-123!", "login-code");
+
+        mockMvc.perform(post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of(
+                    "loginId", "SERVICE.USER",
+                    "password", "password-123!"
+                ))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+            .andExpect(jsonPath("$.data.refreshToken").isNotEmpty())
+            .andExpect(jsonPath("$.data.newUser").value(false));
+    }
+
+    @Test
+    void loginFailsWithWrongPassword() throws Exception {
+        inviteCodeJpaRepository.save(new InviteCodeEntity(
+            "WRONG-PW-CODE", null, "wrongpw", null, 0, true, null, Instant.now()
+        ));
+        signup("member.two", "password-123!", "WRONG-PW-CODE");
+
+        mockMvc.perform(post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of(
+                    "loginId", "member.two",
+                    "password", "wrong-password"
+                ))))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.error.code").value("user_login_failed"));
+    }
+
+    private String signup(String loginId, String password, String inviteCode) throws Exception {
+        return mockMvc.perform(post("/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of(
+                    "loginId", loginId,
+                    "password", password,
+                    "inviteCode", inviteCode
+                ))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+            .andExpect(jsonPath("$.data.refreshToken").isNotEmpty())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    }
+}

--- a/apps/mobile/lib/src/core/network/api_client.dart
+++ b/apps/mobile/lib/src/core/network/api_client.dart
@@ -7,6 +7,8 @@ import '../storage/token_storage.dart';
 import 'api_exception.dart';
 
 class ApiClient {
+  static const Duration _requestTimeout = Duration(seconds: 12);
+
   final String baseUrl;
   final TokenStorage tokenStorage;
 
@@ -130,19 +132,37 @@ class ApiClient {
       }
     }
 
-    switch (method) {
-      case 'GET':
-        return http.get(uri, headers: headers);
-      case 'POST':
-        return http.post(uri, headers: headers, body: _encodeBody(body));
-      case 'PUT':
-        return http.put(uri, headers: headers, body: _encodeBody(body));
-      case 'PATCH':
-        return http.patch(uri, headers: headers, body: _encodeBody(body));
-      case 'DELETE':
-        return http.delete(uri, headers: headers);
-      default:
-        throw ApiException('지원하지 않는 HTTP 메서드입니다: $method');
+    try {
+      switch (method) {
+        case 'GET':
+          return await http.get(uri, headers: headers).timeout(_requestTimeout);
+        case 'POST':
+          return await http
+              .post(uri, headers: headers, body: _encodeBody(body))
+              .timeout(_requestTimeout);
+        case 'PUT':
+          return await http
+              .put(uri, headers: headers, body: _encodeBody(body))
+              .timeout(_requestTimeout);
+        case 'PATCH':
+          return await http
+              .patch(uri, headers: headers, body: _encodeBody(body))
+              .timeout(_requestTimeout);
+        case 'DELETE':
+          return await http
+              .delete(uri, headers: headers)
+              .timeout(_requestTimeout);
+        default:
+          throw ApiException('지원하지 않는 HTTP 메서드입니다: $method');
+      }
+    } on TimeoutException {
+      throw ApiException(
+        '서버 응답이 지연되고 있습니다. 네트워크/API 주소를 확인해 주세요.',
+      );
+    } on http.ClientException {
+      throw ApiException(
+        '서버에 연결할 수 없습니다. 네트워크/API 주소를 확인해 주세요.',
+      );
     }
   }
 
@@ -175,11 +195,20 @@ class ApiClient {
     }
 
     final uri = Uri.parse('$baseUrl/auth/refresh');
-    final response = await http.post(
-      uri,
-      headers: const {'Content-Type': 'application/json'},
-      body: jsonEncode({'refreshToken': refreshToken}),
-    );
+    http.Response response;
+    try {
+      response = await http
+          .post(
+            uri,
+            headers: const {'Content-Type': 'application/json'},
+            body: jsonEncode({'refreshToken': refreshToken}),
+          )
+          .timeout(_requestTimeout);
+    } on TimeoutException {
+      return false;
+    } on http.ClientException {
+      return false;
+    }
 
     final envelope = _decodeJsonObject(response.body);
     if (response.statusCode < 200 || response.statusCode >= 300) {

--- a/apps/mobile/lib/src/features/auth/auth_repository.dart
+++ b/apps/mobile/lib/src/features/auth/auth_repository.dart
@@ -71,33 +71,32 @@ class AuthRepository {
     return profile;
   }
 
-  Future<SessionProfile> loginWithDev({
-    required String displayName,
-    required String userId,
-    required UserRole role,
-  }) async {
-    final raw = await apiClient.post(
-      '/auth/dev/login',
-      includeAuth: false,
+  Future<SessionProfile> signupWithAccount({
+    required String loginId,
+    required String password,
+    required String inviteCode,
+  }) {
+    return _loginWithPasswordEndpoint(
+      '/auth/signup',
       body: {
-        'userId': userId,
-        'role': role == UserRole.admin ? 'ADMIN' : 'USER',
-        'displayName': displayName,
+        'loginId': loginId,
+        'password': password,
+        'inviteCode': inviteCode,
       },
     );
+  }
 
-    final tokens = _extractTokens(raw);
-    await tokenStorage.saveTokens(
-      accessToken: tokens.$1,
-      refreshToken: tokens.$2,
+  Future<SessionProfile> loginWithAccount({
+    required String loginId,
+    required String password,
+  }) {
+    return _loginWithPasswordEndpoint(
+      '/auth/login',
+      body: {
+        'loginId': loginId,
+        'password': password,
+      },
     );
-
-    final profile = await fetchProfile();
-    if (profile == null) {
-      await tokenStorage.clear();
-      throw ApiException('Login response is not usable.');
-    }
-    return profile;
   }
 
   Future<SessionProfile> loginWithAdmin({
@@ -145,6 +144,30 @@ class AuthRepository {
 
   Future<void> clearSession() {
     return tokenStorage.clear();
+  }
+
+  Future<SessionProfile> _loginWithPasswordEndpoint(
+    String path, {
+    required Map<String, Object?> body,
+  }) async {
+    final raw = await apiClient.post(
+      path,
+      includeAuth: false,
+      body: body,
+    );
+
+    final tokens = _extractTokens(raw);
+    await tokenStorage.saveTokens(
+      accessToken: tokens.$1,
+      refreshToken: tokens.$2,
+    );
+
+    final profile = await fetchProfile();
+    if (profile == null) {
+      await tokenStorage.clear();
+      throw ApiException('Login response is not usable.');
+    }
+    return profile;
   }
 
   SessionProfile _toSessionProfile(Map<String, dynamic> raw) {

--- a/apps/mobile/lib/src/features/auth/login_page.dart
+++ b/apps/mobile/lib/src/features/auth/login_page.dart
@@ -143,9 +143,13 @@ class _LoginPageState extends State<LoginPage> {
         ),
       ),
     );
-    if (profile != null) {
-      await widget.onLoggedIn(profile);
+    if (!mounted || profile == null) {
+      return;
     }
+
+    await _runWithLoading(() async {
+      await widget.onLoggedIn(profile);
+    });
   }
 
   @override

--- a/apps/mobile/lib/src/features/auth/login_page.dart
+++ b/apps/mobile/lib/src/features/auth/login_page.dart
@@ -101,7 +101,12 @@ class _LoginPageState extends State<LoginPage> {
         );
       }
 
-      final token = await widget.socialSdkService.fetchToken();
+      final token = await widget.socialSdkService.fetchToken().timeout(
+        const Duration(seconds: 45),
+        onTimeout: () => throw ApiException(
+          '카카오 로그인 응답이 지연되고 있습니다. 다시 시도해 주세요.',
+        ),
+      );
       final profile = await widget.authRepository.loginWithSocial(
         token: token,
         inviteCode: _normalizedInviteCode,
@@ -111,14 +116,6 @@ class _LoginPageState extends State<LoginPage> {
   }
 
   Future<void> _handleAccountLogin() async {
-    final inviteCodeError = _validateInviteCode();
-    if (inviteCodeError != null) {
-      setState(() {
-        _error = inviteCodeError;
-      });
-      return;
-    }
-
     final loginId = _accountIdController.text.trim();
     final password = _accountPasswordController.text;
     if (loginId.isEmpty || password.isEmpty) {
@@ -128,33 +125,27 @@ class _LoginPageState extends State<LoginPage> {
       return;
     }
 
-    if (!_isValidUuid(loginId)) {
-      setState(() {
-        _error = '현재는 DB에 저장된 사용자 ID(UUID) 형식만 사용 가능합니다.';
-      });
-      return;
-    }
-
     await _runWithLoading(() async {
-      final profile = await widget.authRepository.loginWithDev(
-        displayName: loginId,
-        userId: loginId,
-        role: UserRole.user,
+      final profile = await widget.authRepository.loginWithAccount(
+        loginId: loginId,
+        password: password,
       );
       await widget.onLoggedIn(profile);
     });
   }
 
-  bool _isValidUuid(String value) {
-    return RegExp(r'^[0-9a-fA-F-]{36}$').hasMatch(value);
-  }
-
   Future<void> _openSignUp() async {
-    await Navigator.of(context).push(
-      MaterialPageRoute<void>(
-        builder: (_) => const SignUpPage(),
+    final profile = await Navigator.of(context).push<SessionProfile>(
+      MaterialPageRoute<SessionProfile>(
+        builder: (_) => SignUpPage(
+          authRepository: widget.authRepository,
+          initialInviteCode: _inviteCodeController.text,
+        ),
       ),
     );
+    if (profile != null) {
+      await widget.onLoggedIn(profile);
+    }
   }
 
   @override
@@ -191,7 +182,7 @@ class _LoginPageState extends State<LoginPage> {
                           ),
                           const SizedBox(height: 6),
                           const Text(
-                            '초대 코드를 입력한 뒤 로그인 방법을 선택해 주세요.',
+                            '카카오 또는 계정 로그인을 선택해 주세요.',
                             style: TextStyle(color: Color(0xFF5B6572)),
                           ),
                           const SizedBox(height: 14),
@@ -326,7 +317,10 @@ class _LoginPageState extends State<LoginPage> {
                   const Center(
                     child: Text(
                       '회원/교회 정보는 첫 사용 시에만 입력합니다.',
-                      style: TextStyle(color: Color(0xFF6B7280), fontSize: 12),
+                      style: TextStyle(
+                        color: Color(0xFF6B7280),
+                        fontSize: 12,
+                      ),
                     ),
                   ),
                 ],

--- a/apps/mobile/lib/src/features/auth/sign_up_page.dart
+++ b/apps/mobile/lib/src/features/auth/sign_up_page.dart
@@ -1,13 +1,24 @@
 import 'package:flutter/material.dart';
 
+import '../../core/network/api_exception.dart';
+import 'auth_repository.dart';
+
 class SignUpPage extends StatefulWidget {
-  const SignUpPage({super.key});
+  final AuthRepository authRepository;
+  final String initialInviteCode;
+
+  const SignUpPage({
+    super.key,
+    required this.authRepository,
+    this.initialInviteCode = '',
+  });
 
   @override
   State<SignUpPage> createState() => _SignUpPageState();
 }
 
 class _SignUpPageState extends State<SignUpPage> {
+  late final TextEditingController _inviteCodeController;
   final _loginIdController = TextEditingController();
   final _passwordController = TextEditingController();
   final _confirmPasswordController = TextEditingController();
@@ -16,7 +27,16 @@ class _SignUpPageState extends State<SignUpPage> {
   bool _submitting = false;
 
   @override
+  void initState() {
+    super.initState();
+    _inviteCodeController = TextEditingController(
+      text: widget.initialInviteCode.trim(),
+    );
+  }
+
+  @override
   void dispose() {
+    _inviteCodeController.dispose();
     _loginIdController.dispose();
     _passwordController.dispose();
     _confirmPasswordController.dispose();
@@ -24,13 +44,21 @@ class _SignUpPageState extends State<SignUpPage> {
   }
 
   Future<void> _handleSubmit() async {
+    final inviteCode = _inviteCodeController.text.trim().toUpperCase();
     final loginId = _loginIdController.text.trim();
     final password = _passwordController.text;
     final confirm = _confirmPasswordController.text;
 
-    if (loginId.isEmpty || password.isEmpty || confirm.isEmpty) {
+    if (inviteCode.isEmpty || loginId.isEmpty || password.isEmpty || confirm.isEmpty) {
       setState(() {
-        _error = '아이디와 비밀번호를 입력해 주세요.';
+        _error = '초대코드, 아이디, 비밀번호를 모두 입력해 주세요.';
+      });
+      return;
+    }
+
+    if (password.length < 8) {
+      setState(() {
+        _error = '비밀번호는 최소 8자 이상이어야 합니다.';
       });
       return;
     }
@@ -48,27 +76,29 @@ class _SignUpPageState extends State<SignUpPage> {
     });
 
     try {
-      await Future.delayed(const Duration(milliseconds: 300));
-      if (!mounted) {
-        return;
-      }
-      await showDialog<void>(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text('알림'),
-          content: const Text('현재 회원가입은 준비 중입니다.'),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('확인'),
-            ),
-          ],
-        ),
+      final profile = await widget.authRepository.signupWithAccount(
+        loginId: loginId,
+        password: password,
+        inviteCode: inviteCode,
       );
       if (!mounted) {
         return;
       }
-      Navigator.of(context).pop();
+      Navigator.of(context).pop(profile);
+    } on ApiException catch (e) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = e.message;
+      });
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = '회원가입 처리 중 오류가 발생했습니다. 다시 시도해 주세요.';
+      });
     } finally {
       if (mounted) {
         setState(() {
@@ -104,10 +134,19 @@ class _SignUpPageState extends State<SignUpPage> {
                       ),
                       const SizedBox(height: 6),
                       const Text(
-                        '요청하신 계정 생성 API가 준비되면 바로 연결됩니다.',
+                        '초대코드가 확인되면 계정이 생성되고 바로 로그인됩니다.',
                         style: TextStyle(color: Color(0xFF5B6572)),
                       ),
                       const SizedBox(height: 16),
+                      TextField(
+                        controller: _inviteCodeController,
+                        enabled: !_submitting,
+                        decoration: const InputDecoration(
+                          labelText: '초대 코드',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                      const SizedBox(height: 12),
                       TextField(
                         controller: _loginIdController,
                         enabled: !_submitting,


### PR DESCRIPTION
## 배경
- 기존 모바일 계정 로그인은 dev 전용(`/auth/dev/login`) 경로에 의존했습니다.
- 운영 로그인 플로우를 위해 사용자 ID/비밀번호 기반 회원가입/로그인 API가 필요했습니다.

## 변경사항
### API
- `/auth/signup`, `/auth/login` 엔드포인트 추가
- `user_password_credentials` 도메인/리포지토리/엔티티/매퍼 추가
- `V12__user_password_credentials.sql` 마이그레이션 추가
- invite code 검증 + loginId 정규화(소문자) + 비밀번호 해시 저장
- 로그인 시 토큰 발급 및 갱신 토큰 저장

### Mobile
- 계정 로그인 버튼이 `/auth/login`을 사용하도록 변경
- 회원가입 화면이 `/auth/signup`을 사용하고 성공 시 즉시 로그인 완료
- 카카오 토큰 획득 timeout(45초) 추가
- API 클라이언트 timeout(12초) 및 네트워크 예외 메시지 처리 추가

### Test
- `UserPasswordAuthApiTest` 추가
  - 회원가입 성공/중복 ID/로그인 성공/오류 비밀번호 케이스 검증

## 검증
- `apps/api`: `./gradlew.bat test`
- `apps/mobile`: `..\\..\\scripts\\flutterw.ps1 test`
- `apps/mobile`: `..\\..\\scripts\\flutterw.ps1 analyze`