### PR TITLE
fix(api): harden auth rate-limit client IP resolution

### DIFF
--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AuthController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AuthController.java
@@ -14,6 +14,7 @@ import com.eunhyehymn.infrastructure.security.SocialLoginException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.constraints.NotBlank;
 import java.util.Locale;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,6 +34,7 @@ public class AuthController {
     private final UserPasswordSignupUseCase userPasswordSignupUseCase;
     private final UserPasswordLoginUseCase userPasswordLoginUseCase;
     private final AuthRateLimitService authRateLimitService;
+    private final boolean trustForwardedIpHeader;
 
     public AuthController(
         AdminPasswordLoginUseCase adminPasswordLoginUseCase,
@@ -42,7 +44,8 @@ public class AuthController {
         SocialLoginUseCase socialLoginUseCase,
         UserPasswordSignupUseCase userPasswordSignupUseCase,
         UserPasswordLoginUseCase userPasswordLoginUseCase,
-        AuthRateLimitService authRateLimitService
+        AuthRateLimitService authRateLimitService,
+        @Value("${security.rate-limit.auth.trust-forwarded-ip-header:false}") boolean trustForwardedIpHeader
     ) {
         this.adminPasswordLoginUseCase = adminPasswordLoginUseCase;
         this.refreshTokenUseCase = refreshTokenUseCase;
@@ -52,6 +55,7 @@ public class AuthController {
         this.userPasswordSignupUseCase = userPasswordSignupUseCase;
         this.userPasswordLoginUseCase = userPasswordLoginUseCase;
         this.authRateLimitService = authRateLimitService;
+        this.trustForwardedIpHeader = trustForwardedIpHeader;
     }
 
     @PostMapping("/admin/login")
@@ -196,15 +200,32 @@ public class AuthController {
     }
 
     private String resolveClientIp(HttpServletRequest request) {
+        if (!trustForwardedIpHeader) {
+            return normalizeIp(request.getRemoteAddr());
+        }
+
         String forwardedFor = request.getHeader("X-Forwarded-For");
         if (forwardedFor != null && !forwardedFor.isBlank()) {
-            return forwardedFor.split(",")[0].trim();
+            String candidate = normalizeIp(forwardedFor.split(",")[0]);
+            if (!candidate.isBlank()) {
+                return candidate;
+            }
         }
         String realIp = request.getHeader("X-Real-IP");
         if (realIp != null && !realIp.isBlank()) {
-            return realIp.trim();
+            String candidate = normalizeIp(realIp);
+            if (!candidate.isBlank()) {
+                return candidate;
+            }
         }
-        return request.getRemoteAddr();
+        return normalizeIp(request.getRemoteAddr());
+    }
+
+    private String normalizeIp(String source) {
+        if (source == null) {
+            return "";
+        }
+        return source.trim();
     }
 
     public record SocialLoginRequest(

--- a/apps/api/src/main/resources/application.yml
+++ b/apps/api/src/main/resources/application.yml
@@ -37,6 +37,7 @@ security:
       enabled: ${AUTH_RATE_LIMIT_ENABLED:true}
       window-seconds: ${AUTH_RATE_LIMIT_WINDOW_SECONDS:60}
       max-attempts-per-key: ${AUTH_RATE_LIMIT_MAX_ATTEMPTS_PER_KEY:25}
+      trust-forwarded-ip-header: ${AUTH_RATE_LIMIT_TRUST_FORWARDED_IP_HEADER:false}
   invite:
     code: ${INVITE_CODE}
   admin:

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AuthRateLimitApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/AuthRateLimitApiTest.java
@@ -52,4 +52,33 @@ class AuthRateLimitApiTest {
             .andExpect(status().isTooManyRequests())
             .andExpect(jsonPath("$.error.code").value("too_many_requests"));
     }
+
+    @Test
+    void spoofedForwardedIpHeaderDoesNotBypassRateLimitByDefault() throws Exception {
+        String payload = objectMapper.writeValueAsString(Map.of(
+            "loginId", "member.spoof",
+            "password", "wrong-password"
+        ));
+
+        mockMvc.perform(post("/auth/login")
+                .header("X-Forwarded-For", "203.0.113.10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.error.code").value("user_login_failed"));
+
+        mockMvc.perform(post("/auth/login")
+                .header("X-Forwarded-For", "203.0.113.11")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.error.code").value("user_login_failed"));
+
+        mockMvc.perform(post("/auth/login")
+                .header("X-Forwarded-For", "203.0.113.12")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload))
+            .andExpect(status().isTooManyRequests())
+            .andExpect(jsonPath("$.error.code").value("too_many_requests"));
+    }
 }


### PR DESCRIPTION
## What
- make auth rate-limit key use `remoteAddr` by default
- only trust `X-Forwarded-For`/`X-Real-IP` when `security.rate-limit.auth.trust-forwarded-ip-header=true`
- add coverage to ensure spoofed forwarded headers cannot bypass rate-limit in default config

## Why
- addresses PR #105 review feedback about forwarded-header spoofing bypassing auth rate limiting

## Validation
- `apps/api`: `./gradlew.bat test --no-daemon --tests *AuthRateLimitApiTest* --tests *AuthFlowTest*`