### PR TITLE
fix(mobile): enforce streamed cache limits for hymn assets

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -19,6 +19,7 @@
   - Recent history
 - Offline
   - Local cache fallback for list/detail/note/favorites/history
+  - Hymn score/MIDI downloads are cached per session user and rejected when content-type or size checks fail
   - Offline changes are synced when network is restored
 - Auth
   - Access/refresh token persistence

--- a/apps/mobile/lib/src/features/hymn/local_asset_cache.dart
+++ b/apps/mobile/lib/src/features/hymn/local_asset_cache.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
@@ -71,7 +72,9 @@ class LocalAssetCache {
     }
 
     try {
-      final response = await _httpClient.get(uri).timeout(_downloadTimeout);
+      final request = http.Request('GET', uri);
+      final response =
+          await _httpClient.send(request).timeout(_downloadTimeout);
       if (response.statusCode < 200 || response.statusCode >= 300) {
         return null;
       }
@@ -85,8 +88,8 @@ class LocalAssetCache {
         return null;
       }
 
-      final bytes = response.bodyBytes;
-      if (bytes.length > _maxAssetBytes) {
+      final bytes = await _readResponseBytesWithinLimit(response);
+      if (bytes == null) {
         return null;
       }
 
@@ -107,6 +110,23 @@ class LocalAssetCache {
     } catch (_) {
       return null;
     }
+  }
+
+  Future<Uint8List?> _readResponseBytesWithinLimit(
+    http.StreamedResponse response,
+  ) async {
+    final bytes = BytesBuilder(copy: false);
+    var totalBytes = 0;
+
+    await for (final chunk in response.stream.timeout(_downloadTimeout)) {
+      totalBytes += chunk.length;
+      if (totalBytes > _maxAssetBytes) {
+        return null;
+      }
+      bytes.add(chunk);
+    }
+
+    return bytes.takeBytes();
   }
 
   Future<String?> _resolveExistingPath(
@@ -202,7 +222,7 @@ class LocalAssetCache {
 
   bool _supportsContentType(HymnAsset asset, String? rawContentType) {
     if (rawContentType == null || rawContentType.isEmpty) {
-      return true;
+      return false;
     }
 
     final contentType = rawContentType.split(';').first.trim().toLowerCase();

--- a/apps/mobile/test/local_asset_cache_test.dart
+++ b/apps/mobile/test/local_asset_cache_test.dart
@@ -90,17 +90,39 @@ void main() {
     expect(path, isNull);
   });
 
-  test('rejects payloads larger than max cache size', () async {
+  test('rejects missing content-type for image assets', () async {
     final cache = _createCache(
       client: _MockHttpClient((_) async {
         return http.Response.bytes(
-          [0, 1, 2, 3, 4],
+          [1, 2, 3],
+          200,
+        );
+      }),
+      tempDirectory: tempDirectory,
+    );
+
+    final path = await cache.getOrDownload(
+      _imageAsset(id: 'asset-4', version: 'v1'),
+      userId: 'member-1',
+    );
+
+    expect(path, isNull);
+  });
+
+  test('rejects payloads larger than max cache size while streaming', () async {
+    final cache = _createCache(
+      client: _MockStreamingHttpClient((_) async {
+        return http.StreamedResponse(
+          Stream<List<int>>.fromIterable([
+            [0, 1, 2, 3],
+            [4, 5, 6, 7],
+          ]),
           200,
           headers: const {'content-type': 'image/png'},
         );
       }),
       tempDirectory: tempDirectory,
-      maxAssetBytes: 4,
+      maxAssetBytes: 6,
     );
 
     final path = await cache.getOrDownload(
@@ -204,5 +226,16 @@ class _MockHttpClient extends http.BaseClient {
       reasonPhrase: response.reasonPhrase,
       request: request,
     );
+  }
+}
+
+class _MockStreamingHttpClient extends http.BaseClient {
+  final Future<http.StreamedResponse> Function(Uri uri) _handler;
+
+  _MockStreamingHttpClient(this._handler);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    return _handler(request.url);
   }
 }


### PR DESCRIPTION
## What\n- switch asset downloads to http.Client.send + streaming byte accumulation\n- enforce max size during stream read (not after full body buffering)\n- reject missing Content-Type during cache validation\n- extend mobile cache tests for missing content-type and streaming oversize responses\n- document stricter offline asset cache validation in pps/mobile/README.md\n\n## Why\nAddresses follow-up fixes after the original cache-hardening merge, including Codex review findings on memory safety and content-type validation.