### PR TITLE
fix: select newest matching workflow run in mobile cycle

### DIFF
--- a/scripts/mobile-store-cycle.ps1
+++ b/scripts/mobile-store-cycle.ps1
@@ -226,7 +226,8 @@ for ($i = 0; $i -lt $RunDetectRetries; $i++) {
         ($_.CreatedAtUtc -ge $triggeredAfter) -and
         ([string]::IsNullOrWhiteSpace($_.Run.headBranch) -or $_.Run.headBranch -eq $Ref)
       }
-    $selected = $strictCandidates | Sort-Object CreatedAtUtc -Descending | Select-Object -First 1
+    # Select the earliest matching run after dispatch to avoid attaching to later concurrent runs.
+    $selected = $strictCandidates | Sort-Object CreatedAtUtc | Select-Object -First 1
 
     if ($null -eq $selected) {
       $fallbackCandidates = $runsWithCreatedAt |
@@ -235,7 +236,7 @@ for ($i = 0; $i -lt $RunDetectRetries; $i++) {
           ($_.CreatedAtUtc -ge $dispatchWindowStart) -and
           ([string]::IsNullOrWhiteSpace($_.Run.headBranch) -or $_.Run.headBranch -eq $Ref)
         }
-      $selected = $fallbackCandidates | Sort-Object CreatedAtUtc -Descending | Select-Object -First 1
+      $selected = $fallbackCandidates | Sort-Object CreatedAtUtc | Select-Object -First 1
     }
 
     if ($null -ne $selected) {

--- a/scripts/mobile-store-cycle.ps1
+++ b/scripts/mobile-store-cycle.ps1
@@ -226,7 +226,7 @@ for ($i = 0; $i -lt $RunDetectRetries; $i++) {
         ($_.CreatedAtUtc -ge $triggeredAfter) -and
         ([string]::IsNullOrWhiteSpace($_.Run.headBranch) -or $_.Run.headBranch -eq $Ref)
       }
-    $selected = $strictCandidates | Sort-Object CreatedAtUtc | Select-Object -First 1
+    $selected = $strictCandidates | Sort-Object CreatedAtUtc -Descending | Select-Object -First 1
 
     if ($null -eq $selected) {
       $fallbackCandidates = $runsWithCreatedAt |
@@ -235,7 +235,7 @@ for ($i = 0; $i -lt $RunDetectRetries; $i++) {
           ($_.CreatedAtUtc -ge $dispatchWindowStart) -and
           ([string]::IsNullOrWhiteSpace($_.Run.headBranch) -or $_.Run.headBranch -eq $Ref)
         }
-      $selected = $fallbackCandidates | Sort-Object CreatedAtUtc | Select-Object -First 1
+      $selected = $fallbackCandidates | Sort-Object CreatedAtUtc -Descending | Select-Object -First 1
     }
 
     if ($null -ne $selected) {


### PR DESCRIPTION
## Summary
- address review on #111 about choosing oldest matching run
- change strict/fallback candidate selection to sort CreatedAtUtc descending and pick latest run
- keep existing dispatch-window safeguards and branch matching

## Why
- 	riggeredAfter is captured before dispatch; picking oldest candidate can attach to another operator's run created after 	riggeredAfter but before our run appears
- newest matching run better tracks the dispatch this script just initiated

## Validation
- powershell -NoProfile -File scripts/mobile-store-cycle.ps1 -DryRun
- powershell -NoProfile -File scripts/mobile-store-cycle.ps1 -SkipPreflight (success, run id: 22214548251)

## Link
- follow-up to #111
