### PR TITLE
feat(ops): automate mobile store release cycle and logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -531,11 +531,19 @@ com.eunhyehymn/
 
 ### Mobile Store Release Readiness (`mobile-store-release.yml`)
 - **트리거**: `workflow_dispatch` (manual)
-- **입력**: `target=android|ios|both`, `api_base_url`
-- **Android 경로**: signed AAB 빌드(`flutter build appbundle --release`)
+- **입력**: `target=android|ios|both`, `android_distribution_mode=build_only|play_upload`, `ios_distribution_mode=build_only|testflight`, `api_base_url`
+- **Android 경로**:
+  - signed AAB 빌드(`flutter build appbundle --release`)
+  - `android_distribution_mode=play_upload` 시 Google Play 업로드
   - required secrets: `MOBILE_ANDROID_KEYSTORE_BASE64`, `MOBILE_ANDROID_KEY_ALIAS`, `MOBILE_ANDROID_KEY_PASSWORD`, `MOBILE_ANDROID_STORE_PASSWORD`
-- **iOS 경로**: release no-codesign 빌드(`flutter build ios --release --no-codesign`)
+- **iOS 경로**:
+  - `ios_distribution_mode=build_only`: release no-codesign 빌드(`flutter build ios --release --no-codesign`)
+  - `ios_distribution_mode=testflight`: signed IPA 빌드 + TestFlight 업로드
 - **목적**: 스토어 업로드 전 빌드/서명 readiness 검증
+- **운영 스크립트**:
+  - `scripts/mobile-store-preflight.ps1`
+  - `scripts/mobile-store-cycle.ps1`
+  - 실행 로그: `docs/mobile-store-release-log.md`
 
 ### Deploy Staging (`deploy-staging.yml`)
 - **트리거**: develop push + `workflow_dispatch`
@@ -792,7 +800,11 @@ develop push → GitHub Actions
 - 현재 저장소 기준 실행은 `flutter run -d chrome` 중심
 - Android release APK 빌드 검증 워크플로우 추가 완료 (`mobile-release-check.yml`, 2026-02-16)
 - Android signed AAB / iOS no-codesign 수동 readiness 워크플로우 추가 완료 (`mobile-store-release.yml`, 2026-02-17)
-- 남은 과제: 스토어 업로드 자동화(서명/인증서/배포 트랙/릴리즈 노트) 파이프라인 확정
+- 운영 루프 자동화 완료: preflight + dispatch + run watch + 로그 적재(`scripts/mobile-store-*.ps1`)
+- Android build-only 실검증 완료: run `22210175274`, `22210322592` 성공
+- 남은 과제:
+  - Google Play 실제 업로드 모드(`play_upload`) 실행 승인/검증
+  - iOS TestFlight 업로드용 시크릿(`MOBILE_IOS_*`) 프로비저닝 후 실검증
 
 ---
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -88,10 +88,12 @@ lib/
 - Local APK build helper: `scripts/build-mobile-apk.ps1`
   - debug APK (staging): `.\scripts\build-mobile-apk.ps1 -Environment staging -BuildMode debug -Install`
   - release APK: `.\scripts\build-mobile-apk.ps1 -Environment release -BuildMode release -ApiBaseUrl https://<prod-domain>/api/v1`
-- Store release readiness (Android only for now): `.github/workflows/mobile-store-release.yml` (manual)
+- Store release readiness: `.github/workflows/mobile-store-release.yml` (manual)
   - signed AAB build (`flutter build appbundle --release`)
   - `android_distribution_mode=build_only`: build artifact only
   - `android_distribution_mode=play_upload`: Google Play upload after AAB build
+  - `ios_distribution_mode=build_only`: unsigned iOS release artifact build
+  - `ios_distribution_mode=testflight`: signed IPA build + TestFlight upload
   - required inputs for play upload:
     - `android_track`: `internal | alpha | beta | production`
     - `android_release_status`: `draft | completed | inProgress | halted`
@@ -109,6 +111,20 @@ Android signing config:
 Google Play upload secrets:
 - `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`
 - `GOOGLE_PLAY_PACKAGE_NAME`
+
+iOS TestFlight secrets:
+- `MOBILE_IOS_BUNDLE_ID`
+- `MOBILE_IOS_TEAM_ID`
+- `MOBILE_IOS_P12_BASE64`
+- `MOBILE_IOS_P12_PASSWORD`
+- `MOBILE_IOS_APPSTORE_ISSUER_ID`
+- `MOBILE_IOS_APPSTORE_API_KEY_ID`
+- `MOBILE_IOS_APPSTORE_API_PRIVATE_KEY`
+
+Store release cycle helpers:
+- `scripts/mobile-store-preflight.ps1` (mode-based secret/input checks)
+- `scripts/mobile-store-cycle.ps1` (preflight + workflow_dispatch + run watch + log append)
+- `docs/mobile-store-release-log.md` (execution evidence log)
 
 See also:
 - Minimal-tooling QA guide: `docs/mobile/qa-minimal-tooling.md`

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -1184,3 +1184,38 @@
 - `powershell -NoProfile -File .\\scripts\\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner codex -AutoLogin -WaitForCompletion`
 - `rg -n "aws login|22207213127|CONDITIONAL_GO" docs/staging-smoke-log.md docs/staging-smoke-checklist.md docs/changelog-dev.md CLAUDE.md`
 
+## 41. 이번 사이클 기록 (2026-02-20, mobile store release ops cycle automation)
+
+### 목표
+- 모바일 스토어 릴리즈 작업을 반복 가능한 사이클로 고정한다. (preflight → dispatch → run watch → 로그 적재)
+
+### 범위
+- 포함: 모바일 스토어 운영 스크립트 추가, Android build_only 실검증, 문서 동기화
+- 제외: Google Play 실제 업로드(`play_upload`), iOS TestFlight 실제 업로드
+
+### 수행 작업
+1. 모바일 스토어 운영 스크립트 추가
+- `scripts/mobile-store-preflight.ps1`
+  - target/mode 기준 필수 시크릿/입력값 점검
+- `scripts/mobile-store-cycle.ps1`
+  - preflight 실행 후 `mobile-store-release.yml` workflow_dispatch
+  - run ID 감지/완료 대기/결과 로그(`docs/mobile-store-release-log.md`) 자동 적재
+
+2. 실검증
+- Android build_only 실행 성공
+  - run `22210175274`
+  - run `22210322592`
+- iOS testflight preflight 실행 결과: `MOBILE_IOS_*` 시크릿 미구성으로 실패(예상)
+
+3. 문서 동기화
+- `apps/mobile/README.md`, `docs/mobile/README.md`
+- `docs/mobile-store-release-log.md`
+- `docs/changelog-dev.md`, `docs/current-usable-scope.md`, `CLAUDE.md`, `docs/WORK_CYCLE.md`
+
+### 검증
+- `powershell -NoProfile -File .\\scripts\\mobile-store-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn -Target android -AndroidDistributionMode build_only`
+- `powershell -NoProfile -File .\\scripts\\mobile-store-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn -Target ios -IosDistributionMode testflight`
+- `powershell -NoProfile -File .\\scripts\\mobile-store-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref develop -Target android -AndroidDistributionMode build_only -IosDistributionMode build_only`
+- `gh run view 22210175274 --repo V4N1LLA/Eunhye_Hymn --json conclusion,status,url,headSha`
+- `rg -n "mobile-store|22210175274|22210322592|MOBILE_IOS_" scripts docs apps/mobile CLAUDE.md`
+

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,22 @@
 
 ## 2026-02-20
 
+### Mobile store release cycle automation + Android build-only verification
+- 스크립트 추가
+  - `scripts/mobile-store-preflight.ps1`
+    - target/mode 기준으로 필수 시크릿과 입력값 사전 점검
+  - `scripts/mobile-store-cycle.ps1`
+    - preflight + `mobile-store-release.yml` workflow_dispatch + run watch + 로그 적재 자동화
+- 실행 로그 문서 추가
+  - `docs/mobile-store-release-log.md`
+- 운영 검증
+  - Android build_only 워크플로우 2회 성공
+    - run `22210175274`
+    - run `22210322592`
+  - iOS testflight preflight는 필수 시크릿(`MOBILE_IOS_*`) 미구성으로 실패 확인
+- 문서 동기화
+  - `apps/mobile/README.md`, `docs/mobile/README.md`, `docs/current-usable-scope.md`, `CLAUDE.md`
+
 ### Staging preflight 자동 복구 + 운영 사이클 게이트 보강
 - 스크립트 개선
   - `scripts/staging-preflight.ps1`

--- a/docs/current-usable-scope.md
+++ b/docs/current-usable-scope.md
@@ -15,7 +15,7 @@
 - CI 기능: API/Admin/Mobile 검증 + Mobile release APK 검증 + Mobile store readiness(수동) 워크플로우 구성 완료
 - 스테이징 리허설/롤백/복구 자동 실행 증빙 확보(run `22010284332`, `22010387328`, `22010470389`)
 - 현재 우선 과제: 운영 PC 기준 preflight 무스킵 통과 환경 유지 + Admin/Mobile 수동 스모크 정례화
-- 모바일 배포 상태: Android signed AAB/iOS no-codesign 수동 readiness 워크플로우 추가, 스토어 업로드 파이프라인은 추가 준비 필요
+- 모바일 배포 상태: store release 워크플로우 + 운영 스크립트(`mobile-store-preflight.ps1`, `mobile-store-cycle.ps1`) 구성 완료, Android build_only 실검증 완료(run `22210175274`, `22210322592`)
 
 ## 2. 지금 바로 검증 가능한 범위 (로컬)
 
@@ -199,6 +199,9 @@ AWS 스테이징 인프라 및 CI/CD 자동 배포는 코드 기준으로 구성
 - 운영 기능 백로그
   - 비동기 export 운영 모니터링 지표(실패율/처리시간/정리량) 정례화 완료
   - 후속 과제: 지표 임계치 기반 알림/대시보드 연동 설계
+- 모바일 스토어 업로드 실검증
+  - Android `play_upload`: `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` 시크릿 준비 후 실행 검증 필요
+  - iOS `testflight`: `MOBILE_IOS_*` 시크릿 프로비저닝 후 실행 검증 필요
 
 ## 6. 빠른 사용 체크리스트
 

--- a/docs/mobile-store-release-log.md
+++ b/docs/mobile-store-release-log.md
@@ -1,0 +1,8 @@
+# Mobile Store Release Log
+
+Operational log for mobile store release workflow cycles.
+
+| UTC Time | Repo | Ref | Target | AndroidMode | iOSMode | Preflight | RunId | Result | URL | Notes |
+|----------|------|-----|--------|-------------|---------|-----------|-------|--------|-----|-------|
+| 2026-02-20T03:39:55Z | V4N1LLA/Eunhye_Hymn | develop | android | build_only | build_only | PASS | 22210175274 | SUCCESS | https://github.com/V4N1LLA/Eunhye_Hymn/actions/runs/22210175274 | conclusion=success, head_sha=50520da1d88e6a22672c6a1778329422bf89016f |
+| 2026-02-20T03:47:44Z | V4N1LLA/Eunhye_Hymn | develop | android | build_only | build_only | PASS | 22210322592 | SUCCESS | https://github.com/V4N1LLA/Eunhye_Hymn/actions/runs/22210322592 | conclusion=success, head_sha=50520da1d88e6a22672c6a1778329422bf89016f |

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -140,6 +140,9 @@ Android Kakao 콜백 스킴은 `kakao<KAKAO_NATIVE_APP_KEY>`이므로,
   - `android_track`: `internal` | `alpha` | `beta` | `production` (play upload 시)
   - `android_release_status`: `draft` | `completed` | `inProgress` | `halted` (play upload 시)
   - `android_changes_not_sent_for_review`: `true` | `false` (play upload 시)
+  - `ios_distribution_mode`: `build_only` | `testflight`
+  - `ios_bundle_id`: iOS bundle id 1회 오버라이드(미입력 시 `MOBILE_IOS_BUNDLE_ID` 사용)
+  - `release_notes`: TestFlight release notes
   - `api_base_url`: 릴리즈 빌드 시 주입할 API URL
 - Android 경로:
   - 서명형 AAB 빌드(`flutter build appbundle --release`)
@@ -151,9 +154,30 @@ Android Kakao 콜백 스킴은 `kakao<KAKAO_NATIVE_APP_KEY>`이므로,
     - `MOBILE_ANDROID_STORE_PASSWORD`
     - `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` (play upload 시)
     - `GOOGLE_PLAY_PACKAGE_NAME` (입력 미지정 시)
+- iOS 경로:
+  - `ios_distribution_mode=build_only`: no-codesign 릴리즈 빌드 후 artifact 업로드
+  - `ios_distribution_mode=testflight`: signed archive/IPA 빌드 후 TestFlight 업로드
+  - 필요한 Secrets (testflight 시):
+    - `MOBILE_IOS_BUNDLE_ID` (입력 미지정 시)
+    - `MOBILE_IOS_TEAM_ID`
+    - `MOBILE_IOS_P12_BASE64`
+    - `MOBILE_IOS_P12_PASSWORD`
+    - `MOBILE_IOS_APPSTORE_ISSUER_ID`
+    - `MOBILE_IOS_APPSTORE_API_KEY_ID`
+    - `MOBILE_IOS_APPSTORE_API_PRIVATE_KEY`
 - Android 서명 설정:
   - `apps/mobile/android/key.properties.example`를 기준으로 `apps/mobile/android/key.properties` 구성
   - `key.properties`가 없으면 로컬 릴리즈 체크는 debug signing fallback을 사용
+
+## 6.3 Store release 사이클 자동화
+
+- preflight(권장):
+  - `.\scripts\mobile-store-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn -Target android -AndroidDistributionMode build_only`
+  - `.\scripts\mobile-store-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn -Target ios -IosDistributionMode testflight`
+- 사이클 실행(권장):
+  - `.\scripts\mobile-store-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref develop -Target android -AndroidDistributionMode build_only -IosDistributionMode build_only`
+- 실행 로그:
+  - `docs/mobile-store-release-log.md`
 
 ## 7. 운영 연계 체크포인트
 

--- a/scripts/mobile-store-cycle.ps1
+++ b/scripts/mobile-store-cycle.ps1
@@ -1,0 +1,316 @@
+param(
+  [string]$Repo = "V4N1LLA/Eunhye_Hymn",
+  [string]$Ref = "develop",
+  [string]$Workflow = "mobile-store-release.yml",
+  [ValidateSet("android", "ios", "both")][string]$Target = "android",
+  [ValidateSet("build_only", "play_upload")][string]$AndroidDistributionMode = "build_only",
+  [string]$AndroidPackageName = "",
+  [ValidateSet("internal", "alpha", "beta", "production")][string]$AndroidTrack = "internal",
+  [ValidateSet("draft", "completed", "inProgress", "halted")][string]$AndroidReleaseStatus = "draft",
+  [bool]$AndroidChangesNotSentForReview = $true,
+  [ValidateSet("build_only", "testflight")][string]$IosDistributionMode = "build_only",
+  [string]$IosBundleId = "",
+  [string]$ReleaseNotes = "",
+  [string]$ApiBaseUrl = "https://example.com/api/v1",
+  [string]$LogFile = "docs/mobile-store-release-log.md",
+  [switch]$SkipPreflight,
+  [switch]$DryRun,
+  [int]$RunDetectRetries = 36,
+  [int]$RunDetectIntervalSeconds = 5,
+  [int]$WatchIntervalSeconds = 20
+)
+
+$ErrorActionPreference = "Stop"
+
+function Escape-MarkdownCell {
+  param([string]$Value)
+  if ($null -eq $Value) {
+    return ""
+  }
+  return $Value.Replace("|", "\|").Trim()
+}
+
+function Ensure-LogFile {
+  param([string]$Path)
+
+  if (Test-Path $Path) {
+    return
+  }
+
+@"
+# Mobile Store Release Log
+
+Operational log for mobile store release workflow cycles.
+
+| UTC Time | Repo | Ref | Target | AndroidMode | iOSMode | Preflight | RunId | Result | URL | Notes |
+|----------|------|-----|--------|-------------|---------|-----------|-------|--------|-----|-------|
+"@ | Set-Content -Path $Path -Encoding utf8
+}
+
+function Append-LogRow {
+  param(
+    [string]$Path,
+    [hashtable]$Row
+  )
+
+  Ensure-LogFile -Path $Path
+  $line = "| {0} | {1} | {2} | {3} | {4} | {5} | {6} | {7} | {8} | {9} | {10} |" -f `
+    (Escape-MarkdownCell $Row.UtcTime),
+    (Escape-MarkdownCell $Row.Repo),
+    (Escape-MarkdownCell $Row.Ref),
+    (Escape-MarkdownCell $Row.Target),
+    (Escape-MarkdownCell $Row.AndroidMode),
+    (Escape-MarkdownCell $Row.IosMode),
+    (Escape-MarkdownCell $Row.Preflight),
+    (Escape-MarkdownCell $Row.RunId),
+    (Escape-MarkdownCell $Row.Result),
+    (Escape-MarkdownCell $Row.Url),
+    (Escape-MarkdownCell $Row.Notes)
+  Add-Content -Path $Path -Value $line -Encoding utf8
+}
+
+function Invoke-PowerShellFile {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ScriptPath,
+    [string[]]$Arguments = @()
+  )
+
+  $output = & powershell.exe -NoProfile -File $ScriptPath @Arguments 2>&1
+  return [PSCustomObject]@{
+    ExitCode = $LASTEXITCODE
+    Output = ($output -join "`n")
+  }
+}
+
+function Test-CommandExists {
+  param([string]$Name)
+  return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+if (-not (Test-CommandExists "gh")) {
+  throw "gh CLI is required."
+}
+
+$preflightState = "SKIPPED"
+
+if (-not $SkipPreflight) {
+  $preflightScript = Join-Path $PSScriptRoot "mobile-store-preflight.ps1"
+  if (-not (Test-Path $preflightScript)) {
+    throw "mobile-store-preflight.ps1 not found: $preflightScript"
+  }
+
+  $preflightArgs = @(
+    "-Repo", $Repo,
+    "-Target", $Target,
+    "-AndroidDistributionMode", $AndroidDistributionMode,
+    "-IosDistributionMode", $IosDistributionMode
+  )
+  if (-not [string]::IsNullOrWhiteSpace($AndroidPackageName)) {
+    $preflightArgs += @("-AndroidPackageName", $AndroidPackageName)
+  }
+  if (-not [string]::IsNullOrWhiteSpace($IosBundleId)) {
+    $preflightArgs += @("-IosBundleId", $IosBundleId)
+  }
+
+  $preflightResult = Invoke-PowerShellFile -ScriptPath $preflightScript -Arguments $preflightArgs
+  if ($preflightResult.ExitCode -eq 0) {
+    $preflightState = "PASS"
+  } else {
+    $preflightState = "FAIL"
+    Append-LogRow -Path $LogFile -Row @{
+      UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+      Repo = $Repo
+      Ref = $Ref
+      Target = $Target
+      AndroidMode = $AndroidDistributionMode
+      IosMode = $IosDistributionMode
+      Preflight = $preflightState
+      RunId = "-"
+      Result = "ABORTED"
+      Url = "-"
+      Notes = "preflight failed"
+    }
+    throw "mobile store preflight failed; cycle aborted."
+  }
+}
+
+$androidChanges = if ($AndroidChangesNotSentForReview) { "true" } else { "false" }
+
+if ($DryRun) {
+  Write-Host "[DryRun] Repo: $Repo"
+  Write-Host "[DryRun] Ref: $Ref"
+  Write-Host "[DryRun] Workflow: $Workflow"
+  Write-Host "[DryRun] Target: $Target"
+  Write-Host "[DryRun] Android mode: $AndroidDistributionMode"
+  Write-Host "[DryRun] iOS mode: $IosDistributionMode"
+  Write-Host "[DryRun] Preflight: $preflightState"
+  Write-Host "[DryRun] LogFile: $LogFile"
+  exit 0
+}
+
+$triggeredAfter = (Get-Date).ToUniversalTime()
+$baselineRuns = gh run list --repo $Repo --workflow $Workflow --branch $Ref --event workflow_dispatch --limit 30 --json databaseId 2>$null
+$knownRunIds = @{}
+if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($baselineRuns)) {
+  try {
+    $known = $baselineRuns | ConvertFrom-Json
+    foreach ($run in $known) {
+      $id = "$($run.databaseId)"
+      if (-not [string]::IsNullOrWhiteSpace($id)) {
+        $knownRunIds[$id] = $true
+      }
+    }
+  } catch {
+    # Best-effort baseline only.
+  }
+}
+
+$workflowArgs = @(
+  "workflow", "run", $Workflow,
+  "--repo", $Repo,
+  "--ref", $Ref,
+  "-f", "target=$Target",
+  "-f", "android_distribution_mode=$AndroidDistributionMode",
+  "-f", "android_track=$AndroidTrack",
+  "-f", "android_release_status=$AndroidReleaseStatus",
+  "-f", "android_changes_not_sent_for_review=$androidChanges",
+  "-f", "ios_distribution_mode=$IosDistributionMode",
+  "-f", "release_notes=$ReleaseNotes",
+  "-f", "api_base_url=$ApiBaseUrl"
+)
+
+if (-not [string]::IsNullOrWhiteSpace($AndroidPackageName)) {
+  $workflowArgs += @("-f", "android_package_name=$AndroidPackageName")
+}
+if (-not [string]::IsNullOrWhiteSpace($IosBundleId)) {
+  $workflowArgs += @("-f", "ios_bundle_id=$IosBundleId")
+}
+
+& gh @workflowArgs
+if ($LASTEXITCODE -ne 0) {
+  Append-LogRow -Path $LogFile -Row @{
+    UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    Repo = $Repo
+    Ref = $Ref
+    Target = $Target
+    AndroidMode = $AndroidDistributionMode
+    IosMode = $IosDistributionMode
+    Preflight = $preflightState
+    RunId = "-"
+    Result = "FAILED"
+    Url = "-"
+    Notes = "workflow dispatch failed"
+  }
+  throw "failed to dispatch workflow."
+}
+
+$runId = ""
+$runUrl = ""
+for ($i = 0; $i -lt $RunDetectRetries; $i++) {
+  $runJson = gh run list --repo $Repo --workflow $Workflow --branch $Ref --event workflow_dispatch --limit 10 --json databaseId,createdAt,url,status
+  if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($runJson)) {
+    $runs = $runJson | ConvertFrom-Json
+    $candidate = $runs |
+      Where-Object { -not $knownRunIds.ContainsKey("$($_.databaseId)") } |
+      Sort-Object { [DateTime]$_.createdAt } -Descending |
+      Select-Object -First 1
+
+    if ($null -ne $candidate) {
+      $runId = "$($candidate.databaseId)"
+      $runUrl = "$($candidate.url)"
+      break
+    }
+
+    # Fallback: if no baseline match was captured, use latest run after dispatch time window.
+    if ($knownRunIds.Count -eq 0) {
+      $fallback = $runs |
+        Where-Object { ([DateTime]$_.createdAt).ToUniversalTime() -ge $triggeredAfter.AddSeconds(-30) } |
+        Sort-Object { [DateTime]$_.createdAt } -Descending |
+        Select-Object -First 1
+      if ($null -ne $fallback) {
+        $runId = "$($fallback.databaseId)"
+        $runUrl = "$($fallback.url)"
+        break
+      }
+    }
+  }
+
+  Start-Sleep -Seconds $RunDetectIntervalSeconds
+}
+
+if ([string]::IsNullOrWhiteSpace($runId)) {
+  Append-LogRow -Path $LogFile -Row @{
+    UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    Repo = $Repo
+    Ref = $Ref
+    Target = $Target
+    AndroidMode = $AndroidDistributionMode
+    IosMode = $IosDistributionMode
+    Preflight = $preflightState
+    RunId = "-"
+    Result = "FAILED"
+    Url = "-"
+    Notes = "could not detect workflow run id"
+  }
+  throw "failed to detect workflow run id."
+}
+
+& gh run watch $runId --repo $Repo --interval $WatchIntervalSeconds --exit-status
+$watchExitCode = $LASTEXITCODE
+
+$runView = gh run view $runId --repo $Repo --json conclusion,status,url,headSha
+if ($LASTEXITCODE -ne 0) {
+  $result = if ($watchExitCode -eq 0) { "SUCCESS" } else { "FAILED" }
+  Append-LogRow -Path $LogFile -Row @{
+    UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    Repo = $Repo
+    Ref = $Ref
+    Target = $Target
+    AndroidMode = $AndroidDistributionMode
+    IosMode = $IosDistributionMode
+    Preflight = $preflightState
+    RunId = $runId
+    Result = $result
+    Url = $runUrl
+    Notes = "run watch completed, run view failed"
+  }
+  if ($watchExitCode -ne 0) {
+    throw "workflow run failed (run id: $runId)"
+  }
+  exit 0
+}
+
+$runInfo = $runView | ConvertFrom-Json
+$conclusion = if ([string]::IsNullOrWhiteSpace($runInfo.conclusion)) { "unknown" } else { $runInfo.conclusion }
+$result = if ($watchExitCode -eq 0 -and $conclusion -eq "success") { "SUCCESS" } else { "FAILED" }
+$notes = "conclusion=$conclusion, head_sha=$($runInfo.headSha)"
+
+Append-LogRow -Path $LogFile -Row @{
+  UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+  Repo = $Repo
+  Ref = $Ref
+  Target = $Target
+  AndroidMode = $AndroidDistributionMode
+  IosMode = $IosDistributionMode
+  Preflight = $preflightState
+  RunId = $runId
+  Result = $result
+  Url = $runInfo.url
+  Notes = $notes
+}
+
+Write-Host "== Mobile Store Cycle =="
+Write-Host ("Repo: {0}" -f $Repo)
+Write-Host ("Ref: {0}" -f $Ref)
+Write-Host ("Target: {0}" -f $Target)
+Write-Host ("RunId: {0}" -f $runId)
+Write-Host ("Preflight: {0}" -f $preflightState)
+Write-Host ("Conclusion: {0}" -f $conclusion)
+Write-Host ("Log: {0}" -f $LogFile)
+
+if ($result -ne "SUCCESS") {
+  exit 1
+}
+
+exit 0

--- a/scripts/mobile-store-preflight.ps1
+++ b/scripts/mobile-store-preflight.ps1
@@ -1,0 +1,126 @@
+param(
+  [string]$Repo = "V4N1LLA/Eunhye_Hymn",
+  [ValidateSet("android", "ios", "both")][string]$Target = "both",
+  [ValidateSet("build_only", "play_upload")][string]$AndroidDistributionMode = "build_only",
+  [string]$AndroidPackageName = "",
+  [ValidateSet("build_only", "testflight")][string]$IosDistributionMode = "build_only",
+  [string]$IosBundleId = ""
+)
+
+$ErrorActionPreference = "Stop"
+$checks = @()
+
+function Add-Check {
+  param(
+    [string]$Name,
+    [bool]$Passed,
+    [string]$Detail
+  )
+
+  $script:checks += [PSCustomObject]@{
+    Name = $Name
+    Passed = $Passed
+    Detail = $Detail
+  }
+}
+
+function Test-CommandExists {
+  param([string]$Name)
+  return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Add-SecretCheck {
+  param(
+    [string]$SecretName,
+    [string]$Reason
+  )
+
+  $exists = $script:existingSecrets.ContainsKey($SecretName)
+  if ($exists) {
+    Add-Check ("secret " + $SecretName) $true "set"
+    return
+  }
+
+  Add-Check ("secret " + $SecretName) $false ("missing: " + $Reason)
+}
+
+Add-Check "gh cli" (Test-CommandExists "gh") "required"
+if (-not (Test-CommandExists "gh")) {
+  $checks | Format-Table -AutoSize
+  exit 1
+}
+
+gh auth status 1>$null 2>$null
+Add-Check "gh auth status" ($LASTEXITCODE -eq 0) "github auth"
+if ($LASTEXITCODE -ne 0) {
+  $checks | Format-Table -AutoSize
+  exit 1
+}
+
+$secretNames = gh secret list --repo $Repo --json name --jq '.[].name' 2>$null
+if ($LASTEXITCODE -ne 0) {
+  Add-Check "gh secret list" $false "failed"
+  $checks | Format-Table -AutoSize
+  exit 1
+}
+
+$script:existingSecrets = @{}
+foreach ($name in $secretNames) {
+  $trimmed = "$name".Trim()
+  if (-not [string]::IsNullOrWhiteSpace($trimmed)) {
+    $script:existingSecrets[$trimmed] = $true
+  }
+}
+Add-Check "gh secret list" $true "ok"
+
+$targetAndroid = ($Target -eq "android" -or $Target -eq "both")
+$targetIos = ($Target -eq "ios" -or $Target -eq "both")
+
+if ($targetAndroid) {
+  Add-SecretCheck "MOBILE_ANDROID_KEYSTORE_BASE64" "android signed AAB build"
+  Add-SecretCheck "MOBILE_ANDROID_KEY_ALIAS" "android signed AAB build"
+  Add-SecretCheck "MOBILE_ANDROID_KEY_PASSWORD" "android signed AAB build"
+  Add-SecretCheck "MOBILE_ANDROID_STORE_PASSWORD" "android signed AAB build"
+
+  if ($AndroidDistributionMode -eq "play_upload") {
+    Add-SecretCheck "GOOGLE_PLAY_SERVICE_ACCOUNT_JSON" "google play upload mode"
+
+    if (-not [string]::IsNullOrWhiteSpace($AndroidPackageName)) {
+      Add-Check "android package name" $true "input override"
+    } elseif ($script:existingSecrets.ContainsKey("GOOGLE_PLAY_PACKAGE_NAME")) {
+      Add-Check "android package name" $true "secret GOOGLE_PLAY_PACKAGE_NAME"
+    } else {
+      Add-Check "android package name" $false "missing input or GOOGLE_PLAY_PACKAGE_NAME secret"
+    }
+  } else {
+    Add-Check "android play upload secrets" $true "not required for build_only"
+  }
+}
+
+if ($targetIos) {
+  if ($IosDistributionMode -eq "testflight") {
+    if (-not [string]::IsNullOrWhiteSpace($IosBundleId)) {
+      Add-Check "ios bundle id" $true "input override"
+    } else {
+      Add-SecretCheck "MOBILE_IOS_BUNDLE_ID" "ios testflight upload mode"
+    }
+
+    Add-SecretCheck "MOBILE_IOS_TEAM_ID" "ios testflight upload mode"
+    Add-SecretCheck "MOBILE_IOS_P12_BASE64" "ios testflight upload mode"
+    Add-SecretCheck "MOBILE_IOS_P12_PASSWORD" "ios testflight upload mode"
+    Add-SecretCheck "MOBILE_IOS_APPSTORE_ISSUER_ID" "ios testflight upload mode"
+    Add-SecretCheck "MOBILE_IOS_APPSTORE_API_KEY_ID" "ios testflight upload mode"
+    Add-SecretCheck "MOBILE_IOS_APPSTORE_API_PRIVATE_KEY" "ios testflight upload mode"
+  } else {
+    Add-Check "ios testflight secrets" $true "not required for build_only"
+  }
+}
+
+$checks | Format-Table -AutoSize
+
+$failed = @($checks | Where-Object { -not $_.Passed })
+if ($failed.Count -gt 0) {
+  exit 1
+}
+
+exit 0


### PR DESCRIPTION
﻿## Summary
- add `scripts/mobile-store-preflight.ps1` to validate required secrets/inputs by target and distribution mode before dispatch
- add `scripts/mobile-store-cycle.ps1` to run preflight -> dispatch `mobile-store-release.yml` -> watch completion -> append `docs/mobile-store-release-log.md`
- add mobile store execution log document (`docs/mobile-store-release-log.md`)
- sync mobile release docs (`apps/mobile/README.md`, `docs/mobile/README.md`) and project status docs (`CLAUDE.md`, `docs/current-usable-scope.md`, `docs/changelog-dev.md`, `docs/WORK_CYCLE.md`)

## Validation
- `powershell -NoProfile -File .\scripts\mobile-store-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn -Target android -AndroidDistributionMode build_only`
- `powershell -NoProfile -File .\scripts\mobile-store-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn -Target ios -IosDistributionMode testflight` (expected fail: missing `MOBILE_IOS_*` secrets)
- `powershell -NoProfile -File .\scripts\mobile-store-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref develop -Target android -AndroidDistributionMode build_only -IosDistributionMode build_only`
- `gh run view 22210175274 --repo V4N1LLA/Eunhye_Hymn --json conclusion,status,url,headSha,createdAt,updatedAt`
- `gh run view 22210322592 --repo V4N1LLA/Eunhye_Hymn --json conclusion,status,url,headSha,createdAt,updatedAt`

## Result
- Android build_only store readiness run succeeded twice:
  - `22210175274`
  - `22210322592`
- Remaining blockers are explicitly surfaced by preflight:
  - `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` for Android `play_upload`
  - `MOBILE_IOS_*` secrets for iOS `testflight`
