### PR TITLE
feat(profile): server-synced profile + settings tab + auth rate-limit

### DIFF
--- a/.github/workflows/mobile-release-check.yml
+++ b/.github/workflows/mobile-release-check.yml
@@ -47,7 +47,8 @@ jobs:
         run: flutter pub get
 
       - name: Build Android release APK
-        run: flutter build apk --release --dart-define=API_BASE_URL=${{ env.API_BASE_URL }}
+        run: |
+          flutter build apk --release --dart-define=API_BASE_URL="${API_BASE_URL}"
 
       - name: Upload release artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/mobile-store-release.yml
+++ b/.github/workflows/mobile-store-release.yml
@@ -130,7 +130,8 @@ jobs:
         run: flutter pub get
 
       - name: Build Android signed AAB
-        run: flutter build appbundle --release --dart-define=API_BASE_URL=${{ env.API_BASE_URL }}
+        run: |
+          flutter build appbundle --release --dart-define=API_BASE_URL="${API_BASE_URL}"
 
       - name: Upload Android AAB artifact
         uses: actions/upload-artifact@v4
@@ -171,7 +172,8 @@ jobs:
         run: flutter pub get
 
       - name: Build iOS release (no codesign)
-        run: flutter build ios --release --no-codesign --dart-define=API_BASE_URL=${{ env.API_BASE_URL }}
+        run: |
+          flutter build ios --release --no-codesign --dart-define=API_BASE_URL="${API_BASE_URL}"
 
       - name: Upload iOS app artifact
         uses: actions/upload-artifact@v4
@@ -247,7 +249,7 @@ jobs:
       - name: Build iOS signed archive and IPA
         run: |
           set -euo pipefail
-          flutter build ios --release --no-codesign --dart-define=API_BASE_URL=${{ env.API_BASE_URL }}
+          flutter build ios --release --no-codesign --dart-define=API_BASE_URL="${API_BASE_URL}"
 
           xcodebuild -workspace ios/Runner.xcworkspace \
             -scheme Runner \

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/GetMyProfileUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/GetMyProfileUseCase.java
@@ -1,0 +1,53 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.common.error.ApiException;
+import com.eunhyehymn.domain.model.Role;
+import com.eunhyehymn.domain.model.User;
+import com.eunhyehymn.domain.model.UserProfile;
+import com.eunhyehymn.domain.repository.UserProfileRepository;
+import com.eunhyehymn.domain.repository.UserRepository;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+
+public class GetMyProfileUseCase {
+    private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
+
+    public GetMyProfileUseCase(UserRepository userRepository, UserProfileRepository userProfileRepository) {
+        this.userRepository = userRepository;
+        this.userProfileRepository = userProfileRepository;
+    }
+
+    public Result get(UUID userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "user_not_found", "user not found", null));
+
+        UserProfile profile = userProfileRepository.findByUserId(userId).orElse(null);
+        return new Result(
+            user.id(),
+            user.role(),
+            user.displayName(),
+            profile == null ? null : profile.churchName(),
+            profile == null ? null : profile.name(),
+            profile == null ? null : profile.groupName(),
+            profile == null ? null : profile.updatedAt()
+        );
+    }
+
+    public record Result(
+        UUID userId,
+        Role role,
+        String displayName,
+        String churchName,
+        String name,
+        String group,
+        Instant profileUpdatedAt
+    ) {
+        public boolean profileCompleted() {
+            return churchName != null && !churchName.isBlank()
+                && name != null && !name.isBlank()
+                && group != null && !group.isBlank();
+        }
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/UpsertMyProfileUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/UpsertMyProfileUseCase.java
@@ -1,0 +1,60 @@
+package com.eunhyehymn.application.usecases;
+
+import com.eunhyehymn.common.error.ApiException;
+import com.eunhyehymn.domain.model.UserProfile;
+import com.eunhyehymn.domain.repository.UserProfileRepository;
+import com.eunhyehymn.domain.repository.UserRepository;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+
+public class UpsertMyProfileUseCase {
+    private static final int MAX_TEXT_LENGTH = 255;
+
+    private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
+
+    public UpsertMyProfileUseCase(UserRepository userRepository, UserProfileRepository userProfileRepository) {
+        this.userRepository = userRepository;
+        this.userProfileRepository = userProfileRepository;
+    }
+
+    public UserProfile upsert(UUID userId, String churchName, String name, String group) {
+        userRepository.findById(userId)
+            .orElseThrow(() -> new ApiException(HttpStatus.NOT_FOUND, "user_not_found", "user not found", null));
+
+        String normalizedChurchName = normalizeRequired(churchName, "churchName");
+        String normalizedName = normalizeRequired(name, "name");
+        String normalizedGroup = normalizeRequired(group, "group");
+
+        UserProfile profile = new UserProfile(
+            userId,
+            normalizedChurchName,
+            normalizedName,
+            normalizedGroup,
+            Instant.now()
+        );
+        return userProfileRepository.save(profile);
+    }
+
+    private String normalizeRequired(String value, String fieldName) {
+        String normalized = value == null ? "" : value.trim();
+        if (normalized.isEmpty()) {
+            throw new ApiException(
+                HttpStatus.BAD_REQUEST,
+                "validation_error",
+                fieldName + " is required",
+                null
+            );
+        }
+        if (normalized.length() > MAX_TEXT_LENGTH) {
+            throw new ApiException(
+                HttpStatus.BAD_REQUEST,
+                "validation_error",
+                fieldName + " is too long",
+                null
+            );
+        }
+        return normalized;
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/common/config/UseCaseConfig.java
+++ b/apps/api/src/main/java/com/eunhyehymn/common/config/UseCaseConfig.java
@@ -16,10 +16,12 @@ import com.eunhyehymn.application.usecases.GetFavoriteUseCase;
 import com.eunhyehymn.application.usecases.GetHistoryUseCase;
 import com.eunhyehymn.application.usecases.GetHymnDetailUseCase;
 import com.eunhyehymn.application.usecases.GetHymnNoteUseCase;
+import com.eunhyehymn.application.usecases.GetMyProfileUseCase;
 import com.eunhyehymn.application.usecases.ListHymnsUseCase;
 import com.eunhyehymn.application.usecases.RecordEventsUseCase;
 import com.eunhyehymn.application.usecases.SaveHymnNoteUseCase;
 import com.eunhyehymn.application.usecases.ToggleFavoriteUseCase;
+import com.eunhyehymn.application.usecases.UpsertMyProfileUseCase;
 import com.eunhyehymn.domain.repository.AssetRepository;
 import com.eunhyehymn.domain.repository.EventExportJobCleanupRunRepository;
 import com.eunhyehymn.domain.repository.EventExportJobRepository;
@@ -27,6 +29,7 @@ import com.eunhyehymn.domain.repository.EventRepository;
 import com.eunhyehymn.domain.repository.HymnNoteRepository;
 import com.eunhyehymn.domain.repository.HymnRepository;
 import com.eunhyehymn.domain.repository.UserHymnStateRepository;
+import com.eunhyehymn.domain.repository.UserProfileRepository;
 import com.eunhyehymn.domain.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -71,6 +74,22 @@ public class UseCaseConfig {
     @Bean
     GetHistoryUseCase getHistoryUseCase(UserHymnStateRepository userHymnStateRepository, HymnRepository hymnRepository) {
         return new GetHistoryUseCase(userHymnStateRepository, hymnRepository);
+    }
+
+    @Bean
+    GetMyProfileUseCase getMyProfileUseCase(
+        UserRepository userRepository,
+        UserProfileRepository userProfileRepository
+    ) {
+        return new GetMyProfileUseCase(userRepository, userProfileRepository);
+    }
+
+    @Bean
+    UpsertMyProfileUseCase upsertMyProfileUseCase(
+        UserRepository userRepository,
+        UserProfileRepository userProfileRepository
+    ) {
+        return new UpsertMyProfileUseCase(userRepository, userProfileRepository);
     }
 
     @Bean

--- a/apps/api/src/main/java/com/eunhyehymn/domain/model/UserProfile.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/model/UserProfile.java
@@ -1,0 +1,13 @@
+package com.eunhyehymn.domain.model;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record UserProfile(
+    UUID userId,
+    String churchName,
+    String name,
+    String groupName,
+    Instant updatedAt
+) {
+}

--- a/apps/api/src/main/java/com/eunhyehymn/domain/repository/UserProfileRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/domain/repository/UserProfileRepository.java
@@ -1,0 +1,11 @@
+package com.eunhyehymn.domain.repository;
+
+import com.eunhyehymn.domain.model.UserProfile;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserProfileRepository {
+    UserProfile save(UserProfile userProfile);
+
+    Optional<UserProfile> findByUserId(UUID userId);
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserProfileEntity.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserProfileEntity.java
@@ -1,0 +1,59 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_profiles")
+public class UserProfileEntity {
+    @Id
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "church_name", nullable = false)
+    private String churchName;
+
+    @Column(name = "member_name", nullable = false)
+    private String memberName;
+
+    @Column(name = "group_name", nullable = false)
+    private String groupName;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected UserProfileEntity() {
+    }
+
+    public UserProfileEntity(UUID userId, String churchName, String memberName, String groupName, Instant updatedAt) {
+        this.userId = userId;
+        this.churchName = churchName;
+        this.memberName = memberName;
+        this.groupName = groupName;
+        this.updatedAt = updatedAt;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public String getChurchName() {
+        return churchName;
+    }
+
+    public String getMemberName() {
+        return memberName;
+    }
+
+    public String getGroupName() {
+        return groupName;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserProfileJpaRepository.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserProfileJpaRepository.java
@@ -1,0 +1,7 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserProfileJpaRepository extends JpaRepository<UserProfileEntity, UUID> {
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserProfileRepositoryAdapter.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/UserProfileRepositoryAdapter.java
@@ -1,0 +1,28 @@
+package com.eunhyehymn.infrastructure.persistence;
+
+import com.eunhyehymn.domain.model.UserProfile;
+import com.eunhyehymn.domain.repository.UserProfileRepository;
+import com.eunhyehymn.infrastructure.persistence.mapper.UserProfileMapper;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class UserProfileRepositoryAdapter implements UserProfileRepository {
+    private final UserProfileJpaRepository userProfileJpaRepository;
+
+    public UserProfileRepositoryAdapter(UserProfileJpaRepository userProfileJpaRepository) {
+        this.userProfileJpaRepository = userProfileJpaRepository;
+    }
+
+    @Override
+    public UserProfile save(UserProfile userProfile) {
+        UserProfileEntity saved = userProfileJpaRepository.save(UserProfileMapper.toEntity(userProfile));
+        return UserProfileMapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<UserProfile> findByUserId(UUID userId) {
+        return userProfileJpaRepository.findById(userId).map(UserProfileMapper::toDomain);
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/mapper/UserProfileMapper.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/persistence/mapper/UserProfileMapper.java
@@ -1,0 +1,29 @@
+package com.eunhyehymn.infrastructure.persistence.mapper;
+
+import com.eunhyehymn.domain.model.UserProfile;
+import com.eunhyehymn.infrastructure.persistence.UserProfileEntity;
+
+public final class UserProfileMapper {
+    private UserProfileMapper() {
+    }
+
+    public static UserProfile toDomain(UserProfileEntity entity) {
+        return new UserProfile(
+            entity.getUserId(),
+            entity.getChurchName(),
+            entity.getMemberName(),
+            entity.getGroupName(),
+            entity.getUpdatedAt()
+        );
+    }
+
+    public static UserProfileEntity toEntity(UserProfile profile) {
+        return new UserProfileEntity(
+            profile.userId(),
+            profile.churchName(),
+            profile.name(),
+            profile.groupName(),
+            profile.updatedAt()
+        );
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/infrastructure/security/AuthRateLimitService.java
+++ b/apps/api/src/main/java/com/eunhyehymn/infrastructure/security/AuthRateLimitService.java
@@ -1,0 +1,146 @@
+package com.eunhyehymn.infrastructure.security;
+
+import com.eunhyehymn.common.error.ApiException;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthRateLimitService {
+    private static final Logger log = LoggerFactory.getLogger(AuthRateLimitService.class);
+    private static final String RATE_LIMIT_MESSAGE = "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.";
+
+    private final MeterRegistry meterRegistry;
+    private final boolean enabled;
+    private final int windowSeconds;
+    private final int maxAttemptsPerKey;
+    private final Clock clock;
+
+    private final ConcurrentHashMap<String, WindowCounter> counters = new ConcurrentHashMap<>();
+    private final AtomicLong callCounter = new AtomicLong(0);
+
+    public AuthRateLimitService(
+        MeterRegistry meterRegistry,
+        @Value("${security.rate-limit.auth.enabled:true}") boolean enabled,
+        @Value("${security.rate-limit.auth.window-seconds:60}") int windowSeconds,
+        @Value("${security.rate-limit.auth.max-attempts-per-key:25}") int maxAttemptsPerKey
+    ) {
+        this.meterRegistry = meterRegistry;
+        this.enabled = enabled;
+        this.windowSeconds = Math.max(1, windowSeconds);
+        this.maxAttemptsPerKey = Math.max(1, maxAttemptsPerKey);
+        this.clock = Clock.systemUTC();
+    }
+
+    public void checkOrThrow(String scope, String subject) {
+        if (!enabled) {
+            return;
+        }
+
+        String normalizedScope = normalizeScope(scope);
+        String normalizedSubject = normalizeSubject(subject);
+        boolean allowed = tryAcquire(normalizedScope, normalizedSubject);
+        if (allowed) {
+            meterRegistry.counter("auth_rate_limit_allowed_total", "scope", normalizedScope).increment();
+            return;
+        }
+
+        meterRegistry.counter("auth_rate_limit_rejected_total", "scope", normalizedScope).increment();
+        log.warn(
+            "auth rate limit exceeded: scope={} subject={} windowSeconds={} maxAttemptsPerKey={}",
+            normalizedScope,
+            normalizedSubject,
+            windowSeconds,
+            maxAttemptsPerKey
+        );
+
+        throw new ApiException(
+            HttpStatus.TOO_MANY_REQUESTS,
+            "too_many_requests",
+            RATE_LIMIT_MESSAGE,
+            Map.of("scope", normalizedScope, "windowSeconds", windowSeconds)
+        );
+    }
+
+    public void recordOutcome(String scope, boolean success) {
+        meterRegistry.counter(
+            "auth_requests_total",
+            "scope",
+            normalizeScope(scope),
+            "result",
+            success ? "success" : "failure"
+        ).increment();
+    }
+
+    private boolean tryAcquire(String scope, String subject) {
+        long nowEpochSecond = Instant.now(clock).getEpochSecond();
+        long windowStart = (nowEpochSecond / windowSeconds) * windowSeconds;
+        String key = scope + ":" + subject;
+
+        AtomicBoolean allowed = new AtomicBoolean(false);
+        counters.compute(key, (ignored, existing) -> {
+            WindowCounter next = existing;
+            if (next == null || next.windowStartEpochSecond != windowStart) {
+                next = new WindowCounter(windowStart, 0, nowEpochSecond);
+            }
+            next.lastSeenEpochSecond = nowEpochSecond;
+            if (next.count < maxAttemptsPerKey) {
+                next.count += 1;
+                allowed.set(true);
+            }
+            return next;
+        });
+
+        maybeCleanup(nowEpochSecond);
+        return allowed.get();
+    }
+
+    private void maybeCleanup(long nowEpochSecond) {
+        long currentCalls = callCounter.incrementAndGet();
+        if (currentCalls % 256 != 0) {
+            return;
+        }
+
+        long expireBefore = nowEpochSecond - (windowSeconds * 2L);
+        counters.entrySet().removeIf(entry -> entry.getValue().lastSeenEpochSecond < expireBefore);
+    }
+
+    private String normalizeScope(String scope) {
+        if (scope == null || scope.isBlank()) {
+            return "unknown";
+        }
+        return scope.trim().toLowerCase();
+    }
+
+    private String normalizeSubject(String subject) {
+        if (subject == null || subject.isBlank()) {
+            return "anonymous";
+        }
+        String normalized = subject.trim().toLowerCase();
+        if (normalized.length() <= 120) {
+            return normalized;
+        }
+        return normalized.substring(0, 120);
+    }
+
+    private static final class WindowCounter {
+        long windowStartEpochSecond;
+        int count;
+        long lastSeenEpochSecond;
+
+        private WindowCounter(long windowStartEpochSecond, int count, long lastSeenEpochSecond) {
+            this.windowStartEpochSecond = windowStartEpochSecond;
+            this.count = count;
+            this.lastSeenEpochSecond = lastSeenEpochSecond;
+        }
+    }
+}

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AuthController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AuthController.java
@@ -9,8 +9,11 @@ import com.eunhyehymn.application.usecases.UserPasswordSignupUseCase;
 import com.eunhyehymn.application.usecases.ValidateInviteCodeUseCase;
 import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.common.response.ApiResponse;
+import com.eunhyehymn.infrastructure.security.AuthRateLimitService;
 import com.eunhyehymn.infrastructure.security.SocialLoginException;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.constraints.NotBlank;
+import java.util.Locale;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,6 +32,7 @@ public class AuthController {
     private final SocialLoginUseCase socialLoginUseCase;
     private final UserPasswordSignupUseCase userPasswordSignupUseCase;
     private final UserPasswordLoginUseCase userPasswordLoginUseCase;
+    private final AuthRateLimitService authRateLimitService;
 
     public AuthController(
         AdminPasswordLoginUseCase adminPasswordLoginUseCase,
@@ -37,7 +41,8 @@ public class AuthController {
         ValidateInviteCodeUseCase validateInviteCodeUseCase,
         SocialLoginUseCase socialLoginUseCase,
         UserPasswordSignupUseCase userPasswordSignupUseCase,
-        UserPasswordLoginUseCase userPasswordLoginUseCase
+        UserPasswordLoginUseCase userPasswordLoginUseCase,
+        AuthRateLimitService authRateLimitService
     ) {
         this.adminPasswordLoginUseCase = adminPasswordLoginUseCase;
         this.refreshTokenUseCase = refreshTokenUseCase;
@@ -46,80 +51,114 @@ public class AuthController {
         this.socialLoginUseCase = socialLoginUseCase;
         this.userPasswordSignupUseCase = userPasswordSignupUseCase;
         this.userPasswordLoginUseCase = userPasswordLoginUseCase;
+        this.authRateLimitService = authRateLimitService;
     }
 
     @PostMapping("/admin/login")
     public ApiResponse<SocialLoginResponse> adminPasswordLogin(
-        @RequestBody @Validated AdminPasswordLoginRequest request
+        @RequestBody @Validated AdminPasswordLoginRequest request,
+        HttpServletRequest httpRequest
     ) {
+        String key = keyByIpAndLoginId(httpRequest, request.loginId());
+        authRateLimitService.checkOrThrow("admin_login", key);
+
         try {
             AdminPasswordLoginUseCase.LoginResult result = adminPasswordLoginUseCase.login(
                 request.loginId(),
                 request.password()
             );
+            authRateLimitService.recordOutcome("admin_login", true);
             return ApiResponse.success(new SocialLoginResponse(
                 result.accessToken(), result.refreshToken(), result.newUser()
             ));
         } catch (AdminPasswordLoginUseCase.LoginDisabledException e) {
+            authRateLimitService.recordOutcome("admin_login", false);
             throw new ApiException(HttpStatus.SERVICE_UNAVAILABLE, "admin_login_disabled", e.getMessage(), null);
         } catch (AdminPasswordLoginUseCase.InvalidCredentialsException e) {
+            authRateLimitService.recordOutcome("admin_login", false);
             throw new ApiException(HttpStatus.UNAUTHORIZED, "admin_login_failed", e.getMessage(), null);
         }
     }
 
     @PostMapping("/social")
-    public ApiResponse<SocialLoginResponse> socialLogin(@RequestBody @Validated SocialLoginRequest request) {
+    public ApiResponse<SocialLoginResponse> socialLogin(
+        @RequestBody @Validated SocialLoginRequest request,
+        HttpServletRequest httpRequest
+    ) {
+        authRateLimitService.checkOrThrow("social_login", keyByIp(httpRequest));
         try {
             SocialLoginUseCase.LoginResult result = socialLoginUseCase.login(
                 request.provider(), request.token(), request.inviteCode()
             );
+            authRateLimitService.recordOutcome("social_login", true);
             return ApiResponse.success(new SocialLoginResponse(
                 result.accessToken(), result.refreshToken(), result.newUser()
             ));
         } catch (SocialLoginException e) {
+            authRateLimitService.recordOutcome("social_login", false);
             throw new ApiException(HttpStatus.UNAUTHORIZED, "social_auth_failed", e.getMessage(), null);
         } catch (SocialLoginUseCase.AdminOnlyException e) {
+            authRateLimitService.recordOutcome("social_login", false);
             throw new ApiException(HttpStatus.FORBIDDEN, "admin_only", e.getMessage(), null);
         } catch (SocialLoginUseCase.InvalidInviteCodeException e) {
+            authRateLimitService.recordOutcome("social_login", false);
             throw new ApiException(HttpStatus.FORBIDDEN, "invalid_invite_code", e.getMessage(), null);
         }
     }
 
     @PostMapping("/signup")
-    public ApiResponse<SocialLoginResponse> signup(@RequestBody @Validated UserPasswordSignupRequest request) {
+    public ApiResponse<SocialLoginResponse> signup(
+        @RequestBody @Validated UserPasswordSignupRequest request,
+        HttpServletRequest httpRequest
+    ) {
+        String key = keyByIpAndLoginId(httpRequest, request.loginId());
+        authRateLimitService.checkOrThrow("user_signup", key);
+
         try {
             UserPasswordSignupUseCase.LoginResult result = userPasswordSignupUseCase.signup(
                 request.loginId(),
                 request.password(),
                 request.inviteCode()
             );
+            authRateLimitService.recordOutcome("user_signup", true);
             return ApiResponse.success(new SocialLoginResponse(
                 result.accessToken(),
                 result.refreshToken(),
                 result.newUser()
             ));
         } catch (UserPasswordSignupUseCase.InvalidInviteCodeException e) {
+            authRateLimitService.recordOutcome("user_signup", false);
             throw new ApiException(HttpStatus.FORBIDDEN, "invalid_invite_code", e.getMessage(), null);
         } catch (UserPasswordSignupUseCase.DuplicateLoginIdException e) {
+            authRateLimitService.recordOutcome("user_signup", false);
             throw new ApiException(HttpStatus.CONFLICT, "login_id_exists", e.getMessage(), null);
         } catch (UserPasswordSignupUseCase.InvalidCredentialFormatException e) {
+            authRateLimitService.recordOutcome("user_signup", false);
             throw new ApiException(HttpStatus.BAD_REQUEST, "invalid_credential_format", e.getMessage(), null);
         }
     }
 
     @PostMapping("/login")
-    public ApiResponse<SocialLoginResponse> login(@RequestBody @Validated UserPasswordLoginRequest request) {
+    public ApiResponse<SocialLoginResponse> login(
+        @RequestBody @Validated UserPasswordLoginRequest request,
+        HttpServletRequest httpRequest
+    ) {
+        String key = keyByIpAndLoginId(httpRequest, request.loginId());
+        authRateLimitService.checkOrThrow("user_login", key);
+
         try {
             UserPasswordLoginUseCase.LoginResult result = userPasswordLoginUseCase.login(
                 request.loginId(),
                 request.password()
             );
+            authRateLimitService.recordOutcome("user_login", true);
             return ApiResponse.success(new SocialLoginResponse(
                 result.accessToken(),
                 result.refreshToken(),
                 result.newUser()
             ));
         } catch (UserPasswordLoginUseCase.InvalidCredentialsException e) {
+            authRateLimitService.recordOutcome("user_login", false);
             throw new ApiException(HttpStatus.UNAUTHORIZED, "user_login_failed", e.getMessage(), null);
         }
     }
@@ -137,9 +176,35 @@ public class AuthController {
     }
 
     @PostMapping("/invite/validate")
-    public ApiResponse<InviteValidateResponse> validateInvite(@RequestBody @Validated InviteValidateRequest request) {
+    public ApiResponse<InviteValidateResponse> validateInvite(
+        @RequestBody @Validated InviteValidateRequest request,
+        HttpServletRequest httpRequest
+    ) {
+        authRateLimitService.checkOrThrow("invite_validate", keyByIp(httpRequest));
         boolean valid = validateInviteCodeUseCase.validate(request.code());
+        authRateLimitService.recordOutcome("invite_validate", valid);
         return ApiResponse.success(new InviteValidateResponse(valid));
+    }
+
+    private String keyByIp(HttpServletRequest request) {
+        return resolveClientIp(request);
+    }
+
+    private String keyByIpAndLoginId(HttpServletRequest request, String loginId) {
+        String normalizedLoginId = loginId == null ? "" : loginId.trim().toLowerCase(Locale.ROOT);
+        return resolveClientIp(request) + "|" + normalizedLoginId;
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            return forwardedFor.split(",")[0].trim();
+        }
+        String realIp = request.getHeader("X-Real-IP");
+        if (realIp != null && !realIp.isBlank()) {
+            return realIp.trim();
+        }
+        return request.getRemoteAddr();
     }
 
     public record SocialLoginRequest(

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/MeController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/MeController.java
@@ -1,15 +1,19 @@
 package com.eunhyehymn.presentation.controllers;
 
-import com.eunhyehymn.application.usecases.GetHistoryUseCase;
 import com.eunhyehymn.application.usecases.GetFavoriteUseCase;
+import com.eunhyehymn.application.usecases.GetHistoryUseCase;
 import com.eunhyehymn.application.usecases.GetHymnNoteUseCase;
+import com.eunhyehymn.application.usecases.GetMyProfileUseCase;
 import com.eunhyehymn.application.usecases.SaveHymnNoteUseCase;
 import com.eunhyehymn.application.usecases.ToggleFavoriteUseCase;
+import com.eunhyehymn.application.usecases.UpsertMyProfileUseCase;
+import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.common.response.ApiResponse;
 import jakarta.validation.constraints.NotBlank;
-import java.util.Map;
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,7 +21,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.validation.annotation.Validated;
 
 @RestController
 @RequestMapping("/me")
@@ -28,47 +31,67 @@ public class MeController {
     private final GetHymnNoteUseCase getHymnNoteUseCase;
     private final SaveHymnNoteUseCase saveHymnNoteUseCase;
     private final GetHistoryUseCase getHistoryUseCase;
+    private final GetMyProfileUseCase getMyProfileUseCase;
+    private final UpsertMyProfileUseCase upsertMyProfileUseCase;
 
     public MeController(
         ToggleFavoriteUseCase toggleFavoriteUseCase,
         GetFavoriteUseCase getFavoriteUseCase,
         GetHymnNoteUseCase getHymnNoteUseCase,
         SaveHymnNoteUseCase saveHymnNoteUseCase,
-        GetHistoryUseCase getHistoryUseCase
+        GetHistoryUseCase getHistoryUseCase,
+        GetMyProfileUseCase getMyProfileUseCase,
+        UpsertMyProfileUseCase upsertMyProfileUseCase
     ) {
         this.toggleFavoriteUseCase = toggleFavoriteUseCase;
         this.getFavoriteUseCase = getFavoriteUseCase;
         this.getHymnNoteUseCase = getHymnNoteUseCase;
         this.saveHymnNoteUseCase = saveHymnNoteUseCase;
         this.getHistoryUseCase = getHistoryUseCase;
+        this.getMyProfileUseCase = getMyProfileUseCase;
+        this.upsertMyProfileUseCase = upsertMyProfileUseCase;
     }
 
     @GetMapping("/profile")
-    public ApiResponse<Map<String, String>> profile(Authentication authentication) {
-        String role = authentication.getAuthorities().stream()
-            .findFirst()
-            .map(authority -> authority.getAuthority().replace("ROLE_", ""))
-            .orElse("UNKNOWN");
-        return ApiResponse.success(Map.of("userId", authentication.getName(), "role", role));
+    public ApiResponse<ProfileResponse> profile(Authentication authentication) {
+        UUID userId = parseUserId(authentication);
+        GetMyProfileUseCase.Result profile = getMyProfileUseCase.get(userId);
+        return ApiResponse.success(toProfileResponse(profile));
+    }
+
+    @PutMapping("/profile")
+    public ApiResponse<ProfileResponse> upsertProfile(
+        @RequestBody @Validated UpsertProfileRequest request,
+        Authentication authentication
+    ) {
+        UUID userId = parseUserId(authentication);
+        upsertMyProfileUseCase.upsert(
+            userId,
+            request.churchName(),
+            request.name(),
+            request.group()
+        );
+        GetMyProfileUseCase.Result updated = getMyProfileUseCase.get(userId);
+        return ApiResponse.success(toProfileResponse(updated));
     }
 
     @PostMapping("/favorites/{hymnId}")
     public ApiResponse<FavoriteResponse> toggleFavorite(@PathVariable UUID hymnId, Authentication authentication) {
-        UUID userId = UUID.fromString(authentication.getName());
+        UUID userId = parseUserId(authentication);
         boolean favorite = toggleFavoriteUseCase.toggle(userId, hymnId).favorite();
         return ApiResponse.success(new FavoriteResponse(favorite));
     }
 
     @GetMapping("/favorites/{hymnId}")
     public ApiResponse<FavoriteResponse> getFavorite(@PathVariable UUID hymnId, Authentication authentication) {
-        UUID userId = UUID.fromString(authentication.getName());
+        UUID userId = parseUserId(authentication);
         boolean favorite = getFavoriteUseCase.get(userId, hymnId);
         return ApiResponse.success(new FavoriteResponse(favorite));
     }
 
     @GetMapping("/hymns/{hymnId}/note")
     public ApiResponse<NoteResponse> getNote(@PathVariable UUID hymnId, Authentication authentication) {
-        UUID userId = UUID.fromString(authentication.getName());
+        UUID userId = parseUserId(authentication);
         String content = getHymnNoteUseCase.get(userId, hymnId).map(note -> note.content()).orElse(null);
         return ApiResponse.success(new NoteResponse(content));
     }
@@ -79,14 +102,14 @@ public class MeController {
         @RequestBody @Validated NoteRequest request,
         Authentication authentication
     ) {
-        UUID userId = UUID.fromString(authentication.getName());
+        UUID userId = parseUserId(authentication);
         String content = saveHymnNoteUseCase.save(userId, hymnId, request.content()).content();
         return ApiResponse.success(new NoteResponse(content));
     }
 
     @GetMapping("/history")
     public ApiResponse<java.util.List<HistoryItemResponse>> history(Authentication authentication) {
-        UUID userId = UUID.fromString(authentication.getName());
+        UUID userId = parseUserId(authentication);
         var items = getHistoryUseCase.getHistory(userId).stream()
             .map(item -> new HistoryItemResponse(
                 item.hymn().id(),
@@ -99,7 +122,51 @@ public class MeController {
         return ApiResponse.success(items);
     }
 
+    private ProfileResponse toProfileResponse(GetMyProfileUseCase.Result profile) {
+        return new ProfileResponse(
+            profile.userId().toString(),
+            profile.role().name(),
+            profile.displayName(),
+            profile.churchName(),
+            profile.name(),
+            profile.group(),
+            profile.profileCompleted(),
+            profile.profileUpdatedAt()
+        );
+    }
+
+    private UUID parseUserId(Authentication authentication) {
+        if (authentication == null || authentication.getName() == null || authentication.getName().isBlank()) {
+            throw new ApiException(HttpStatus.UNAUTHORIZED, "unauthorized", "authentication is required", null);
+        }
+
+        try {
+            return UUID.fromString(authentication.getName());
+        } catch (IllegalArgumentException ex) {
+            throw new ApiException(HttpStatus.UNAUTHORIZED, "invalid_principal", "invalid authenticated principal", null);
+        }
+    }
+
     public record FavoriteResponse(boolean favorite) {
+    }
+
+    public record ProfileResponse(
+        String userId,
+        String role,
+        String displayName,
+        String churchName,
+        String name,
+        String group,
+        boolean profileCompleted,
+        java.time.Instant profileUpdatedAt
+    ) {
+    }
+
+    public record UpsertProfileRequest(
+        @NotBlank String churchName,
+        @NotBlank String name,
+        @NotBlank String group
+    ) {
     }
 
     public record NoteRequest(@NotBlank String content) {

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -32,6 +32,11 @@ security:
     secret: ${JWT_SECRET}
     access-token-ttl-seconds: ${JWT_ACCESS_TTL_SECONDS}
     refresh-token-ttl-seconds: ${JWT_REFRESH_TTL_SECONDS}
+  rate-limit:
+    auth:
+      enabled: ${AUTH_RATE_LIMIT_ENABLED:true}
+      window-seconds: ${AUTH_RATE_LIMIT_WINDOW_SECONDS:60}
+      max-attempts-per-key: ${AUTH_RATE_LIMIT_MAX_ATTEMPTS_PER_KEY:25}
   invite:
     code: ${INVITE_CODE}
   admin:

--- a/apps/api/src/main/resources/db/migration/V13__user_profiles.sql
+++ b/apps/api/src/main/resources/db/migration/V13__user_profiles.sql
@@ -1,0 +1,8 @@
+CREATE TABLE user_profiles (
+    user_id UUID PRIMARY KEY,
+    church_name VARCHAR(255) NOT NULL,
+    member_name VARCHAR(255) NOT NULL,
+    group_name VARCHAR(255) NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    CONSTRAINT fk_user_profiles_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AuthRateLimitApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AuthRateLimitApiTest.java
@@ -1,0 +1,55 @@
+package com.eunhyehymn.presentation.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(
+    properties = {
+        "security.rate-limit.auth.enabled=true",
+        "security.rate-limit.auth.window-seconds=60",
+        "security.rate-limit.auth.max-attempts-per-key=2"
+    }
+)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AuthRateLimitApiTest {
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @Test
+    void loginEndpointReturnsTooManyRequestsAfterThreshold() throws Exception {
+        String payload = objectMapper.writeValueAsString(Map.of(
+            "loginId", "member.one",
+            "password", "wrong-password"
+        ));
+
+        mockMvc.perform(post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.error.code").value("user_login_failed"));
+
+        mockMvc.perform(post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.error.code").value("user_login_failed"));
+
+        mockMvc.perform(post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isTooManyRequests())
+            .andExpect(jsonPath("$.error.code").value("too_many_requests"));
+    }
+}

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/MeProfileApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/MeProfileApiTest.java
@@ -1,0 +1,116 @@
+package com.eunhyehymn.presentation.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.eunhyehymn.domain.model.Role;
+import com.eunhyehymn.domain.model.UserStatus;
+import com.eunhyehymn.infrastructure.persistence.AuthIdentityJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.EventJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.HymnJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.HymnNoteJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.InviteCodeJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.RefreshTokenJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.UserEntity;
+import com.eunhyehymn.infrastructure.persistence.UserHymnStateJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.UserJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.UserProfileJpaRepository;
+import com.eunhyehymn.infrastructure.security.JwtService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MeProfileApiTest {
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private JwtService jwtService;
+    @Autowired private UserJpaRepository userJpaRepository;
+    @Autowired private UserProfileJpaRepository userProfileJpaRepository;
+    @Autowired private UserHymnStateJpaRepository userHymnStateJpaRepository;
+    @Autowired private HymnNoteJpaRepository hymnNoteJpaRepository;
+    @Autowired private HymnJpaRepository hymnJpaRepository;
+    @Autowired private EventJpaRepository eventJpaRepository;
+    @Autowired private AuthIdentityJpaRepository authIdentityJpaRepository;
+    @Autowired private RefreshTokenJpaRepository refreshTokenJpaRepository;
+    @Autowired private InviteCodeJpaRepository inviteCodeJpaRepository;
+
+    private UUID userId;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        inviteCodeJpaRepository.deleteAll();
+        eventJpaRepository.deleteAll();
+        userHymnStateJpaRepository.deleteAll();
+        hymnNoteJpaRepository.deleteAll();
+        authIdentityJpaRepository.deleteAll();
+        refreshTokenJpaRepository.deleteAll();
+        hymnJpaRepository.deleteAll();
+        userProfileJpaRepository.deleteAll();
+        userJpaRepository.deleteAll();
+
+        userId = UUID.randomUUID();
+        userJpaRepository.save(new UserEntity(
+            userId,
+            "프로필테스트",
+            Role.USER,
+            UserStatus.ACTIVE,
+            Instant.now(),
+            Instant.now()
+        ));
+        accessToken = jwtService.issueAccessToken(userId.toString(), Role.USER.name());
+    }
+
+    @Test
+    void meProfileReturnsIncompleteWhenNoProfileExists() throws Exception {
+        mockMvc.perform(get("/me/profile")
+                .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.userId").value(userId.toString()))
+            .andExpect(jsonPath("$.data.role").value("USER"))
+            .andExpect(jsonPath("$.data.profileCompleted").value(false))
+            .andExpect(jsonPath("$.data.churchName").isEmpty())
+            .andExpect(jsonPath("$.data.name").isEmpty())
+            .andExpect(jsonPath("$.data.group").isEmpty());
+    }
+
+    @Test
+    void upsertProfilePersistsAndReturnsCompleteProfile() throws Exception {
+        mockMvc.perform(put("/me/profile")
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of(
+                    "churchName", "은혜교회",
+                    "name", "홍길동",
+                    "group", "청년A"
+                ))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.profileCompleted").value(true))
+            .andExpect(jsonPath("$.data.churchName").value("은혜교회"))
+            .andExpect(jsonPath("$.data.name").value("홍길동"))
+            .andExpect(jsonPath("$.data.group").value("청년A"))
+            .andExpect(jsonPath("$.data.profileUpdatedAt").isNotEmpty());
+
+        mockMvc.perform(get("/me/profile")
+                .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.profileCompleted").value(true))
+            .andExpect(jsonPath("$.data.churchName").value("은혜교회"))
+            .andExpect(jsonPath("$.data.name").value("홍길동"))
+            .andExpect(jsonPath("$.data.group").value("청년A"));
+    }
+}

--- a/apps/api/src/test/resources/application-test.yml
+++ b/apps/api/src/test/resources/application-test.yml
@@ -21,6 +21,9 @@ security:
     secret: test-secret
     access-token-ttl-seconds: 3600
     refresh-token-ttl-seconds: 1209600
+  rate-limit:
+    auth:
+      enabled: false
 
 events:
   export:

--- a/apps/mobile/lib/src/app.dart
+++ b/apps/mobile/lib/src/app.dart
@@ -12,6 +12,7 @@ import 'features/history/history_page.dart';
 import 'features/hymn/hymn_detail_page.dart';
 import 'features/hymn/hymn_list_page.dart';
 import 'features/hymn/hymn_repository.dart';
+import 'features/profile/profile_settings_page.dart';
 
 class EunhyeMobileApp extends StatefulWidget {
   const EunhyeMobileApp({super.key});
@@ -82,13 +83,12 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
         return;
       }
 
-      final needsOnboarding =
-          !(await _onboardingStorage.isCompleted(profile.userId));
+      final resolved = await _resolveProfile(profile);
 
-      _hymnRepository.bindSessionUser(profile.userId);
+      _hymnRepository.bindSessionUser(resolved.profile.userId);
       setState(() {
-        _profile = profile;
-        _needsOnboarding = needsOnboarding;
+        _profile = resolved.profile;
+        _needsOnboarding = resolved.needsOnboarding;
         _loginError = null;
       });
       await _hymnRepository.syncPendingActions();
@@ -110,24 +110,59 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
   }
 
   Future<void> _onLoggedIn(SessionProfile profile) async {
-    final needsOnboarding =
-        !(await _onboardingStorage.isCompleted(profile.userId));
-    _hymnRepository.bindSessionUser(profile.userId);
+    final resolved = await _resolveProfile(profile);
+    _hymnRepository.bindSessionUser(resolved.profile.userId);
     setState(() {
-      _profile = profile;
-      _needsOnboarding = needsOnboarding;
+      _profile = resolved.profile;
+      _needsOnboarding = resolved.needsOnboarding;
       _loginError = null;
     });
     await _hymnRepository.syncPendingActions();
   }
 
-  Future<void> _onOnboardingCompleted() async {
-    if (!mounted || _profile == null) {
+  Future<void> _onOnboardingCompleted(SessionProfile profile) async {
+    if (!mounted) {
       return;
     }
+    _hymnRepository.bindSessionUser(profile.userId);
     await _hymnRepository.syncPendingActions();
     setState(() {
+      _profile = profile;
       _needsOnboarding = false;
+    });
+  }
+
+  Future<_ProfileResolution> _resolveProfile(SessionProfile profile) async {
+    var effective = profile;
+    if (!profile.isProfileCompleted) {
+      final local = await _onboardingStorage.getProfile(profile.userId);
+      if (local != null) {
+        try {
+          final synced = await _authRepository.updateProfile(
+            churchName: local.churchName,
+            name: local.name,
+            group: local.group,
+          );
+          effective = synced;
+        } catch (_) {
+          // Keep onboarding required when server sync is unavailable.
+        }
+      }
+    }
+
+    return _ProfileResolution(
+      profile: effective,
+      needsOnboarding: !effective.isProfileCompleted,
+    );
+  }
+
+  void _onProfileUpdated(SessionProfile profile) {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _profile = profile;
+      _needsOnboarding = !profile.isProfileCompleted;
     });
   }
 
@@ -210,27 +245,37 @@ class _EunhyeMobileAppState extends State<EunhyeMobileApp> {
     if (_needsOnboarding) {
       return OnboardingPage(
         userId: _profile!.userId,
+        authRepository: _authRepository,
         onboardingStorage: _onboardingStorage,
         onCompleted: _onOnboardingCompleted,
       );
     }
 
     return _HomeShell(
+      initialProfile: _profile!,
       authRepository: _authRepository,
       hymnRepository: _hymnRepository,
+      onboardingStorage: _onboardingStorage,
+      onProfileUpdated: _onProfileUpdated,
       onLogout: _onLogout,
     );
   }
 }
 
 class _HomeShell extends StatefulWidget {
+  final SessionProfile initialProfile;
   final AuthRepository authRepository;
   final HymnRepository hymnRepository;
+  final OnboardingStorage onboardingStorage;
+  final ValueChanged<SessionProfile> onProfileUpdated;
   final Future<void> Function() onLogout;
 
   const _HomeShell({
+    required this.initialProfile,
     required this.authRepository,
     required this.hymnRepository,
+    required this.onboardingStorage,
+    required this.onProfileUpdated,
     required this.onLogout,
   });
 
@@ -240,7 +285,21 @@ class _HomeShell extends StatefulWidget {
 
 class _HomeShellState extends State<_HomeShell> {
   int _index = 0;
-  bool _loggingOut = false;
+  late SessionProfile _profile;
+
+  @override
+  void initState() {
+    super.initState();
+    _profile = widget.initialProfile;
+  }
+
+  @override
+  void didUpdateWidget(covariant _HomeShell oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.initialProfile != widget.initialProfile) {
+      _profile = widget.initialProfile;
+    }
+  }
 
   Future<void> _openHymnDetail(String hymnId) async {
     await Navigator.of(context).push(
@@ -253,23 +312,14 @@ class _HomeShellState extends State<_HomeShell> {
     );
   }
 
-  Future<void> _handleLogout() async {
-    if (_loggingOut) {
+  void _handleProfileUpdated(SessionProfile profile) {
+    if (!mounted) {
       return;
     }
-
     setState(() {
-      _loggingOut = true;
+      _profile = profile;
     });
-    try {
-      await widget.onLogout();
-    } finally {
-      if (mounted) {
-        setState(() {
-          _loggingOut = false;
-        });
-      }
-    }
+    widget.onProfileUpdated(profile);
   }
 
   @override
@@ -283,32 +333,20 @@ class _HomeShellState extends State<_HomeShell> {
         hymnRepository: widget.hymnRepository,
         onOpenHymnDetail: _openHymnDetail,
       ),
+      ProfileSettingsPage(
+        profile: _profile,
+        authRepository: widget.authRepository,
+        hymnRepository: widget.hymnRepository,
+        onboardingStorage: widget.onboardingStorage,
+        onProfileUpdated: _handleProfileUpdated,
+        onLogout: widget.onLogout,
+      ),
     ];
-    final titles = <String>['찬양', '히스토리'];
+    final titles = <String>['찬양', '히스토리', '내 정보'];
 
     return Scaffold(
       appBar: AppBar(
         title: Text(titles[_index]),
-        actions: [
-          PopupMenuButton<String>(
-            enabled: !_loggingOut,
-            onSelected: (value) {
-              if (value == 'logout') {
-                _handleLogout();
-              }
-            },
-            itemBuilder: (_) => const [
-              PopupMenuItem(value: 'logout', child: Text('로그아웃')),
-            ],
-            icon: _loggingOut
-                ? const SizedBox(
-                    width: 18,
-                    height: 18,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Icon(Icons.more_vert),
-          ),
-        ],
       ),
       body: pages[_index],
       bottomNavigationBar: NavigationBar(
@@ -329,8 +367,23 @@ class _HomeShellState extends State<_HomeShell> {
             selectedIcon: Icon(Icons.history),
             label: '히스토리',
           ),
+          NavigationDestination(
+            icon: Icon(Icons.person_outline),
+            selectedIcon: Icon(Icons.person),
+            label: '내 정보',
+          ),
         ],
       ),
     );
   }
+}
+
+class _ProfileResolution {
+  final SessionProfile profile;
+  final bool needsOnboarding;
+
+  const _ProfileResolution({
+    required this.profile,
+    required this.needsOnboarding,
+  });
 }

--- a/apps/mobile/lib/src/core/storage/onboarding_storage.dart
+++ b/apps/mobile/lib/src/core/storage/onboarding_storage.dart
@@ -60,4 +60,11 @@ class OnboardingStorage {
     final profile = await getProfile(userId);
     return profile != null;
   }
+
+  Future<void> clearProfile(String userId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_churchKey(userId));
+    await prefs.remove(_nameKey(userId));
+    await prefs.remove(_groupKey(userId));
+  }
 }

--- a/apps/mobile/lib/src/features/auth/auth_repository.dart
+++ b/apps/mobile/lib/src/features/auth/auth_repository.dart
@@ -7,11 +7,30 @@ enum UserRole { user, admin }
 class SessionProfile {
   final String userId;
   final UserRole role;
+  final String? displayName;
+  final String? churchName;
+  final String? name;
+  final String? group;
+  final bool profileCompleted;
 
   const SessionProfile({
     required this.userId,
     required this.role,
+    required this.displayName,
+    required this.churchName,
+    required this.name,
+    required this.group,
+    required this.profileCompleted,
   });
+
+  bool get isProfileCompleted {
+    if (profileCompleted) {
+      return true;
+    }
+    return (churchName?.trim().isNotEmpty ?? false) &&
+        (name?.trim().isNotEmpty ?? false) &&
+        (group?.trim().isNotEmpty ?? false);
+  }
 }
 
 class AuthRepository {
@@ -146,6 +165,27 @@ class AuthRepository {
     return tokenStorage.clear();
   }
 
+  Future<SessionProfile> updateProfile({
+    required String churchName,
+    required String name,
+    required String group,
+  }) async {
+    final raw = await apiClient.put(
+      '/me/profile',
+      body: {
+        'churchName': churchName.trim(),
+        'name': name.trim(),
+        'group': group.trim(),
+      },
+    );
+
+    if (raw is! Map<String, dynamic>) {
+      throw ApiException('Profile response is invalid.');
+    }
+
+    return _toSessionProfile(raw);
+  }
+
   Future<SessionProfile> _loginWithPasswordEndpoint(
     String path, {
     required Map<String, Object?> body,
@@ -181,7 +221,15 @@ class AuthRepository {
     }
 
     final role = roleText == 'ADMIN' ? UserRole.admin : UserRole.user;
-    return SessionProfile(userId: userId, role: role);
+    return SessionProfile(
+      userId: userId,
+      role: role,
+      displayName: _toNullableText(raw['displayName']),
+      churchName: _toNullableText(raw['churchName']),
+      name: _toNullableText(raw['name']),
+      group: _toNullableText(raw['group']),
+      profileCompleted: raw['profileCompleted'] == true,
+    );
   }
 
   bool _isUnauthorized(ApiException exception) {
@@ -203,5 +251,13 @@ class AuthRepository {
     }
 
     return (accessToken, refreshToken);
+  }
+
+  String? _toNullableText(Object? value) {
+    final text = value?.toString();
+    if (text == null || text.trim().isEmpty) {
+      return null;
+    }
+    return text.trim();
   }
 }

--- a/apps/mobile/lib/src/features/auth/onboarding_page.dart
+++ b/apps/mobile/lib/src/features/auth/onboarding_page.dart
@@ -1,15 +1,19 @@
 import 'package:flutter/material.dart';
 
 import '../../core/storage/onboarding_storage.dart';
+import '../../core/network/api_exception.dart';
+import 'auth_repository.dart';
 
 class OnboardingPage extends StatefulWidget {
   final String userId;
+  final AuthRepository authRepository;
   final OnboardingStorage onboardingStorage;
-  final Future<void> Function() onCompleted;
+  final Future<void> Function(SessionProfile profile) onCompleted;
 
   const OnboardingPage({
     super.key,
     required this.userId,
+    required this.authRepository,
     required this.onboardingStorage,
     required this.onCompleted,
   });
@@ -71,19 +75,31 @@ class _OnboardingPageState extends State<OnboardingPage> {
     });
 
     try {
+      final updatedProfile = await widget.authRepository.updateProfile(
+        churchName: churchName,
+        name: name,
+        group: group,
+      );
       await widget.onboardingStorage.saveProfile(
         userId: widget.userId,
         churchName: churchName,
         name: name,
         group: group,
       );
-      await widget.onCompleted();
+      await widget.onCompleted(updatedProfile);
+    } on ApiException catch (e) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = e.message;
+      });
     } catch (_) {
       if (!mounted) {
         return;
       }
       setState(() {
-        _error = '입력값 저장 중 문제가 발생했습니다. 다시 시도해 주세요.';
+        _error = '프로필 저장 중 문제가 발생했습니다. 다시 시도해 주세요.';
       });
     } finally {
       if (mounted) {
@@ -120,7 +136,7 @@ class _OnboardingPageState extends State<OnboardingPage> {
                       ),
                       const SizedBox(height: 6),
                       const Text(
-                        '초대 코드 검증이 완료되면 앱 이용이 가능합니다.',
+                        '입력값은 계정 프로필로 저장되어 다른 기기에서도 동기화됩니다.',
                         style: TextStyle(color: Color(0xFF5B6572)),
                       ),
                       const SizedBox(height: 16),

--- a/apps/mobile/lib/src/features/hymn/hymn_repository.dart
+++ b/apps/mobile/lib/src/features/hymn/hymn_repository.dart
@@ -184,6 +184,26 @@ class HymnRepository {
     _sessionUserId = userId;
   }
 
+  Future<void> clearPersonalCache() async {
+    final userId = _sessionUserId;
+    if (userId == null || userId.isEmpty) {
+      throw ApiException('로그인 세션이 없습니다.');
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    final suffix = '.$userId';
+    final keys = prefs
+        .getKeys()
+        .where(
+          (key) => key.startsWith('mobile.cache.') && key.endsWith(suffix),
+        )
+        .toList();
+
+    for (final key in keys) {
+      await prefs.remove(key);
+    }
+  }
+
   Future<List<HymnSummary>> listHymns() async {
     try {
       final raw = await apiClient.get('/hymns', includeAuth: false);

--- a/apps/mobile/lib/src/features/hymn/local_asset_cache.dart
+++ b/apps/mobile/lib/src/features/hymn/local_asset_cache.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
@@ -15,7 +16,7 @@ typedef CacheDirectoryProvider = Future<Directory> Function();
 class LocalAssetCache {
   static const _indexKeyBase = 'mobile.cache.assets.files.v2';
   static const _cacheDirName = 'hymn-assets';
-  static const _downloadTimeout = Duration(seconds: 20);
+  static const _defaultDownloadTimeout = Duration(seconds: 20);
   static const _defaultMaxAssetBytes = 25 * 1024 * 1024;
 
   final http.Client _httpClient;
@@ -23,6 +24,7 @@ class LocalAssetCache {
   final CachePrefsFactory _prefsFactory;
   final CacheDirectoryProvider _documentsDirectoryProvider;
   final CacheNowProvider _now;
+  final Duration _downloadTimeout;
   final int _maxAssetBytes;
 
   LocalAssetCache({
@@ -30,6 +32,7 @@ class LocalAssetCache {
     CachePrefsFactory? prefsFactory,
     CacheDirectoryProvider? documentsDirectoryProvider,
     CacheNowProvider? now,
+    Duration downloadTimeout = _defaultDownloadTimeout,
     int maxAssetBytes = _defaultMaxAssetBytes,
   })  : _httpClient = httpClient ?? http.Client(),
         _ownsHttpClient = httpClient == null,
@@ -37,6 +40,7 @@ class LocalAssetCache {
         _documentsDirectoryProvider =
             documentsDirectoryProvider ?? getApplicationDocumentsDirectory,
         _now = now ?? DateTime.now,
+        _downloadTimeout = downloadTimeout,
         _maxAssetBytes = maxAssetBytes;
 
   void dispose() {
@@ -76,15 +80,18 @@ class LocalAssetCache {
       final response =
           await _httpClient.send(request).timeout(_downloadTimeout);
       if (response.statusCode < 200 || response.statusCode >= 300) {
+        await _cancelStreamedResponse(response);
         return null;
       }
 
       if (!_supportsContentType(asset, response.headers['content-type'])) {
+        await _cancelStreamedResponse(response);
         return null;
       }
 
       final announcedLength = response.contentLength;
       if (announcedLength != null && announcedLength > _maxAssetBytes) {
+        await _cancelStreamedResponse(response);
         return null;
       }
 
@@ -112,21 +119,101 @@ class LocalAssetCache {
     }
   }
 
+  Future<void> clearForUser({required String userId}) async {
+    final normalizedUserId = _normalizeUserId(userId);
+    if (normalizedUserId == null) {
+      return;
+    }
+
+    final index = await _readIndex(normalizedUserId);
+    for (final entry in index.values) {
+      if (entry is! Map<String, dynamic>) {
+        continue;
+      }
+      final filePath = entry['path']?.toString();
+      if (filePath == null || filePath.isEmpty) {
+        continue;
+      }
+      try {
+        final file = File(filePath);
+        if (await file.exists()) {
+          await file.delete();
+        }
+      } catch (_) {
+        // Continue cleanup on a best-effort basis.
+      }
+    }
+
+    final prefs = await _prefsFactory();
+    await prefs.remove(_indexKeyForUser(normalizedUserId));
+
+    try {
+      final directory = await _cacheDirectoryForUser(normalizedUserId);
+      if (await directory.exists()) {
+        await directory.delete(recursive: true);
+      }
+    } catch (_) {
+      // Continue cleanup on a best-effort basis.
+    }
+  }
+
   Future<Uint8List?> _readResponseBytesWithinLimit(
     http.StreamedResponse response,
   ) async {
     final bytes = BytesBuilder(copy: false);
+    final completer = Completer<Uint8List?>();
     var totalBytes = 0;
+    Timer? timer;
 
-    await for (final chunk in response.stream.timeout(_downloadTimeout)) {
-      totalBytes += chunk.length;
-      if (totalBytes > _maxAssetBytes) {
-        return null;
+    late final StreamSubscription<List<int>> subscription;
+    subscription = response.stream.listen(
+      (chunk) {
+        totalBytes += chunk.length;
+        if (totalBytes > _maxAssetBytes) {
+          timer?.cancel();
+          subscription.cancel();
+          if (!completer.isCompleted) {
+            completer.complete(null);
+          }
+          return;
+        }
+        bytes.add(chunk);
+      },
+      onError: (_) {
+        timer?.cancel();
+        if (!completer.isCompleted) {
+          completer.complete(null);
+        }
+      },
+      onDone: () {
+        timer?.cancel();
+        if (!completer.isCompleted) {
+          completer.complete(bytes.takeBytes());
+        }
+      },
+      cancelOnError: true,
+    );
+
+    timer = Timer(_downloadTimeout, () {
+      subscription.cancel();
+      if (!completer.isCompleted) {
+        completer.complete(null);
       }
-      bytes.add(chunk);
-    }
+    });
 
-    return bytes.takeBytes();
+    try {
+      return await completer.future;
+    } finally {
+      timer.cancel();
+    }
+  }
+
+  Future<void> _cancelStreamedResponse(http.StreamedResponse response) async {
+    try {
+      await response.stream.listen((_) {}).cancel();
+    } catch (_) {
+      // Best effort cleanup only.
+    }
   }
 
   Future<String?> _resolveExistingPath(
@@ -267,15 +354,19 @@ class LocalAssetCache {
   }
 
   Future<Directory> _ensureCacheDirectory(String normalizedUserId) async {
-    final baseDir = await _documentsDirectoryProvider();
-    final cacheDir = Directory(
-      '${baseDir.path}${Platform.pathSeparator}$_cacheDirName'
-      '${Platform.pathSeparator}$normalizedUserId',
-    );
+    final cacheDir = await _cacheDirectoryForUser(normalizedUserId);
     if (!await cacheDir.exists()) {
       await cacheDir.create(recursive: true);
     }
     return cacheDir;
+  }
+
+  Future<Directory> _cacheDirectoryForUser(String normalizedUserId) async {
+    final baseDir = await _documentsDirectoryProvider();
+    return Directory(
+      '${baseDir.path}${Platform.pathSeparator}$_cacheDirName'
+      '${Platform.pathSeparator}$normalizedUserId',
+    );
   }
 
   String _indexKeyForUser(String normalizedUserId) {

--- a/apps/mobile/lib/src/features/profile/profile_settings_page.dart
+++ b/apps/mobile/lib/src/features/profile/profile_settings_page.dart
@@ -1,0 +1,377 @@
+import 'package:flutter/material.dart';
+
+import '../../core/network/api_exception.dart';
+import '../../core/storage/onboarding_storage.dart';
+import '../auth/auth_repository.dart';
+import '../hymn/hymn_repository.dart';
+import '../hymn/local_asset_cache.dart';
+
+class ProfileSettingsPage extends StatefulWidget {
+  final SessionProfile profile;
+  final AuthRepository authRepository;
+  final HymnRepository hymnRepository;
+  final OnboardingStorage onboardingStorage;
+  final ValueChanged<SessionProfile> onProfileUpdated;
+  final Future<void> Function() onLogout;
+
+  const ProfileSettingsPage({
+    super.key,
+    required this.profile,
+    required this.authRepository,
+    required this.hymnRepository,
+    required this.onboardingStorage,
+    required this.onProfileUpdated,
+    required this.onLogout,
+  });
+
+  @override
+  State<ProfileSettingsPage> createState() => _ProfileSettingsPageState();
+}
+
+class _ProfileSettingsPageState extends State<ProfileSettingsPage> {
+  final _churchController = TextEditingController();
+  final _nameController = TextEditingController();
+  final _groupController = TextEditingController();
+
+  bool _savingProfile = false;
+  bool _clearingCache = false;
+  bool _loggingOut = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _applyProfile(widget.profile);
+  }
+
+  @override
+  void didUpdateWidget(covariant ProfileSettingsPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.profile != widget.profile) {
+      _applyProfile(widget.profile);
+    }
+  }
+
+  @override
+  void dispose() {
+    _churchController.dispose();
+    _nameController.dispose();
+    _groupController.dispose();
+    super.dispose();
+  }
+
+  void _applyProfile(SessionProfile profile) {
+    _churchController.text = profile.churchName ?? '';
+    _nameController.text = profile.name ?? '';
+    _groupController.text = profile.group ?? '';
+  }
+
+  Future<void> _saveProfile() async {
+    final churchName = _churchController.text.trim();
+    final name = _nameController.text.trim();
+    final group = _groupController.text.trim();
+    if (churchName.isEmpty || name.isEmpty || group.isEmpty) {
+      setState(() {
+        _error = '교회, 이름, 구역을 모두 입력해 주세요.';
+      });
+      return;
+    }
+
+    setState(() {
+      _savingProfile = true;
+      _error = null;
+    });
+
+    try {
+      final updated = await widget.authRepository.updateProfile(
+        churchName: churchName,
+        name: name,
+        group: group,
+      );
+      await widget.onboardingStorage.saveProfile(
+        userId: updated.userId,
+        churchName: churchName,
+        name: name,
+        group: group,
+      );
+      widget.onProfileUpdated(updated);
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('프로필을 저장했어요.')),
+      );
+    } on ApiException catch (e) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = e.message;
+      });
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = '프로필 저장 중 문제가 발생했습니다.';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _savingProfile = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _clearCache() async {
+    if (_clearingCache) {
+      return;
+    }
+
+    setState(() {
+      _clearingCache = true;
+    });
+
+    try {
+      await widget.hymnRepository.clearPersonalCache();
+      final localAssetCache = LocalAssetCache();
+      try {
+        await localAssetCache.clearForUser(userId: widget.profile.userId);
+      } finally {
+        localAssetCache.dispose();
+      }
+
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('개인 캐시를 정리했어요.')),
+      );
+    } catch (e) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('캐시 정리에 실패했습니다: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _clearingCache = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _logout() async {
+    if (_loggingOut) {
+      return;
+    }
+
+    setState(() {
+      _loggingOut = true;
+    });
+    try {
+      await widget.onLogout();
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loggingOut = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final roleText = widget.profile.role == UserRole.admin ? 'ADMIN' : 'USER';
+
+    return RefreshIndicator(
+      onRefresh: () async {
+        try {
+          final updated = await widget.authRepository.fetchProfile();
+          if (updated != null) {
+            widget.onProfileUpdated(updated);
+          }
+        } catch (_) {
+          // Keep current state.
+        }
+      },
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+        children: [
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    '내 계정',
+                    style: TextStyle(
+                      fontSize: 17,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  _InfoRow(label: '역할', value: roleText),
+                  _InfoRow(label: '사용자 ID', value: widget.profile.userId),
+                  if (widget.profile.displayName != null)
+                    _InfoRow(
+                      label: '표시 이름',
+                      value: widget.profile.displayName!,
+                    ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const Text(
+                    '개인 정보',
+                    style: TextStyle(
+                      fontSize: 17,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  TextField(
+                    controller: _churchController,
+                    enabled: !_savingProfile,
+                    decoration: const InputDecoration(
+                      labelText: '교회',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  TextField(
+                    controller: _nameController,
+                    enabled: !_savingProfile,
+                    decoration: const InputDecoration(
+                      labelText: '이름',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  TextField(
+                    controller: _groupController,
+                    enabled: !_savingProfile,
+                    decoration: const InputDecoration(
+                      labelText: '구역',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  if (_error != null) ...[
+                    const SizedBox(height: 10),
+                    Text(
+                      _error!,
+                      style: const TextStyle(
+                        color: Color(0xFFC2291E),
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                  const SizedBox(height: 12),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: FilledButton(
+                      onPressed: _savingProfile ? null : _saveProfile,
+                      child: Text(_savingProfile ? '저장 중...' : '프로필 저장'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const Text(
+                    '설정',
+                    style: TextStyle(
+                      fontSize: 17,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  OutlinedButton.icon(
+                    onPressed: _clearingCache ? null : _clearCache,
+                    icon: _clearingCache
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.cleaning_services_outlined),
+                    label: Text(_clearingCache ? '정리 중...' : '개인 캐시 정리'),
+                  ),
+                  const SizedBox(height: 8),
+                  FilledButton.tonalIcon(
+                    onPressed: _loggingOut ? null : _logout,
+                    icon: _loggingOut
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.logout),
+                    label: Text(_loggingOut ? '로그아웃 중...' : '로그아웃'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _InfoRow({
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 76,
+            child: Text(
+              label,
+              style: const TextStyle(
+                color: Color(0xFF5B6572),
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: const TextStyle(fontWeight: FontWeight.w600),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/test/local_asset_cache_test.dart
+++ b/apps/mobile/test/local_asset_cache_test.dart
@@ -47,6 +47,37 @@ void main() {
     expect(requestCount, 2);
   });
 
+  test('clearForUser removes only target user cache', () async {
+    var requestCount = 0;
+    final cache = _createCache(
+      client: _MockHttpClient((_) async {
+        requestCount += 1;
+        return http.Response.bytes(
+          [1, 2, 3],
+          200,
+          headers: const {'content-type': 'image/png'},
+        );
+      }),
+      tempDirectory: tempDirectory,
+    );
+
+    final asset = _imageAsset(id: 'asset-clear', version: 'v1');
+    final userAPath = await cache.getOrDownload(asset, userId: 'user-A');
+    final userBPath = await cache.getOrDownload(asset, userId: 'user-B');
+    expect(userAPath, isNotNull);
+    expect(userBPath, isNotNull);
+    expect(requestCount, 2);
+
+    await cache.clearForUser(userId: 'user-A');
+
+    final userAAfterClear = await cache.getOrDownload(asset, userId: 'user-A');
+    final userBAfterClear = await cache.getOrDownload(asset, userId: 'user-B');
+
+    expect(userAAfterClear, isNotNull);
+    expect(userBAfterClear, equals(userBPath));
+    expect(requestCount, 3);
+  });
+
   test('reuses cached file for same user and version', () async {
     var requestCount = 0;
     final cache = _createCache(
@@ -133,6 +164,34 @@ void main() {
     expect(path, isNull);
   });
 
+  test('enforces total download timeout even when chunks keep arriving', () async {
+    final cache = _createCache(
+      client: _MockStreamingHttpClient((_) async {
+        Stream<List<int>> stream() async* {
+          for (var i = 0; i < 10; i++) {
+            await Future<void>.delayed(const Duration(milliseconds: 15));
+            yield [i];
+          }
+        }
+
+        return http.StreamedResponse(
+          stream(),
+          200,
+          headers: const {'content-type': 'image/png'},
+        );
+      }),
+      tempDirectory: tempDirectory,
+      downloadTimeout: const Duration(milliseconds: 40),
+    );
+
+    final path = await cache.getOrDownload(
+      _imageAsset(id: 'asset-timeout', version: 'v1'),
+      userId: 'member-1',
+    );
+
+    expect(path, isNull);
+  });
+
   test('removes stale file when asset version changes', () async {
     var requestCount = 0;
     final cache = _createCache(
@@ -189,6 +248,7 @@ void main() {
 LocalAssetCache _createCache({
   required http.Client client,
   required Directory tempDirectory,
+  Duration downloadTimeout = const Duration(seconds: 20),
   int maxAssetBytes = 25 * 1024 * 1024,
 }) {
   return LocalAssetCache(
@@ -196,6 +256,7 @@ LocalAssetCache _createCache({
     prefsFactory: SharedPreferences.getInstance,
     documentsDirectoryProvider: () async => tempDirectory,
     now: () => DateTime.utc(2026, 2, 19),
+    downloadTimeout: downloadTimeout,
     maxAssetBytes: maxAssetBytes,
   );
 }

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -339,6 +339,28 @@ Base URL: `/api/v1`
 
 ### 5.1 프로필
 - `GET /me/profile`
+- `PUT /me/profile`
+- `PUT /me/profile` 요청 `data`:
+```json
+{
+  "churchName": "은혜교회",
+  "name": "홍길동",
+  "group": "청년A"
+}
+```
+- `GET/PUT /me/profile` 응답 `data` 예시:
+```json
+{
+  "userId": "9f2a6c6e-42f8-4a54-8dd3-2dbf2f8a1ab1",
+  "role": "USER",
+  "displayName": "Kakao User",
+  "churchName": "은혜교회",
+  "name": "홍길동",
+  "group": "청년A",
+  "profileCompleted": true,
+  "profileUpdatedAt": "2026-02-19T23:00:00Z"
+}
+```
 
 ### 5.2 즐겨찾기
 - `GET /me/favorites/{hymnId}`

--- a/docs/current-usable-scope.md
+++ b/docs/current-usable-scope.md
@@ -82,7 +82,7 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
 
 - `develop` push 트리거
 - API 테스트 + Admin 타입체크/빌드 + Mobile analyze/test
-- Mobile release APK 빌드 검증(`mobile-release-check.yml`)
+- Mobile release APK 빌드 검증(`mobile-release-check.yml`, `apps/mobile/**` 변경 시 조건부 실행)
 - Mobile store release readiness 수동 검증(`mobile-store-release.yml`)
 - API/Admin Docker 이미지 ECR push
 - EC2 SSH 배포 및 헬스체크

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -19,6 +19,7 @@
   - 로컬 악보 파일 디코딩 실패 시 원본 URL로 자동 fallback
   - MIDI 에셋 앱 내 재생 UX (재생/일시정지/정지/속도)
 - 개인화
+  - 내 정보(교회/이름/구역) 조회/수정
   - 즐겨찾기 토글
   - 메모 조회/저장
   - 최근 열람 히스토리 조회 (검색 + 기간 필터 + 빈 상태 가이드)
@@ -54,6 +55,7 @@
   - `POST /auth/refresh`
   - `POST /auth/logout`
   - `GET /me/profile`
+  - `PUT /me/profile`
   - `GET /me/favorites/{hymnId}`
   - `GET /hymns`
   - `GET /hymns/{id}`


### PR DESCRIPTION
## What
- add server-backed user profile model (`user_profiles`) with migration V13
- extend `/me/profile` and add `PUT /me/profile` for profile upsert
- add mobile profile/settings tab (`내 정보`) with profile edit, cache clear, logout
- switch onboarding completion to server profile sync
- add auth endpoint rate limiting + auth success/failure metrics
- backfill API/mobile docs and add coverage tests
- harden local asset cache stream handling (stream cancel on early return + total download timeout)

## Why
- complete P0 personal profile/settings flow with cross-device consistency
- improve auth abuse resistance and observability
- proactively address existing review feedback patterns on streamed cache handling

## Validation
- `apps/api`: `./gradlew.bat test --no-daemon`
- `apps/mobile`: `..\\..\\scripts\\flutterw.ps1 analyze`
- `apps/mobile`: `..\\..\\scripts\\flutterw.ps1 test`