### PR TITLE
chore(mobile): local/staging/release 환경 분리 및 실행/빌드 자동화

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -26,7 +26,10 @@
 
 ## Run
 
-Use the repo wrapper script `scripts/flutterw.ps1`.
+Use environment profiles under `apps/mobile/env/`:
+- `local.json`
+- `staging.json`
+- `release.json`
 
 ```powershell
 # first time from repo root
@@ -35,19 +38,20 @@ Use the repo wrapper script `scripts/flutterw.ps1`.
 cd apps/mobile
 ..\..\scripts\flutterw.ps1 pub get
 
-# web
-..\..\scripts\flutterw.ps1 run -d chrome --dart-define=API_BASE_URL=http://10.0.2.2:8080/api/v1
+# local emulator run
+cd ..\..
+.\scripts\run-mobile-emulator.ps1 -Environment local -DeviceId emulator-5554
 
-# android emulator/device (staging)
-..\..\scripts\flutterw.ps1 run -d emulator-5554 `
-  --dart-define=API_BASE_URL=http://13.209.200.12 `
-  --dart-define=KAKAO_NATIVE_APP_KEY=<kakao_native_app_key>
+# staging emulator run
+.\scripts\run-mobile-emulator.ps1 -Environment staging -DeviceId emulator-5554
 ```
 
 Notes:
+- `run-mobile-emulator.ps1` always injects `KAKAO_NATIVE_APP_KEY` from `apps/mobile/.env` (fallback: repo `.env`) unless overridden.
 - `API_BASE_URL` automatically appends `/api/v1` if omitted.
 - For physical devices, use the reachable host IP/domain instead of `10.0.2.2`.
 - Kakao Android callback scheme is `kakao<KAKAO_NATIVE_APP_KEY>`. If the key is missing/mismatched at run time, Kakao consent can stop at "Continue" without returning to the app.
+- Keep secrets (`KAKAO_NATIVE_APP_KEY`, signing keys) out of Git. See `docs/SECRETS_MANAGEMENT.md`.
 - `ENABLE_DEV_LOGIN=true` adds hidden local dev login panel on the login screen.
 
 ## Structure
@@ -81,6 +85,9 @@ lib/
 
 - Android release check: `.github/workflows/mobile-release-check.yml`
   - Builds `app-release.apk` and uploads artifact.
+- Local APK build helper: `scripts/build-mobile-apk.ps1`
+  - debug APK (staging): `.\scripts\build-mobile-apk.ps1 -Environment staging -BuildMode debug -Install`
+  - release APK: `.\scripts\build-mobile-apk.ps1 -Environment release -BuildMode release -ApiBaseUrl https://<prod-domain>/api/v1`
 - Store release readiness (Android only for now): `.github/workflows/mobile-store-release.yml` (manual)
   - signed AAB build (`flutter build appbundle --release`)
   - `android_distribution_mode=build_only`: build artifact only

--- a/apps/mobile/env/local.json
+++ b/apps/mobile/env/local.json
@@ -1,0 +1,5 @@
+{
+  "APP_ENV": "local",
+  "API_BASE_URL": "http://10.0.2.2:8080/api/v1",
+  "ENABLE_DEV_LOGIN": "false"
+}

--- a/apps/mobile/env/release.json
+++ b/apps/mobile/env/release.json
@@ -1,0 +1,5 @@
+{
+  "APP_ENV": "release",
+  "API_BASE_URL": "https://example.com/api/v1",
+  "ENABLE_DEV_LOGIN": "false"
+}

--- a/apps/mobile/env/staging.json
+++ b/apps/mobile/env/staging.json
@@ -1,0 +1,5 @@
+{
+  "APP_ENV": "staging",
+  "API_BASE_URL": "http://13.209.200.12/api/v1",
+  "ENABLE_DEV_LOGIN": "false"
+}

--- a/apps/mobile/lib/src/core/config/app_config.dart
+++ b/apps/mobile/lib/src/core/config/app_config.dart
@@ -1,11 +1,17 @@
 class AppConfig {
   static const _defaultApiBaseUrl = 'http://10.0.2.2:8080/api/v1';
+  static const _defaultAppEnv = 'local';
 
   static final apiBaseUrl = normalizeApiBaseUrl(
     const String.fromEnvironment(
       'API_BASE_URL',
       defaultValue: _defaultApiBaseUrl,
     ),
+  );
+
+  static const appEnv = String.fromEnvironment(
+    'APP_ENV',
+    defaultValue: _defaultAppEnv,
   );
 
   static const kakaoNativeAppKey = String.fromEnvironment(

--- a/apps/mobile/test/app_config_test.dart
+++ b/apps/mobile/test/app_config_test.dart
@@ -2,6 +2,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:eunhye_hymn_mobile/src/core/config/app_config.dart';
 
 void main() {
+  test('app env defaults to local', () {
+    expect(AppConfig.appEnv, 'local');
+  });
+
   test('API base URL default always includes /api/v1', () {
     expect(AppConfig.apiBaseUrl.endsWith('/api/v1'), isTrue);
   });

--- a/docs/SECRETS_MANAGEMENT.md
+++ b/docs/SECRETS_MANAGEMENT.md
@@ -1,44 +1,57 @@
 # Secrets Management Guide
 
-## 1. Principle
-- Do not commit real secrets to Git, even in private repositories.
-- Keep `.env` local-only and commit only templates (`.env.example`).
-- Store runtime secrets in dedicated secret stores.
+## 1) Core principles
+- Never commit real secrets to Git (private repo included).
+- Keep `.env` files local-only; commit only templates (`.env.example`).
+- Inject secrets at runtime (or CI job runtime), not in source files.
 
-## 2. Where to Store Secrets
-1. Local development
-- Store values in `.env` (ignored by Git).
-- Use non-production values only.
+## 2) Classify values first
+1. Public config (safe to commit)
+   - Example: feature flags, non-sensitive `API_BASE_URL`, `APP_ENV`.
+2. Sensitive config (treat as secret by policy)
+   - Example: third-party app keys that can be abused (`KAKAO_NATIVE_APP_KEY`).
+3. Real secrets (must never be committed)
+   - Example: `JWT_SECRET`, DB password, cloud credentials, signing keys.
 
-2. CI/CD (GitHub Actions)
-- Use `Settings > Secrets and variables > Actions`.
-- Split secrets by environment (`staging`, `production`).
+## 3) Environment separation policy
+- local
+  - Use local `.env` / `apps/mobile/.env` only.
+  - Non-production values only.
+- staging
+  - Use GitHub Actions environment secrets + managed secret store.
+  - Separate credentials from production.
+- release (production)
+  - Use dedicated production secret store and strict least-privilege access.
+  - No shared credentials with local/staging.
 
-3. Runtime (AWS)
-- Use AWS Secrets Manager or SSM Parameter Store.
-- Inject at deploy/runtime time, not at build time.
+## 4) Current repo conventions
+- Versioned (committed): `apps/mobile/env/local.json`, `staging.json`, `release.json`
+  - Store non-secret app config only (`APP_ENV`, `API_BASE_URL`, `ENABLE_DEV_LOGIN`).
+- Non-versioned (ignored): `.env`, `apps/mobile/.env`
+  - Store local-only secrets like `KAKAO_NATIVE_APP_KEY`.
+- CI/CD secret source: GitHub Actions `Settings > Secrets and variables > Actions`
+  - Split by environment (`staging`, `production`) and by purpose.
 
-## 3. Rotation Policy
-- Rotate immediately if exposure is suspected.
-- Rotate on a fixed schedule for high-impact secrets:
+## 5) Rotation and leak response
+- Rotate immediately when leak is suspected.
+- Periodically rotate high-impact secrets:
   - `JWT_SECRET`
-  - database passwords
+  - DB credentials
   - cloud access keys
+  - mobile signing credentials
+- Leak response steps:
+  1. Revoke/rotate leaked secret.
+  2. Audit access logs and token usage.
+  3. Purge leaked value from history if needed.
+  4. Record follow-up in `docs/changelog-dev.md`.
 
-## 4. PR/Review Checklist
+## 6) PR/review checklist
 - No real keys/tokens/passwords in changed files.
-- No secrets in logs, screenshots, PR body, or comments.
+- No secrets in logs/screenshots/PR body/comments.
 - `.env` files are not tracked by Git.
-- `.env.example` contains placeholders or local-safe defaults only.
+- `.env.example` keeps placeholders or local-safe defaults only.
 
-## 5. Incident Response (Secret Leak)
-1. Revoke/rotate the leaked secret.
-2. Audit access logs and token usage.
-3. Remove leaked values from history if needed.
-4. Record follow-up in `docs/changelog-dev.md`.
-
-## 6. Mobile Release Secrets (GitHub Actions)
-
+## 7) Mobile release secrets (GitHub Actions)
 Android signing (`.github/workflows/mobile-store-release.yml`):
 - `MOBILE_ANDROID_KEYSTORE_BASE64`
 - `MOBILE_ANDROID_KEY_ALIAS`

--- a/docs/TEAM_LOCAL_DEVELOPMENT.md
+++ b/docs/TEAM_LOCAL_DEVELOPMENT.md
@@ -102,13 +102,14 @@ Use `ADMIN_LOGIN_ID / ADMIN_LOGIN_PASSWORD` from `.env`.
 
 ## 6) Run mobile (Android emulator)
 ```bash
-.\scripts\run-mobile-emulator.ps1 -DeviceId emulator-5554
+.\scripts\run-mobile-emulator.ps1 -Environment local -DeviceId emulator-5554
 ```
 
 Flow in app:
 - Enter invite code then tap `카카오로 시작하기` for Kakao
-- Or tap `아이디/비밀번호로 시작하기` for DB user login check
-- Use DB user ID printed by `local-verify.ps1` for the ID field
+- Or tap `아이디/비밀번호로 시작하기` for `/auth/login`
+- If account does not exist yet, tap `회원가입` to create one via `/auth/signup`
+- Use an invite code created in local DB (from `local-verify.ps1` or admin page)
 
 ## 7) Useful DB checks
 ```bash

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -69,23 +69,18 @@
 cd apps/mobile
 ..\..\scripts\flutterw.ps1 pub get
 
-# 웹 실행
-..\..\scripts\flutterw.ps1 run -d chrome --dart-define=API_BASE_URL=http://10.0.2.2:8080/api/v1
-
-# Android 에뮬레이터/실기기 (staging)
-..\..\scripts\flutterw.ps1 run -d emulator-5554 --dart-define=API_BASE_URL=http://13.209.200.12
-
-# 소셜 로그인 포함 실행 (권장)
-..\..\scripts\flutterw.ps1 run -d emulator-5554 `
-  --dart-define=API_BASE_URL=http://13.209.200.12 `
-  --dart-define=KAKAO_NATIVE_APP_KEY=<kakao_native_app_key>
+# 환경 프로파일(local/staging/release) 기반 실행
+cd ..\..
+.\scripts\run-mobile-emulator.ps1 -Environment local -DeviceId emulator-5554
+.\scripts\run-mobile-emulator.ps1 -Environment staging -DeviceId emulator-5554
 ```
 
 실기기에서는 `10.0.2.2` 대신 로컬 서버 IP를 사용한다.
 `API_BASE_URL`에 `/api/v1`를 생략해도 앱에서 자동으로 보정한다.
 Android Kakao 콜백 스킴은 `kakao<KAKAO_NATIVE_APP_KEY>`이므로,
-앱 실행 시 `--dart-define=KAKAO_NATIVE_APP_KEY=...` 값이 누락/불일치하면
+`run-mobile-emulator.ps1`가 읽는 `apps/mobile/.env`(fallback: 루트 `.env`)의 키 값이 누락/불일치하면
 동의 화면의 "계속하기" 이후 앱으로 복귀하지 않을 수 있다.
+민감 정보 관리 원칙은 `docs/SECRETS_MANAGEMENT.md`를 따른다.
 로컬 개발용 로그인 화면이 필요하면 `--dart-define=ENABLE_DEV_LOGIN=true`를 함께 사용한다.
 
 ## 5.1 배포 범위 주의
@@ -120,8 +115,11 @@ Android Kakao 콜백 스킴은 `kakao<KAKAO_NATIVE_APP_KEY>`이므로,
 예시:
 
 ```powershell
-cd apps/mobile
-..\..\scripts\flutterw.ps1 build apk --release --dart-define=API_BASE_URL=https://example.com/api/v1
+# staging debug APK + install
+.\scripts\build-mobile-apk.ps1 -Environment staging -BuildMode debug -Install
+
+# release APK (운영 URL 명시 필요)
+.\scripts\build-mobile-apk.ps1 -Environment release -BuildMode release -ApiBaseUrl https://<prod-domain>/api/v1
 ```
 
 ## 6.2 Store release readiness

--- a/scripts/build-mobile-apk.ps1
+++ b/scripts/build-mobile-apk.ps1
@@ -1,9 +1,12 @@
 param(
     [ValidateSet("local", "staging", "release")]
     [string] $Environment = "local",
-    [string] $DeviceId = "emulator-5554",
+    [ValidateSet("debug", "release")]
+    [string] $BuildMode = "debug",
     [string] $ApiBaseUrl,
-    [string] $KakaoNativeAppKey
+    [string] $KakaoNativeAppKey,
+    [switch] $Install,
+    [string] $DeviceId = "emulator-5554"
 )
 
 $ErrorActionPreference = 'Stop'
@@ -74,23 +77,42 @@ function Read-JsonValue {
     return $value.ToString()
 }
 
-$profileApiBaseUrl = Read-JsonValue -Path $profileFile -Name "API_BASE_URL"
+function Resolve-AdbPath {
+    $fromCommand = Get-Command "adb" -ErrorAction SilentlyContinue
+    if ($fromCommand) {
+        return $fromCommand.Source
+    }
 
-$localEnvApiBaseUrl = $null
-if ($Environment -eq "local") {
-    $localEnvApiBaseUrl = Read-EnvValue -Path $mobileEnv -Name "API_BASE_URL"
+    $candidates = @(
+        [Environment]::GetEnvironmentVariable("LOCALAPPDATA", "User"),
+        $env:LOCALAPPDATA,
+        (Join-Path $env:USERPROFILE "AppData/Local")
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+
+    foreach ($base in $candidates) {
+        $candidate = Join-Path $base "Android/Sdk/platform-tools/adb.exe"
+        if (Test-Path -LiteralPath $candidate) {
+            return $candidate
+        }
+    }
+    return $null
 }
 
+$profileApiBaseUrl = Read-JsonValue -Path $profileFile -Name "API_BASE_URL"
 $resolvedApiBaseUrl = if (-not [string]::IsNullOrWhiteSpace($ApiBaseUrl)) {
     $ApiBaseUrl
-} elseif (-not [string]::IsNullOrWhiteSpace($localEnvApiBaseUrl)) {
-    $localEnvApiBaseUrl
 } else {
     $profileApiBaseUrl
 }
 
 if ([string]::IsNullOrWhiteSpace($resolvedApiBaseUrl)) {
     throw "API_BASE_URL is empty. Set it in $profileFile or pass -ApiBaseUrl."
+}
+
+if ($Environment -eq "release" -and
+    -not $ApiBaseUrl -and
+    $resolvedApiBaseUrl.Trim().ToLowerInvariant() -eq "https://example.com/api/v1") {
+    throw "Release API URL is placeholder. Pass -ApiBaseUrl for release build."
 }
 
 $resolvedKakaoKey = if ($KakaoNativeAppKey) {
@@ -117,10 +139,44 @@ if ($resolvedApiBaseUrl.Trim() -ne $profileApiBaseUrl) {
     $dartDefines += "--dart-define=API_BASE_URL=" + $resolvedApiBaseUrl.Trim()
 }
 
+$buildArgs = @("build", "apk")
+if ($BuildMode -eq "release") {
+    $buildArgs += "--release"
+} else {
+    $buildArgs += "--debug"
+}
+$buildArgs += $dartDefines
+
 Push-Location $mobileDir
 try {
-    Write-Host ("[run-mobile-emulator] environment={0} api={1}" -f $Environment, $resolvedApiBaseUrl.Trim())
-    & $flutter run -d $DeviceId @dartDefines
+    Write-Host ("[build-mobile-apk] environment={0} mode={1} api={2}" -f $Environment, $BuildMode, $resolvedApiBaseUrl.Trim())
+    & $flutter @buildArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "Flutter build failed with exit code $LASTEXITCODE"
+    }
 } finally {
     Pop-Location
 }
+
+$apkPath = if ($BuildMode -eq "release") {
+    Join-Path $mobileDir "build/app/outputs/flutter-apk/app-release.apk"
+} else {
+    Join-Path $mobileDir "build/app/outputs/flutter-apk/app-debug.apk"
+}
+
+if (-not (Test-Path -LiteralPath $apkPath)) {
+    throw "APK not found: $apkPath"
+}
+
+if ($Install) {
+    $adb = Resolve-AdbPath
+    if (-not $adb) {
+        throw "adb not found. Install Android SDK platform-tools or add adb to PATH."
+    }
+    & $adb -s $DeviceId install -r $apkPath
+    if ($LASTEXITCODE -ne 0) {
+        throw "adb install failed with exit code $LASTEXITCODE"
+    }
+}
+
+Write-Host ("APK_READY={0}" -f $apkPath)


### PR DESCRIPTION
## 배경
- 모바일 실행/빌드 파라미터가 수동 `--dart-define` 중심이라 환경 전환 시 실수 여지가 컸습니다.
- local/staging/release를 분리해서 실제 서비스 배포 전까지 동일한 절차로 검증할 필요가 있었습니다.
- `.env`/키 관리 가이드를 문서로 명확히 해야 했습니다.

## 변경사항
### Environment profile
- `apps/mobile/env/local.json`
- `apps/mobile/env/staging.json`
- `apps/mobile/env/release.json`
- `APP_ENV`, `API_BASE_URL`, `ENABLE_DEV_LOGIN`를 프로파일별로 분리

### Script
- `scripts/run-mobile-emulator.ps1`
  - `-Environment local|staging|release` 지원
  - `--dart-define-from-file` 기반 실행
  - `KAKAO_NATIVE_APP_KEY`를 `apps/mobile/.env`(fallback: 루트 `.env`)에서 자동 주입
- `scripts/build-mobile-apk.ps1` 추가
  - 환경별 debug/release APK 빌드
  - release placeholder URL 방지 체크
  - optional `-Install` + `adb` 경로 자동 탐색

### Mobile/App config
- `AppConfig.appEnv` 추가 (`APP_ENV`, default `local`)
- `app_config_test.dart`에 기본값 테스트 추가

### Docs
- `apps/mobile/README.md` 업데이트
- `docs/mobile/README.md` 업데이트
- `docs/TEAM_LOCAL_DEVELOPMENT.md` 업데이트
- `docs/SECRETS_MANAGEMENT.md` 보강
  - 환경별(local/staging/release) 민감정보 관리 원칙/체크리스트 명시

## 검증
- `apps/mobile`: `..\\..\\scripts\\flutterw.ps1 test`
- `apps/mobile`: `..\\..\\scripts\\flutterw.ps1 analyze`
- repo root: `./scripts/build-mobile-apk.ps1 -Environment staging -BuildMode debug`