### PR TITLE
fix: harden run detection window in mobile store cycle

### DIFF
--- a/scripts/mobile-store-cycle.ps1
+++ b/scripts/mobile-store-cycle.ps1
@@ -15,7 +15,7 @@ param(
   [string]$LogFile = "docs/mobile-store-release-log.md",
   [switch]$SkipPreflight,
   [switch]$DryRun,
-  [int]$RunDetectRetries = 36,
+  [int]$RunDetectRetries = 120,
   [int]$RunDetectIntervalSeconds = 5,
   [int]$WatchIntervalSeconds = 20
 )
@@ -150,6 +150,8 @@ if ($DryRun) {
 }
 
 $triggeredAfter = (Get-Date).ToUniversalTime()
+# Use a small skew buffer for fallback in case local and GitHub API clocks differ slightly.
+$dispatchWindowStart = $triggeredAfter.AddMinutes(-2)
 $baselineRuns = gh run list --repo $Repo --workflow $Workflow --branch $Ref --event workflow_dispatch --limit 30 --json databaseId 2>$null
 $knownRunIds = @{}
 if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($baselineRuns)) {
@@ -208,31 +210,38 @@ if ($LASTEXITCODE -ne 0) {
 $runId = ""
 $runUrl = ""
 for ($i = 0; $i -lt $RunDetectRetries; $i++) {
-  $runJson = gh run list --repo $Repo --workflow $Workflow --branch $Ref --event workflow_dispatch --limit 10 --json databaseId,createdAt,url,status
+  $runJson = gh run list --repo $Repo --workflow $Workflow --event workflow_dispatch --limit 30 --json databaseId,createdAt,url,status,headBranch
   if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($runJson)) {
     $runs = $runJson | ConvertFrom-Json
-    $candidate = $runs |
-      Where-Object { -not $knownRunIds.ContainsKey("$($_.databaseId)") } |
-      Sort-Object { [DateTime]$_.createdAt } -Descending |
-      Select-Object -First 1
-
-    if ($null -ne $candidate) {
-      $runId = "$($candidate.databaseId)"
-      $runUrl = "$($candidate.url)"
-      break
+    $runsWithCreatedAt = $runs | ForEach-Object {
+      [PSCustomObject]@{
+        Run = $_
+        CreatedAtUtc = ([DateTime]$_.createdAt).ToUniversalTime()
+      }
     }
 
-    # Fallback: if no baseline match was captured, use latest run after dispatch time window.
-    if ($knownRunIds.Count -eq 0) {
-      $fallback = $runs |
-        Where-Object { ([DateTime]$_.createdAt).ToUniversalTime() -ge $triggeredAfter.AddSeconds(-30) } |
-        Sort-Object { [DateTime]$_.createdAt } -Descending |
-        Select-Object -First 1
-      if ($null -ne $fallback) {
-        $runId = "$($fallback.databaseId)"
-        $runUrl = "$($fallback.url)"
-        break
+    $strictCandidates = $runsWithCreatedAt |
+      Where-Object {
+        (-not $knownRunIds.ContainsKey("$($_.Run.databaseId)")) -and
+        ($_.CreatedAtUtc -ge $triggeredAfter) -and
+        ([string]::IsNullOrWhiteSpace($_.Run.headBranch) -or $_.Run.headBranch -eq $Ref)
       }
+    $selected = $strictCandidates | Sort-Object CreatedAtUtc | Select-Object -First 1
+
+    if ($null -eq $selected) {
+      $fallbackCandidates = $runsWithCreatedAt |
+        Where-Object {
+          (-not $knownRunIds.ContainsKey("$($_.Run.databaseId)")) -and
+          ($_.CreatedAtUtc -ge $dispatchWindowStart) -and
+          ([string]::IsNullOrWhiteSpace($_.Run.headBranch) -or $_.Run.headBranch -eq $Ref)
+        }
+      $selected = $fallbackCandidates | Sort-Object CreatedAtUtc | Select-Object -First 1
+    }
+
+    if ($null -ne $selected) {
+      $runId = "$($selected.Run.databaseId)"
+      $runUrl = "$($selected.Run.url)"
+      break
     }
   }
 


### PR DESCRIPTION
## Summary
- prioritize runs created after this script's dispatch timestamp when selecting workflow run id
- keep a bounded fallback dispatch window to tolerate small clock skew between local time and GitHub timestamps
- avoid branch-filter misses by filtering head branch from run JSON while polling and selecting earliest matching run
- increase default run-detection retries to cover delayed run registration

## Validation
- executed scripts/mobile-store-cycle.ps1 -SkipPreflight end-to-end
- detected and watched run 22211192859 successfully
