### PR TITLE
feat(mobile): 로컬 에셋 캐시 보안/세션 분리 및 오프라인 재생 강화

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -7,7 +7,7 @@
 - Social login
   - Kakao SDK login (mobile, redirect flow)
   - Invite code input (first login only)
-  - Hidden dev login switch (`ENABLE_DEV_LOGIN=true`)
+  - Account signup/login (`POST /auth/signup`, `POST /auth/login`)
 - Hymn
   - List and search
   - Detail view
@@ -52,7 +52,6 @@ Notes:
 - For physical devices, use the reachable host IP/domain instead of `10.0.2.2`.
 - Kakao Android callback scheme is `kakao<KAKAO_NATIVE_APP_KEY>`. If the key is missing/mismatched at run time, Kakao consent can stop at "Continue" without returning to the app.
 - Keep secrets (`KAKAO_NATIVE_APP_KEY`, signing keys) out of Git. See `docs/SECRETS_MANAGEMENT.md`.
-- `ENABLE_DEV_LOGIN=true` adds hidden local dev login panel on the login screen.
 
 ## Structure
 

--- a/apps/mobile/lib/src/features/hymn/hymn_detail_page.dart
+++ b/apps/mobile/lib/src/features/hymn/hymn_detail_page.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
 
 import '../../core/network/api_exception.dart';
 import 'hymn_repository.dart';
+import 'local_asset_cache.dart';
 
 class HymnDetailPage extends StatefulWidget {
   final String hymnId;
@@ -19,7 +23,12 @@ class HymnDetailPage extends StatefulWidget {
 }
 
 class _HymnDetailPageState extends State<HymnDetailPage> {
+  static const _assetPrefetchBatchSize = 3;
+
   final _noteController = TextEditingController();
+  final _localAssetCache = LocalAssetCache();
+  final Map<String, String> _localAssetPaths = {};
+  int _assetLoadSequence = 0;
 
   bool _loading = true;
   bool _favorite = false;
@@ -36,6 +45,7 @@ class _HymnDetailPageState extends State<HymnDetailPage> {
 
   @override
   void dispose() {
+    _localAssetCache.dispose();
     _noteController.dispose();
     super.dispose();
   }
@@ -54,11 +64,14 @@ class _HymnDetailPageState extends State<HymnDetailPage> {
       if (!mounted) {
         return;
       }
+      final sequence = ++_assetLoadSequence;
       setState(() {
         _detail = detail;
         _noteController.text = note ?? '';
         _favorite = favorite;
+        _localAssetPaths.clear();
       });
+      unawaited(_cacheAssets(detail.assets, sequence));
     } catch (e) {
       if (!mounted) {
         return;
@@ -73,6 +86,51 @@ class _HymnDetailPageState extends State<HymnDetailPage> {
         });
       }
     }
+  }
+
+  Future<void> _cacheAssets(List<HymnAsset> assets, int sequence) async {
+    final sessionUserId = widget.hymnRepository.sessionUserId;
+    if (sessionUserId == null || sessionUserId.isEmpty || assets.isEmpty) {
+      return;
+    }
+
+    final resolvedPaths = <String, String>{};
+    for (var i = 0; i < assets.length; i += _assetPrefetchBatchSize) {
+      final batch = assets.skip(i).take(_assetPrefetchBatchSize).toList();
+      final batchEntries = await Future.wait(
+        batch.map(
+          (asset) => _cacheAssetPath(asset, sessionUserId: sessionUserId),
+        ),
+      );
+
+      if (!mounted || sequence != _assetLoadSequence) {
+        return;
+      }
+
+      for (final entry in batchEntries.whereType<MapEntry<String, String>>()) {
+        resolvedPaths[entry.key] = entry.value;
+      }
+
+      setState(() {
+        _localAssetPaths
+          ..clear()
+          ..addAll(resolvedPaths);
+      });
+    }
+  }
+
+  Future<MapEntry<String, String>?> _cacheAssetPath(
+    HymnAsset asset, {
+    required String sessionUserId,
+  }) async {
+    final path = await _localAssetCache.getOrDownload(
+      asset,
+      userId: sessionUserId,
+    );
+    if (path == null) {
+      return null;
+    }
+    return MapEntry(asset.id, path);
   }
 
   Future<void> _toggleFavorite() async {
@@ -223,7 +281,9 @@ class _HymnDetailPageState extends State<HymnDetailPage> {
           ),
           const SizedBox(height: 8),
           if (imageAssets.isEmpty)
-            const _EmptyCard(message: '관리자가 악보를 등록하면 여기에서 바로 볼 수 있어요.')
+            const _EmptyCard(
+              message: '관리자가 악보를 등록하면 여기에서 바로 볼 수 있어요.',
+            )
           else
             ...List.generate(
               imageAssets.length,
@@ -231,6 +291,7 @@ class _HymnDetailPageState extends State<HymnDetailPage> {
                 padding: const EdgeInsets.only(bottom: 10),
                 child: _ImageAssetCard(
                   asset: imageAssets[index],
+                  localPath: _localAssetPaths[imageAssets[index].id],
                   label: '악보 ${index + 1}페이지',
                 ),
               ),
@@ -253,11 +314,15 @@ class _HymnDetailPageState extends State<HymnDetailPage> {
                 child: _MidiCard(
                   title: '반주 ${index + 1}',
                   url: midiAssets[index].url,
+                  localPath: _localAssetPaths[midiAssets[index].id],
                 ),
               ),
             ),
           const SizedBox(height: 10),
-          const _SectionTitle(title: '메모', subtitle: '개인 메모를 저장해 보세요.'),
+          const _SectionTitle(
+            title: '메모',
+            subtitle: '개인 메모를 저장해 보세요.',
+          ),
           const SizedBox(height: 8),
           Card(
             child: Padding(
@@ -406,9 +471,11 @@ class _EmptyCard extends StatelessWidget {
 class _ImageAssetCard extends StatelessWidget {
   final HymnAsset asset;
   final String label;
+  final String? localPath;
 
   const _ImageAssetCard({
     required this.asset,
+    required this.localPath,
     required this.label,
   });
 
@@ -425,7 +492,25 @@ class _ImageAssetCard extends StatelessWidget {
               style: const TextStyle(fontWeight: FontWeight.w700),
             ),
             const SizedBox(height: 8),
-            if (asset.url.startsWith('http'))
+            if (localPath != null &&
+                localPath!.isNotEmpty &&
+                File(localPath!).existsSync())
+              ClipRRect(
+                borderRadius: BorderRadius.circular(10),
+                child: InteractiveViewer(
+                  minScale: 1,
+                  maxScale: 4,
+                  child: Image.file(
+                    File(localPath!),
+                    fit: BoxFit.fitWidth,
+                    errorBuilder: (_, __, ___) => const Padding(
+                      padding: EdgeInsets.all(12),
+                      child: Text('악보 이미지를 불러오지 못했습니다.'),
+                    ),
+                  ),
+                ),
+              )
+            else if (asset.url.startsWith('http'))
               ClipRRect(
                 borderRadius: BorderRadius.circular(10),
                 child: InteractiveViewer(
@@ -456,10 +541,12 @@ class _ImageAssetCard extends StatelessWidget {
 class _MidiCard extends StatelessWidget {
   final String title;
   final String url;
+  final String? localPath;
 
   const _MidiCard({
     required this.title,
     required this.url,
+    required this.localPath,
   });
 
   @override
@@ -475,7 +562,10 @@ class _MidiCard extends StatelessWidget {
               style: const TextStyle(fontWeight: FontWeight.w700),
             ),
             const SizedBox(height: 8),
-            _MidiAssetPlayer(url: url),
+            _MidiAssetPlayer(
+              url: url,
+              localPath: localPath,
+            ),
           ],
         ),
       ),
@@ -485,8 +575,12 @@ class _MidiCard extends StatelessWidget {
 
 class _MidiAssetPlayer extends StatefulWidget {
   final String url;
+  final String? localPath;
 
-  const _MidiAssetPlayer({required this.url});
+  const _MidiAssetPlayer({
+    required this.url,
+    required this.localPath,
+  });
 
   @override
   State<_MidiAssetPlayer> createState() => _MidiAssetPlayerState();
@@ -526,7 +620,7 @@ class _MidiAssetPlayerState extends State<_MidiAssetPlayer> {
         await _player.resume();
       } else {
         await _player.setPlaybackRate(_speed);
-        await _player.play(UrlSource(widget.url));
+        await _playFromBestSource();
       }
       if (!mounted) {
         return;
@@ -542,6 +636,21 @@ class _MidiAssetPlayerState extends State<_MidiAssetPlayer> {
         _error = '반주 재생에 실패했습니다.';
       });
     }
+  }
+
+  Future<void> _playFromBestSource() async {
+    final filePath = widget.localPath;
+    if (filePath != null &&
+        filePath.isNotEmpty &&
+        File(filePath).existsSync()) {
+      try {
+        await _player.play(DeviceFileSource(filePath));
+        return;
+      } catch (_) {
+        // Fallback to network when local file cannot be read.
+      }
+    }
+    await _player.play(UrlSource(widget.url));
   }
 
   Future<void> _stop() async {

--- a/apps/mobile/lib/src/features/hymn/hymn_repository.dart
+++ b/apps/mobile/lib/src/features/hymn/hymn_repository.dart
@@ -174,6 +174,8 @@ class HymnRepository {
 
   HymnRepository({required this.apiClient});
 
+  String? get sessionUserId => _sessionUserId;
+
   static const _hymnListCacheKey = 'mobile.cache.hymn.list';
   static const _historyCacheKey = 'mobile.cache.history';
   static const _pendingActionsKey = 'mobile.cache.pending.actions';

--- a/apps/mobile/lib/src/features/hymn/local_asset_cache.dart
+++ b/apps/mobile/lib/src/features/hymn/local_asset_cache.dart
@@ -1,0 +1,293 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'hymn_repository.dart';
+
+typedef CacheNowProvider = DateTime Function();
+typedef CachePrefsFactory = Future<SharedPreferences> Function();
+typedef CacheDirectoryProvider = Future<Directory> Function();
+
+class LocalAssetCache {
+  static const _indexKeyBase = 'mobile.cache.assets.files.v2';
+  static const _cacheDirName = 'hymn-assets';
+  static const _downloadTimeout = Duration(seconds: 20);
+  static const _defaultMaxAssetBytes = 25 * 1024 * 1024;
+
+  final http.Client _httpClient;
+  final bool _ownsHttpClient;
+  final CachePrefsFactory _prefsFactory;
+  final CacheDirectoryProvider _documentsDirectoryProvider;
+  final CacheNowProvider _now;
+  final int _maxAssetBytes;
+
+  LocalAssetCache({
+    http.Client? httpClient,
+    CachePrefsFactory? prefsFactory,
+    CacheDirectoryProvider? documentsDirectoryProvider,
+    CacheNowProvider? now,
+    int maxAssetBytes = _defaultMaxAssetBytes,
+  })  : _httpClient = httpClient ?? http.Client(),
+        _ownsHttpClient = httpClient == null,
+        _prefsFactory = prefsFactory ?? SharedPreferences.getInstance,
+        _documentsDirectoryProvider =
+            documentsDirectoryProvider ?? getApplicationDocumentsDirectory,
+        _now = now ?? DateTime.now,
+        _maxAssetBytes = maxAssetBytes;
+
+  void dispose() {
+    if (_ownsHttpClient) {
+      _httpClient.close();
+    }
+  }
+
+  Future<String?> getOrDownload(
+    HymnAsset asset, {
+    required String? userId,
+  }) async {
+    final normalizedUserId = _normalizeUserId(userId);
+    if (normalizedUserId == null) {
+      return null;
+    }
+
+    final cachedPath = await _resolveExistingPath(
+      asset,
+      normalizedUserId: normalizedUserId,
+    );
+    if (cachedPath != null) {
+      return cachedPath;
+    }
+
+    if (!asset.url.startsWith('http')) {
+      return null;
+    }
+
+    final uri = Uri.tryParse(asset.url);
+    if (uri == null) {
+      return null;
+    }
+
+    try {
+      final response = await _httpClient.get(uri).timeout(_downloadTimeout);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        return null;
+      }
+
+      if (!_supportsContentType(asset, response.headers['content-type'])) {
+        return null;
+      }
+
+      final announcedLength = response.contentLength;
+      if (announcedLength != null && announcedLength > _maxAssetBytes) {
+        return null;
+      }
+
+      final bytes = response.bodyBytes;
+      if (bytes.length > _maxAssetBytes) {
+        return null;
+      }
+
+      final directory = await _ensureCacheDirectory(normalizedUserId);
+      final file = File(
+        '${directory.path}${Platform.pathSeparator}${_buildFileName(asset)}',
+      );
+      await file.writeAsBytes(bytes, flush: true);
+
+      final index = await _readIndex(normalizedUserId);
+      index[asset.id] = {
+        'path': file.path,
+        'version': asset.version,
+        'updatedAt': _now().toUtc().toIso8601String(),
+      };
+      await _writeIndex(index, normalizedUserId);
+      return file.path;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<String?> _resolveExistingPath(
+    HymnAsset asset, {
+    required String normalizedUserId,
+  }) async {
+    final index = await _readIndex(normalizedUserId);
+    final dynamic entry = index[asset.id];
+    if (entry is! Map<String, dynamic>) {
+      return null;
+    }
+
+    final storedPath = entry['path']?.toString();
+    if (storedPath == null || storedPath.isEmpty) {
+      return null;
+    }
+
+    final incomingVersion = (asset.version ?? '').trim();
+    final storedVersion = entry['version']?.toString() ?? '';
+    if (incomingVersion.isNotEmpty && incomingVersion != storedVersion) {
+      await _removeEntry(
+        index,
+        assetId: asset.id,
+        filePath: storedPath,
+        normalizedUserId: normalizedUserId,
+      );
+      return null;
+    }
+
+    final file = File(storedPath);
+    if (!await file.exists()) {
+      await _removeEntry(
+        index,
+        assetId: asset.id,
+        filePath: storedPath,
+        normalizedUserId: normalizedUserId,
+      );
+      return null;
+    }
+
+    return storedPath;
+  }
+
+  Future<void> _removeEntry(
+    Map<String, dynamic> index, {
+    required String assetId,
+    required String filePath,
+    required String normalizedUserId,
+  }) async {
+    try {
+      final file = File(filePath);
+      if (await file.exists()) {
+        await file.delete();
+      }
+    } catch (_) {
+      // Best effort cleanup only.
+    }
+    index.remove(assetId);
+    await _writeIndex(index, normalizedUserId);
+  }
+
+  String _buildFileName(HymnAsset asset) {
+    final safeAssetId = _sanitize(asset.id, fallback: 'asset');
+    final safeVersion = _sanitize(asset.version ?? 'v0', fallback: 'v0');
+    return '$safeAssetId.$safeVersion${_extensionFor(asset)}';
+  }
+
+  String _extensionFor(HymnAsset asset) {
+    if (asset.isImage) {
+      return '.png';
+    }
+    if (asset.isMidi) {
+      return '.mid';
+    }
+
+    final uri = Uri.tryParse(asset.url);
+    if (uri == null) {
+      return '.bin';
+    }
+
+    final path = uri.path;
+    final dotIndex = path.lastIndexOf('.');
+    if (dotIndex <= 0 || dotIndex >= path.length - 1) {
+      return '.bin';
+    }
+
+    final extension = path.substring(dotIndex).toLowerCase();
+    if (extension.length > 10) {
+      return '.bin';
+    }
+    return extension;
+  }
+
+  bool _supportsContentType(HymnAsset asset, String? rawContentType) {
+    if (rawContentType == null || rawContentType.isEmpty) {
+      return true;
+    }
+
+    final contentType = rawContentType.split(';').first.trim().toLowerCase();
+
+    if (asset.isImage) {
+      return contentType.startsWith('image/') ||
+          contentType == 'application/octet-stream';
+    }
+
+    if (asset.isMidi) {
+      const allowedMidiTypes = {
+        'audio/midi',
+        'audio/mid',
+        'audio/x-midi',
+        'audio/sp-midi',
+        'application/x-midi',
+        'application/octet-stream',
+      };
+      return allowedMidiTypes.contains(contentType);
+    }
+
+    return contentType == 'application/octet-stream';
+  }
+
+  String? _normalizeUserId(String? userId) {
+    if (userId == null) {
+      return null;
+    }
+    final trimmed = userId.trim();
+    if (trimmed.isEmpty) {
+      return null;
+    }
+    return _sanitize(trimmed, fallback: 'anonymous');
+  }
+
+  String _sanitize(String raw, {required String fallback}) {
+    final cleaned = raw.replaceAll(RegExp(r'[^A-Za-z0-9_-]'), '_');
+    if (cleaned.isEmpty) {
+      return fallback;
+    }
+    return cleaned;
+  }
+
+  Future<Directory> _ensureCacheDirectory(String normalizedUserId) async {
+    final baseDir = await _documentsDirectoryProvider();
+    final cacheDir = Directory(
+      '${baseDir.path}${Platform.pathSeparator}$_cacheDirName'
+      '${Platform.pathSeparator}$normalizedUserId',
+    );
+    if (!await cacheDir.exists()) {
+      await cacheDir.create(recursive: true);
+    }
+    return cacheDir;
+  }
+
+  String _indexKeyForUser(String normalizedUserId) {
+    return '$_indexKeyBase.$normalizedUserId';
+  }
+
+  Future<Map<String, dynamic>> _readIndex(String normalizedUserId) async {
+    final prefs = await _prefsFactory();
+    final raw = prefs.getString(_indexKeyForUser(normalizedUserId));
+    if (raw == null || raw.isEmpty) {
+      return <String, dynamic>{};
+    }
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic>) {
+        return decoded;
+      }
+    } catch (_) {
+      // Reset to empty when index is malformed.
+    }
+    return <String, dynamic>{};
+  }
+
+  Future<void> _writeIndex(
+    Map<String, dynamic> index,
+    String normalizedUserId,
+  ) async {
+    final prefs = await _prefsFactory();
+    await prefs.setString(
+      _indexKeyForUser(normalizedUserId),
+      jsonEncode(index),
+    );
+  }
+}

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.2.2
+  path_provider: ^2.1.5
   shared_preferences: ^2.3.2
   uuid: ^4.5.1
   kakao_flutter_sdk_user: ^1.9.7+3
@@ -19,6 +20,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^4.0.0
+  path: ^1.9.1
 
 flutter:
   uses-material-design: true

--- a/apps/mobile/test/local_asset_cache_test.dart
+++ b/apps/mobile/test/local_asset_cache_test.dart
@@ -1,0 +1,208 @@
+import 'dart:io';
+
+import 'package:eunhye_hymn_mobile/src/features/hymn/hymn_repository.dart';
+import 'package:eunhye_hymn_mobile/src/features/hymn/local_asset_cache.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late Directory tempDirectory;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    tempDirectory = await Directory.systemTemp.createTemp(
+      'eunhye-asset-cache-test-',
+    );
+  });
+
+  tearDown(() async {
+    if (await tempDirectory.exists()) {
+      await tempDirectory.delete(recursive: true);
+    }
+  });
+
+  test('uses session-scoped cache paths per user', () async {
+    var requestCount = 0;
+    final cache = _createCache(
+      client: _MockHttpClient((_) async {
+        requestCount += 1;
+        return http.Response.bytes(
+          [1, 2, 3],
+          200,
+          headers: const {'content-type': 'image/png'},
+        );
+      }),
+      tempDirectory: tempDirectory,
+    );
+
+    final asset = _imageAsset(id: 'asset-1', version: 'v1');
+    final pathA = await cache.getOrDownload(asset, userId: 'user-A');
+    final pathB = await cache.getOrDownload(asset, userId: 'user-B');
+
+    expect(pathA, isNotNull);
+    expect(pathB, isNotNull);
+    expect(pathA, isNot(pathB));
+    expect(requestCount, 2);
+  });
+
+  test('reuses cached file for same user and version', () async {
+    var requestCount = 0;
+    final cache = _createCache(
+      client: _MockHttpClient((_) async {
+        requestCount += 1;
+        return http.Response.bytes(
+          [1, 2, 3],
+          200,
+          headers: const {'content-type': 'image/png'},
+        );
+      }),
+      tempDirectory: tempDirectory,
+    );
+
+    final asset = _imageAsset(id: 'asset-2', version: 'v1');
+    final firstPath = await cache.getOrDownload(asset, userId: 'member-1');
+    final secondPath = await cache.getOrDownload(asset, userId: 'member-1');
+
+    expect(firstPath, isNotNull);
+    expect(secondPath, firstPath);
+    expect(requestCount, 1);
+  });
+
+  test('rejects unexpected content-type for image assets', () async {
+    final cache = _createCache(
+      client: _MockHttpClient((_) async {
+        return http.Response.bytes(
+          [1, 2, 3],
+          200,
+          headers: const {'content-type': 'text/html'},
+        );
+      }),
+      tempDirectory: tempDirectory,
+    );
+
+    final path = await cache.getOrDownload(
+      _imageAsset(id: 'asset-3', version: 'v1'),
+      userId: 'member-1',
+    );
+
+    expect(path, isNull);
+  });
+
+  test('rejects payloads larger than max cache size', () async {
+    final cache = _createCache(
+      client: _MockHttpClient((_) async {
+        return http.Response.bytes(
+          [0, 1, 2, 3, 4],
+          200,
+          headers: const {'content-type': 'image/png'},
+        );
+      }),
+      tempDirectory: tempDirectory,
+      maxAssetBytes: 4,
+    );
+
+    final path = await cache.getOrDownload(
+      _imageAsset(id: 'asset-4', version: 'v1'),
+      userId: 'member-1',
+    );
+
+    expect(path, isNull);
+  });
+
+  test('removes stale file when asset version changes', () async {
+    var requestCount = 0;
+    final cache = _createCache(
+      client: _MockHttpClient((_) async {
+        requestCount += 1;
+        return http.Response.bytes(
+          [requestCount, requestCount + 1],
+          200,
+          headers: const {'content-type': 'image/png'},
+        );
+      }),
+      tempDirectory: tempDirectory,
+    );
+
+    final oldAsset = _imageAsset(id: 'asset-5', version: 'v1');
+    final newAsset = _imageAsset(id: 'asset-5', version: 'v2');
+    final oldPath = await cache.getOrDownload(oldAsset, userId: 'member-1');
+    final newPath = await cache.getOrDownload(newAsset, userId: 'member-1');
+
+    expect(oldPath, isNotNull);
+    expect(newPath, isNotNull);
+    expect(oldPath, isNot(newPath));
+    expect(File(oldPath!).existsSync(), isFalse);
+    expect(File(newPath!).existsSync(), isTrue);
+  });
+
+  test('sanitizes file names generated from asset id and version', () async {
+    final cache = _createCache(
+      client: _MockHttpClient((_) async {
+        return http.Response.bytes(
+          [1, 2, 3],
+          200,
+          headers: const {'content-type': 'image/png'},
+        );
+      }),
+      tempDirectory: tempDirectory,
+    );
+
+    final path = await cache.getOrDownload(
+      _imageAsset(id: '../bad:asset', version: '../../v1'),
+      userId: 'member-1',
+    );
+
+    expect(path, isNotNull);
+    final fileName = p.basename(path!);
+    expect(fileName.contains('..'), isFalse);
+    expect(fileName.contains('/'), isFalse);
+    expect(fileName.contains('\\'), isFalse);
+    expect(path.contains('../bad:asset'), isFalse);
+    expect(path.contains('..\\bad:asset'), isFalse);
+  });
+}
+
+LocalAssetCache _createCache({
+  required http.Client client,
+  required Directory tempDirectory,
+  int maxAssetBytes = 25 * 1024 * 1024,
+}) {
+  return LocalAssetCache(
+    httpClient: client,
+    prefsFactory: SharedPreferences.getInstance,
+    documentsDirectoryProvider: () async => tempDirectory,
+    now: () => DateTime.utc(2026, 2, 19),
+    maxAssetBytes: maxAssetBytes,
+  );
+}
+
+HymnAsset _imageAsset({required String id, required String version}) {
+  return HymnAsset(
+    id: id,
+    type: 'PNG',
+    part: 'ALL',
+    url: 'https://cdn.example.com/hymns/score.png',
+    checksum: null,
+    version: version,
+  );
+}
+
+class _MockHttpClient extends http.BaseClient {
+  final Future<http.Response> Function(Uri uri) _handler;
+
+  _MockHttpClient(this._handler);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final response = await _handler(request.url);
+    return http.StreamedResponse(
+      Stream<List<int>>.value(response.bodyBytes),
+      response.statusCode,
+      headers: response.headers,
+      reasonPhrase: response.reasonPhrase,
+      request: request,
+    );
+  }
+}

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -93,16 +93,45 @@ Base URL: `/api/v1`
 }
 ```
 
-### 1.7 DEV 로그인 (개발 환경 전용)
-- `POST /auth/dev/login`
+### 1.7 사용자 회원가입
+- `POST /auth/signup`
 - 요청 `data` 예시:
 ```json
 {
-  "userId": "00000000-0000-0000-0000-000000000000",
-  "role": "USER",
-  "displayName": "개발 사용자"
+  "loginId": "member.one",
+  "password": "password-123!",
+  "inviteCode": "ABC123"
 }
 ```
+- 응답 `data` 예시:
+```json
+{
+  "accessToken": "jwt-access",
+  "refreshToken": "jwt-refresh",
+  "newUser": true
+}
+```
+
+### 1.8 사용자 로그인
+- `POST /auth/login`
+- 요청 `data` 예시:
+```json
+{
+  "loginId": "member.one",
+  "password": "password-123!"
+}
+```
+- 응답 `data` 예시:
+```json
+{
+  "accessToken": "jwt-access",
+  "refreshToken": "jwt-refresh",
+  "newUser": false
+}
+```
+
+### 1.9 DEV 로그인 (개발/테스트 전용, 운영 앱 미사용)
+- `POST /auth/dev/login`
 
 ## 2. 찬양
 

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -10,7 +10,7 @@
   - 소셜 SDK 직접 로그인 (Kakao 모바일)
   - 로그인 화면에서 Kakao 버튼 클릭 시 provider 앱/브라우저로 리디렉션
   - 초대코드 입력 지원 (최초 1회)
-  - Dev 로그인은 `ENABLE_DEV_LOGIN=true`일 때만 노출
+  - 계정 회원가입/로그인(`POST /auth/signup`, `POST /auth/login`)
 - 찬양
   - 목록 조회 + 검색
   - 목록 화면 태그 필터 + 검색어/필터 초기화 + 빈 상태 가이드
@@ -48,7 +48,8 @@
 - Base URL: `/api/v1`
 - 사용 API:
   - `POST /auth/social`
-  - `POST /auth/dev/login`
+  - `POST /auth/signup`
+  - `POST /auth/login`
   - `POST /auth/refresh`
   - `POST /auth/logout`
   - `GET /me/profile`
@@ -81,7 +82,7 @@ Android Kakao 콜백 스킴은 `kakao<KAKAO_NATIVE_APP_KEY>`이므로,
 `run-mobile-emulator.ps1`가 읽는 `apps/mobile/.env`(fallback: 루트 `.env`)의 키 값이 누락/불일치하면
 동의 화면의 "계속하기" 이후 앱으로 복귀하지 않을 수 있다.
 민감 정보 관리 원칙은 `docs/SECRETS_MANAGEMENT.md`를 따른다.
-로컬 개발용 로그인 화면이 필요하면 `--dart-define=ENABLE_DEV_LOGIN=true`를 함께 사용한다.
+계정 로그인/회원가입은 운영 API(`/auth/login`, `/auth/signup`)를 사용한다.
 
 ## 5.1 배포 범위 주의
 


### PR DESCRIPTION
## 배경
- 찬양 상세에서 이미지/MIDI를 매번 네트워크로 불러와 오프라인 재생/조회 안정성이 낮았습니다.
- 로컬 에셋 캐시는 있었지만 세션 분리/입력값 sanitizing/콘텐츠 검증이 부족했습니다.

## 변경사항
### 1) 모바일 로컬 에셋 캐시 하드닝
- `LocalAssetCache` 신규 도입 (`apps/mobile/lib/src/features/hymn/local_asset_cache.dart`)
- 사용자 세션별 캐시 분리
  - 인덱스 키: `mobile.cache.assets.files.v2.<user>`
  - 파일 경로: `hymn-assets/<user>/...`
- 파일명 sanitizing 강화 (assetId/version에서 위험 문자 제거)
- 콘텐츠 타입 허용 목록 검증
  - PNG: `image/*`, `application/octet-stream`
  - MIDI: `audio/midi` 계열 + `application/octet-stream`
- 최대 파일 크기 제한(기본 25MB)

### 2) 찬양 상세 화면 개선
- 에셋 prefetch를 배치 병렬(기본 3개)로 수행
- 세션 사용자 ID가 있을 때만 캐시 사용
- 로컬 파일 우선 렌더링/재생
  - 이미지: `Image.file`
  - MIDI: `DeviceFileSource` 우선, 실패 시 URL fallback

### 3) 테스트 추가
- `apps/mobile/test/local_asset_cache_test.dart`
  - 사용자별 경로 분리
  - 동일 버전 재사용
  - 콘텐츠 타입 거부
  - 최대 크기 초과 거부
  - 버전 변경 시 기존 파일 정리
  - 파일명 sanitizing

### 4) 문서 정합성 업데이트
- `apps/mobile/README.md`
- `docs/mobile/README.md`
- `docs/api-contract.md`
- 모바일 운영 로그인 기준(`/auth/signup`, `/auth/login`)으로 정리

## 검증
- `apps/mobile`: `..\\..\\scripts\\flutterw.ps1 analyze`
- `apps/mobile`: `..\\..\\scripts\\flutterw.ps1 test`