### PR TITLE
chore(devops): monorepo PR gate and staging release flow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+- What changed?
+- Why now?
+
+## Scope
+- [ ] API (`apps/api`)
+- [ ] Admin (`apps/admin`)
+- [ ] Mobile (`apps/mobile`)
+- [ ] Infra/DevOps (`infra`, `.github/workflows`, `scripts`)
+- [ ] Docs only
+
+## Branch Flow
+- Base branch:
+  - [ ] `develop` (feature integration)
+  - [ ] `staging` (release candidate validation)
+  - [ ] `production` (release)
+
+## Verification
+- [ ] Local tests/build completed
+- [ ] CI checks passed (`PR Gate` 포함)
+- [ ] No secrets included in diff
+
+## Release Impact
+- SemVer impact:
+  - [ ] PATCH
+  - [ ] MINOR
+  - [ ] MAJOR
+  - [ ] N/A
+- [ ] `CHANGELOG.md` update needed
+
+## Parallel Work Notes
+- Related terminal/worktree tasks:
+- Potentially conflicting files discussed:

--- a/.github/workflows/admin-ci.yml
+++ b/.github/workflows/admin-ci.yml
@@ -2,13 +2,25 @@ name: Admin CI
 
 on:
   pull_request:
+    branches:
+      - develop
+      - staging
+      - production
     paths:
       - "apps/admin/**"
+      - ".github/workflows/admin-ci.yml"
   push:
     branches:
       - develop
+      - staging
+      - production
     paths:
       - "apps/admin/**"
+      - ".github/workflows/admin-ci.yml"
+
+concurrency:
+  group: admin-ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -2,12 +2,18 @@ name: API CI
 
 on:
   pull_request:
+    branches:
+      - develop
+      - staging
+      - production
     paths:
       - "apps/api/**"
       - ".github/workflows/api-ci.yml"
   push:
     branches:
       - develop
+      - staging
+      - production
     paths:
       - "apps/api/**"
       - ".github/workflows/api-ci.yml"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,7 +3,12 @@ name: Deploy Staging
 on:
   push:
     branches:
-      - develop
+      - staging
+    paths:
+      - "apps/api/**"
+      - "apps/admin/**"
+      - "infra/aws/**"
+      - ".github/workflows/deploy-staging.yml"
   workflow_dispatch:
     inputs:
       enable_awslogs:
@@ -126,6 +131,7 @@ jobs:
   deploy:
     needs: build-and-push
     runs-on: ubuntu-latest
+    environment: staging
     timeout-minutes: 30
     concurrency:
       group: staging-ec2-deploy

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -4,15 +4,23 @@ on:
   pull_request:
     branches:
       - develop
+      - staging
+      - production
     paths:
       - "apps/mobile/**"
       - ".github/workflows/mobile-ci.yml"
   push:
     branches:
       - develop
+      - staging
+      - production
     paths:
       - "apps/mobile/**"
       - ".github/workflows/mobile-ci.yml"
+
+concurrency:
+  group: mobile-ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   mobile-ci:

--- a/.github/workflows/mobile-release-check.yml
+++ b/.github/workflows/mobile-release-check.yml
@@ -4,12 +4,16 @@ on:
   pull_request:
     branches:
       - develop
+      - staging
+      - production
     paths:
       - "apps/mobile/**"
       - ".github/workflows/mobile-release-check.yml"
   push:
     branches:
       - develop
+      - staging
+      - production
     paths:
       - "apps/mobile/**"
       - ".github/workflows/mobile-release-check.yml"
@@ -19,6 +23,10 @@ on:
         description: "API base URL passed to flutter build"
         required: false
         default: "https://example.com/api/v1"
+
+concurrency:
+  group: mobile-release-check-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   android-release-build:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,218 @@
+name: PR Gate
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - staging
+      - production
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+concurrency:
+  group: pr-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  detect_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+      admin: ${{ steps.filter.outputs.admin }}
+      mobile: ${{ steps.filter.outputs.mobile }}
+      infra: ${{ steps.filter.outputs.infra }}
+      scripts: ${{ steps.filter.outputs.scripts }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            api:
+              - "apps/api/**"
+            admin:
+              - "apps/admin/**"
+            mobile:
+              - "apps/mobile/**"
+            infra:
+              - "infra/**"
+            scripts:
+              - "scripts/**"
+            workflows:
+              - ".github/workflows/**"
+
+  api_test:
+    needs: detect_changes
+    if: needs.detect_changes.outputs.api == 'true' || needs.detect_changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/api
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+          cache-dependency-path: |
+            apps/api/**/*.gradle*
+            apps/api/**/gradle-wrapper.properties
+      - run: chmod +x gradlew
+      - run: ./gradlew test --no-daemon --stacktrace
+
+  admin_build:
+    needs: detect_changes
+    if: needs.detect_changes.outputs.admin == 'true' || needs.detect_changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/admin
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/admin/package-lock.json
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npm run build
+
+  mobile_ci:
+    needs: detect_changes
+    if: needs.detect_changes.outputs.mobile == 'true' || needs.detect_changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/mobile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+      - run: flutter pub get
+      - run: flutter analyze
+      - run: flutter test --reporter expanded
+
+  mobile_release_check:
+    needs: detect_changes
+    if: needs.detect_changes.outputs.mobile == 'true' || needs.detect_changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/mobile
+    env:
+      API_BASE_URL: https://example.com/api/v1
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+      - run: flutter pub get
+      - run: flutter build apk --release --dart-define=API_BASE_URL="${API_BASE_URL}"
+
+  workflow_lint:
+    needs: detect_changes
+    if: needs.detect_changes.outputs.workflows == 'true' || needs.detect_changes.outputs.infra == 'true' || needs.detect_changes.outputs.scripts == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint GitHub Actions workflows
+        uses: rhysd/actionlint@v1.7.10
+
+      - name: Validate deploy script syntax
+        run: |
+          bash -n infra/aws/deploy.sh
+          bash -n infra/aws/verify-staging.sh
+
+      - name: Validate PowerShell script syntax
+        shell: pwsh
+        run: |
+          $scripts = @(
+            "scripts/staging-preflight.ps1",
+            "scripts/staging-latest-status.ps1",
+            "scripts/staging-ops-cycle.ps1",
+            "scripts/staging-rehearsal.ps1",
+            "scripts/staging-sync-secrets.ps1",
+            "scripts/release-preflight.ps1",
+            "scripts/new-worktree-task.ps1",
+            "scripts/apply-branch-protection.ps1"
+          )
+
+          $hasErrors = $false
+          foreach ($script in $scripts) {
+            if (-not (Test-Path $script)) {
+              Write-Error "Missing script: $script"
+              $hasErrors = $true
+              continue
+            }
+
+            $tokens = $null
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile($script, [ref]$tokens, [ref]$errors) | Out-Null
+            if ($errors.Count -gt 0) {
+              foreach ($error in $errors) {
+                Write-Error ("{0}:{1} {2}" -f $script, $error.Extent.StartLineNumber, $error.Message)
+              }
+              $hasErrors = $true
+            }
+          }
+
+          if ($hasErrors) {
+            throw "PowerShell syntax validation failed."
+          }
+
+  gate:
+    needs:
+      - detect_changes
+      - api_test
+      - admin_build
+      - mobile_ci
+      - mobile_release_check
+      - workflow_lint
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate gate
+        env:
+          API_TEST_RESULT: ${{ needs.api_test.result }}
+          ADMIN_BUILD_RESULT: ${{ needs.admin_build.result }}
+          MOBILE_CI_RESULT: ${{ needs.mobile_ci.result }}
+          MOBILE_RELEASE_RESULT: ${{ needs.mobile_release_check.result }}
+          WORKFLOW_LINT_RESULT: ${{ needs.workflow_lint.result }}
+        run: |
+          echo "api_test=${API_TEST_RESULT}"
+          echo "admin_build=${ADMIN_BUILD_RESULT}"
+          echo "mobile_ci=${MOBILE_CI_RESULT}"
+          echo "mobile_release_check=${MOBILE_RELEASE_RESULT}"
+          echo "workflow_lint=${WORKFLOW_LINT_RESULT}"
+
+          for result in \
+            "${API_TEST_RESULT}" \
+            "${ADMIN_BUILD_RESULT}" \
+            "${MOBILE_CI_RESULT}" \
+            "${MOBILE_RELEASE_RESULT}" \
+            "${WORKFLOW_LINT_RESULT}"; do
+            if [ "${result}" != "success" ] && [ "${result}" != "skipped" ]; then
+              echo "::error::PR gate failed because one or more required jobs did not pass."
+              exit 1
+            fi
+          done
+
+          echo "PR gate passed."

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,119 @@
+name: Release On Tag
+
+on:
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  validate-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.semver.outputs.version }}
+    steps:
+      - name: Validate SemVer tag
+        id: semver
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ ! "${TAG_NAME}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "::error::Tag must match vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
+          echo "version=${TAG_NAME#v}" >> "$GITHUB_OUTPUT"
+
+  test-api:
+    needs: validate-tag
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/api
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+          cache-dependency-path: |
+            apps/api/**/*.gradle*
+            apps/api/**/gradle-wrapper.properties
+      - run: chmod +x gradlew
+      - run: ./gradlew test --no-daemon --stacktrace
+
+  check-admin:
+    needs: validate-tag
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/admin
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/admin/package-lock.json
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npm run build
+
+  mobile-ci:
+    needs: validate-tag
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/mobile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+      - run: flutter pub get
+      - run: flutter analyze
+      - run: flutter test --reporter expanded
+
+  mobile-release-build:
+    needs: validate-tag
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/mobile
+    env:
+      API_BASE_URL: https://example.com/api/v1
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+      - run: flutter pub get
+      - run: flutter build apk --release --dart-define=API_BASE_URL="${API_BASE_URL}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: mobile-android-release-apk-${{ github.ref_name }}
+          path: apps/mobile/build/app/outputs/flutter-apk/app-release.apk
+          if-no-files-found: error
+
+  create-release:
+    needs: [validate-tag, test-api, check-admin, mobile-ci, mobile-release-build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          generate_release_notes: true

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -26,16 +26,20 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run release preflight
+        id: preflight
         env:
           GH_TOKEN: ${{ github.token }}
         shell: pwsh
         run: |
-          ./scripts/release-preflight.ps1 `
+          pwsh -NoProfile -File ./scripts/release-preflight.ps1 `
             -Version "${{ inputs.version }}" `
             -Repo "${{ github.repository }}" `
             -Branch "${{ inputs.branch }}" `
             -MaxStagingAgeMinutes "${{ inputs.max_staging_age_minutes }}" `
             -AsJson | Out-File -FilePath release-preflight.json -Encoding utf8
+          $exitCode = $LASTEXITCODE
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "exit_code=$exitCode"
+          exit 0
 
       - name: Show preflight result
         shell: pwsh
@@ -47,3 +51,9 @@ jobs:
         with:
           name: release-preflight-${{ inputs.version }}
           path: release-preflight.json
+
+      - name: Enforce readiness result
+        if: steps.preflight.outputs.exit_code != '0'
+        shell: pwsh
+        run: |
+          Write-Error "Release preflight returned HOLD. See release-preflight.json for details."

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,49 @@
+name: Release Readiness
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Target SemVer (without v prefix), e.g. 1.2.3"
+        required: true
+      branch:
+        description: "Branch used for staging/CI evidence lookup"
+        required: false
+        default: staging
+      max_staging_age_minutes:
+        description: "Max allowed age of latest successful staging deploy"
+        required: false
+        default: "1440"
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run release preflight
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: pwsh
+        run: |
+          ./scripts/release-preflight.ps1 `
+            -Version "${{ inputs.version }}" `
+            -Repo "${{ github.repository }}" `
+            -Branch "${{ inputs.branch }}" `
+            -MaxStagingAgeMinutes "${{ inputs.max_staging_age_minutes }}" `
+            -AsJson | Out-File -FilePath release-preflight.json -Encoding utf8
+
+      - name: Show preflight result
+        shell: pwsh
+        run: |
+          Get-Content -Raw release-preflight.json
+
+      - name: Upload preflight artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-preflight-${{ inputs.version }}
+          path: release-preflight.json

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -6,6 +6,7 @@ on:
       - ".github/workflows/**"
       - "infra/aws/deploy.sh"
       - "infra/aws/verify-staging.sh"
+      - "scripts/*.ps1"
   push:
     branches:
       - develop
@@ -13,6 +14,7 @@ on:
       - ".github/workflows/**"
       - "infra/aws/deploy.sh"
       - "infra/aws/verify-staging.sh"
+      - "scripts/*.ps1"
 
 jobs:
   actionlint:
@@ -30,3 +32,44 @@ jobs:
         run: |
           bash -n infra/aws/deploy.sh
           bash -n infra/aws/verify-staging.sh
+
+  powershell-script-syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate PowerShell script syntax
+        shell: pwsh
+        run: |
+          $scripts = @(
+            "scripts/staging-preflight.ps1",
+            "scripts/staging-latest-status.ps1",
+            "scripts/staging-ops-cycle.ps1",
+            "scripts/staging-rehearsal.ps1",
+            "scripts/staging-sync-secrets.ps1",
+            "scripts/release-preflight.ps1",
+            "scripts/new-worktree-task.ps1",
+            "scripts/apply-branch-protection.ps1"
+          )
+
+          $hasErrors = $false
+          foreach ($script in $scripts) {
+            if (-not (Test-Path $script)) {
+              Write-Error "Missing script: $script"
+              $hasErrors = $true
+              continue
+            }
+
+            $tokens = $null
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile($script, [ref]$tokens, [ref]$errors) | Out-Null
+            if ($errors.Count -gt 0) {
+              foreach ($error in $errors) {
+                Write-Error ("{0}:{1} {2}" -f $script, $error.Extent.StartLineNumber, $error.Message)
+              }
+              $hasErrors = $true
+            }
+          }
+
+          if ($hasErrors) {
+            throw "PowerShell syntax validation failed."
+          }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on Keep a Changelog.
+Versioning follows Semantic Versioning.
+
+## [Unreleased]
+
+### Added
+- TBD
+
+### Changed
+- TBD
+
+### Fixed
+- TBD

--- a/docs/monorepo-cicd.md
+++ b/docs/monorepo-cicd.md
@@ -1,0 +1,53 @@
+# Monorepo CI/CD 운영 가이드
+
+## 1) 브랜치 역할
+- `develop`: 기능 개발 통합 브랜치
+- `staging`: 스테이징 배포/검증 브랜치
+- `production`: 실제 릴리즈 반영 브랜치
+
+## 2) 워크플로우 트리거 원칙
+- API 변경: `apps/api/**`만 API CI 실행
+- Admin 변경: `apps/admin/**`만 Admin CI 실행
+- Mobile 변경: `apps/mobile/**`만 Mobile CI/Release Check 실행
+- 스테이징 배포: `staging` push + 배포 관련 경로 변경 시 자동 실행
+- PR 병합 게이트: `PR Gate`가 PR마다 단일 pass/fail 체크를 제공
+
+핵심 효과:
+- 모노레포에서도 변경된 영역만 검사해 파이프라인 시간을 줄인다.
+- 브랜치 역할별 자동화 책임을 분리해 운영 사고를 줄인다.
+
+## 3) 기본 개발 흐름
+1. `feature/*` 브랜치에서 개발
+2. `develop` PR 생성 (자동 CI 통과)
+3. 릴리즈 후보 시 `develop -> staging` 머지
+4. 스테이징 자동 배포 + 스모크 검증
+5. 릴리즈 승인 시 `staging -> production` 머지
+6. `production` 커밋에 `vMAJOR.MINOR.PATCH` 태그 생성
+
+## 4) 릴리즈 자동화
+- 릴리즈 전 점검: `scripts/release-preflight.ps1`
+- GitHub 수동 점검: `Release Readiness` workflow_dispatch
+- 태그 푸시: `Release On Tag` 자동 실행 + GitHub Release 생성
+
+## 5) 브랜치 보호 권장
+- `develop`: PR 필수, 최소 1 승인, 필수 CI 체크 통과
+- `staging`: PR 필수, 필수 체크 + 스테이징 배포 성공 확인
+- `production`: PR 필수, 직접 push 금지, 태그 릴리즈만 허용
+
+브랜치 보호 적용 스크립트:
+- baseline(PR 강제): `.\scripts\apply-branch-protection.ps1 -Repo V4N1LLA/Eunhye_Hymn`
+- PR Gate 필수 체크 포함: `.\scripts\apply-branch-protection.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequirePrGateCheck`
+
+## 6) 필수 체크(권장)
+- `PR Gate / gate` (단일 필수 체크 권장)
+- 필요 시 개별 체크를 참고용으로 병행
+
+## 7) 병렬 개발 운영
+- `docs/parallel-pr-workflow.md` 기준으로 터미널별 worktree/브랜치를 분리한다.
+- 작업 시작 시 `docs/parallel-task-board.md`에 작업 소유권을 기록한다.
+
+## 8) 핫픽스
+1. `production`에서 `hotfix/*` 분기
+2. 수정 후 `staging` 검증
+3. `production` 머지 + `PATCH` 태그
+4. 동일 커밋을 `develop`에 역반영

--- a/docs/parallel-pr-workflow.md
+++ b/docs/parallel-pr-workflow.md
@@ -1,0 +1,42 @@
+# Parallel Terminal PR Workflow
+
+## 목적
+- 여러 터미널에서 동시에 작업해도 충돌/실수를 줄인다.
+- 모든 변경을 PR 단위로 추적 가능하게 유지한다.
+
+## 핵심 원칙
+1. 터미널 하나당 작업 브랜치 하나
+2. 같은 브랜치를 여러 터미널에서 동시에 수정하지 않음
+3. 직접 push 금지 브랜치(`develop`, `staging`, `production`)로는 PR만 사용
+4. PR 생성 전 로컬 검증 + CI 통과 확인
+
+## 권장 방식: git worktree
+같은 저장소를 여러 폴더로 분리해 병렬 작업한다.
+
+```powershell
+.\scripts\new-worktree-task.ps1 -TaskName "admin-user-filter" -BaseBranch develop
+```
+
+생성 후:
+1. 각 터미널은 자신의 worktree 경로에서만 작업
+2. 브랜치 이름은 task 기준으로 유지 (`feat/*`, `fix/*`, `chore/*`)
+
+## 병렬 작업 체크리스트
+- 작업 시작 시 `docs/parallel-task-board.md`에 본인 작업/브랜치/경로 등록
+- 같은 파일을 동시에 건드릴 가능성이 있으면 먼저 담당자 합의
+- 공용 파일(`README.md`, `.github/workflows/*`, `docs/*`) 변경 시 PR 설명에 명시
+
+## PR 흐름 (필수)
+1. `feature/*` -> `develop` PR
+2. 릴리즈 후보 시 `develop` -> `staging` PR
+3. 스테이징 검증 완료 후 `staging` -> `production` PR
+
+## PR 전 최소 검증
+- 변경 영역별 로컬 테스트 통과
+- `PR Gate` 워크플로우 성공 확인
+- 릴리즈 관련 변경이면 `Release Readiness` 결과 첨부
+
+## 충돌 발생 시
+1. 먼저 `git fetch origin`
+2. 대상 브랜치 리베이스/머지 후 충돌 해결
+3. 충돌 파일이 공용 정책 파일이면 관련 터미널 담당자와 먼저 합의

--- a/docs/parallel-task-board.md
+++ b/docs/parallel-task-board.md
@@ -1,0 +1,7 @@
+# Parallel Task Board
+
+병렬 작업 시작 시 아래 표에 한 줄씩 등록한다.
+
+| Owner | Task | Branch | Worktree Path | Claimed Paths | Status | Updated (UTC) |
+|---|---|---|---|---|---|---|
+| example | admin filter | feat/admin-filter | ..\worktrees\feat-admin-filter | apps/admin/src/pages/UserListPage.tsx | in_progress | 2026-02-20T00:00:00Z |

--- a/docs/release-management.md
+++ b/docs/release-management.md
@@ -1,0 +1,64 @@
+# Release Management (SemVer + GitHub)
+
+## 목적
+- 스테이징 검증이 끝난 빌드만 릴리즈한다.
+- 릴리즈 버전은 `vMAJOR.MINOR.PATCH` 태그로 GitHub에 영구 기록한다.
+- 릴리즈 시점마다 GitHub Release를 생성해 변경 이력을 남긴다.
+
+## 버전 규칙 (기본 SemVer)
+- `MAJOR`: 하위 호환이 깨지는 변경
+- `MINOR`: 하위 호환을 유지하는 기능 추가
+- `PATCH`: 하위 호환을 유지하는 버그 수정
+
+예시:
+- `v1.0.0`
+- `v1.1.0`
+- `v1.1.1`
+
+## 브랜치/배포 원칙
+- 개발 통합: `develop`
+- 스테이징 자동 배포: `staging` push 기반
+- 릴리즈 기준 브랜치: `production`
+- 모든 반영은 PR로만 진행한다 (직접 push 금지).
+
+정책:
+1. `develop`에서 개발/테스트를 완료한다.
+2. `develop -> staging`으로 릴리즈 후보를 머지한다.
+3. 스테이징 자동 배포 성공 + 스모크 테스트 완료를 확인한다.
+4. `staging -> production`으로 반영 후 릴리즈 태그를 생성한다.
+5. 태그 push 시 릴리즈 검증 워크플로우가 실행되고, 통과하면 GitHub Release가 생성된다.
+
+## 릴리즈 전 점검
+`scripts/release-preflight.ps1`를 사용한다.
+
+```powershell
+.\scripts\release-preflight.ps1 -Version 1.2.3 -Repo V4N1LLA/Eunhye_Hymn -Branch staging
+```
+
+GitHub에서 동일 점검을 실행하려면 `Release Readiness` 워크플로우를 수동 실행한다.
+
+검증 항목:
+- SemVer 형식(`1.2.3`)
+- 태그 중복 여부(`v1.2.3`)
+- 최신 스테이징 배포 성공 여부(배포/검증 단계 포함)
+- 스테이징에 올라간 커밋 SHA 기준 API/Admin/Mobile CI 성공 여부
+
+## 릴리즈 실행 절차
+1. `production`에 릴리즈 대상 반영
+2. 로컬에서 태그 생성
+
+```powershell
+git checkout production
+git pull origin production
+git tag -a v1.2.3 -m "Release v1.2.3"
+git push origin v1.2.3
+```
+
+3. GitHub Actions `Release On Tag`가 자동 실행
+4. 성공 시 GitHub Release 생성
+5. `CHANGELOG.md`의 `Unreleased` 내용을 해당 버전 섹션으로 이동
+
+## 권장 운영
+- 각 릴리즈마다 반드시 태그 + GitHub Release를 함께 남긴다.
+- 릴리즈 전에는 `docs/staging-smoke-checklist.md`와 `docs/staging-feedback-checklist.md`를 완료한다.
+- hotfix도 동일하게 `PATCH` 버전으로 태깅한다.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -20,18 +20,18 @@
 - `docs/SECRETS_MANAGEMENT.md`
 
 ## 4. 배포 체크리스트
-- [ ] `develop` 최신 반영
+- [ ] `staging` 최신 반영
 - [ ] DB 마이그레이션 변경 유무 확인
-- [ ] 환경 변수 파일 최신화 (`DB_*`, `JWT_*`, `INVITE_CODE`, `S3_*`)
+- [ ] 환경 변수 파일 최신화 (`DB_*`, `JWT_*`, `INVITE_CODE`, `ADMIN_*`, `SMS_*`, `S3_*`, `AI_*`)
 - [ ] 롤백 기준 버전(이전 이미지 태그) 확인
 - [ ] 사전 점검 스크립트 통과
   - `.\scripts\staging-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn [-AwsProfile <profile>] [-AutoLogin]`
   - AWS 세션 만료가 잦은 환경은 `-AutoLogin`을 기본으로 사용 (`aws sso login` 또는 `aws login` 자동 재시도)
 - [ ] 배포 리허설 자동 실행(권장)
-  - `.\scripts\staging-rehearsal.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref develop [-AwsProfile <profile>] [-AutoLogin]`
+  - `.\scripts\staging-rehearsal.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref staging [-AwsProfile <profile>] [-AutoLogin]`
   - 로컬 확인만 필요하면 `-DryRun` 사용
 - [ ] 운영 사이클 자동 점검(권장)
-  - `.\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner <담당자> [-AutoLogin] [-WaitForCompletion]`
+  - `.\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch staging -Owner <담당자> [-AutoLogin] [-WaitForCompletion]`
   - preflight + 최신 배포 게이트 + `docs/staging-smoke-log.md` 기록을 일괄 수행
 - [ ] GitHub Actions 필수 Secrets 등록 확인
   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `ECR_REGISTRY`, `EC2_HOST`, `EC2_SSH_KEY`, `DEPLOY_ENV_FILE`
@@ -42,9 +42,9 @@
 - [ ] 스모크 테스트 담당자/기기(Android/iOS/웹) 배정
 
 ## 5. 배포 절차
-1. `develop`에 변경 머지
+1. `develop` 변경을 `staging`에 머지
 2. GitHub Actions 배포 워크플로 실행
-   - 운영 반영: `develop` push 트리거
+   - 운영 반영: `staging` push 트리거
    - 리허설/선검증: `Deploy Staging` workflow_dispatch (`enable_awslogs=false` 권장)
    - 자동화 경로: `.\scripts\staging-rehearsal.ps1` 실행 시 preflight + workflow_dispatch + run 완료 대기 + 로그 기록을 일괄 수행
    - 최신 배포 상태 확인: `.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 120`

--- a/scripts/apply-branch-protection.ps1
+++ b/scripts/apply-branch-protection.ps1
@@ -1,0 +1,118 @@
+param(
+  [string]$Repo = "V4N1LLA/Eunhye_Hymn",
+  [string[]]$Branches = @("develop", "staging", "production"),
+  [int]$RequiredApprovals = 1,
+  [switch]$RequirePrGateCheck,
+  [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+
+function Test-CommandExists {
+  param([string]$Name)
+  return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Assert-PositiveInt {
+  param(
+    [string]$Name,
+    [int]$Value
+  )
+  if ($Value -lt 1) {
+    throw "$Name must be >= 1"
+  }
+}
+
+function ConvertTo-JsonFile {
+  param(
+    [Parameter(Mandatory = $true)]
+    [object]$InputObject
+  )
+  $path = [System.IO.Path]::GetTempFileName()
+  $InputObject | ConvertTo-Json -Depth 10 | Set-Content -Path $path -Encoding utf8
+  return $path
+}
+
+if (-not (Test-CommandExists "gh")) {
+  throw "gh CLI is required."
+}
+
+Assert-PositiveInt -Name "RequiredApprovals" -Value $RequiredApprovals
+
+gh auth status 1>$null 2>$null
+if ($LASTEXITCODE -ne 0) {
+  throw "gh auth status failed. Run 'gh auth login' first."
+}
+
+$contexts = @()
+if ($RequirePrGateCheck) {
+  $contexts += "PR Gate / gate"
+}
+
+foreach ($branch in $Branches) {
+  if ([string]::IsNullOrWhiteSpace($branch)) {
+    continue
+  }
+
+  $trimmedBranch = $branch.Trim()
+  if ([string]::IsNullOrWhiteSpace($trimmedBranch)) {
+    continue
+  }
+
+  $branchInfo = gh api "repos/$Repo/branches/$trimmedBranch" 2>$null
+  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($branchInfo)) {
+    throw "Branch not found or inaccessible: $trimmedBranch"
+  }
+
+  $payload = @{
+    required_status_checks           = $(if ($RequirePrGateCheck) {
+      @{
+        strict   = $true
+        contexts = $contexts
+      }
+    } else {
+      $null
+    })
+    enforce_admins                   = $true
+    required_pull_request_reviews    = @{
+      dismiss_stale_reviews           = $true
+      require_code_owner_reviews      = $false
+      required_approving_review_count = $RequiredApprovals
+      require_last_push_approval      = $false
+    }
+    restrictions                     = $null
+    required_linear_history          = $true
+    allow_force_pushes               = $false
+    allow_deletions                  = $false
+    block_creations                  = $false
+    required_conversation_resolution = $true
+    lock_branch                      = $false
+    allow_fork_syncing               = $true
+  }
+
+  if ($DryRun) {
+    Write-Host "== DryRun: $trimmedBranch =="
+    $payload | ConvertTo-Json -Depth 10
+    Write-Host ""
+    continue
+  }
+
+  $jsonPath = ConvertTo-JsonFile -InputObject $payload
+  try {
+    gh api `
+      --method PUT `
+      -H "Accept: application/vnd.github+json" `
+      "repos/$Repo/branches/$trimmedBranch/protection" `
+      --input $jsonPath 1>$null
+
+    if ($LASTEXITCODE -ne 0) {
+      throw "Failed to apply branch protection: $trimmedBranch"
+    }
+  } finally {
+    Remove-Item $jsonPath -Force -ErrorAction SilentlyContinue
+  }
+
+  Write-Host "Applied branch protection: $trimmedBranch"
+}
+
+Write-Host "Done."

--- a/scripts/new-worktree-task.ps1
+++ b/scripts/new-worktree-task.ps1
@@ -1,0 +1,72 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$TaskName,
+  [string]$BaseBranch = "develop",
+  [string]$BranchPrefix = "feat",
+  [string]$Remote = "origin",
+  [string]$WorktreesDir = "..\\worktrees"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Test-CommandExists {
+  param([string]$Name)
+  return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function New-Slug {
+  param([string]$Value)
+  $slug = $Value.ToLowerInvariant()
+  $slug = $slug -replace "[^a-z0-9]+", "-"
+  $slug = $slug.Trim("-")
+  if ([string]::IsNullOrWhiteSpace($slug)) {
+    throw "TaskName produced an empty slug. Use letters/numbers in TaskName."
+  }
+  return $slug
+}
+
+if (-not (Test-CommandExists "git")) {
+  throw "git CLI is required."
+}
+
+$slug = New-Slug -Value $TaskName
+$branchName = "$BranchPrefix/$slug"
+$startPoint = "$Remote/$BaseBranch"
+
+git fetch $Remote $BaseBranch
+if ($LASTEXITCODE -ne 0) {
+  throw "git fetch failed: $Remote $BaseBranch"
+}
+
+$localBranch = git branch --list $branchName
+if ($LASTEXITCODE -ne 0) {
+  throw "git branch check failed."
+}
+if (-not [string]::IsNullOrWhiteSpace($localBranch)) {
+  throw "Local branch already exists: $branchName"
+}
+
+if (-not (Test-Path $WorktreesDir)) {
+  New-Item -ItemType Directory -Path $WorktreesDir | Out-Null
+}
+
+$worktreePath = Join-Path $WorktreesDir $branchName.Replace("/", "-")
+if (Test-Path $worktreePath) {
+  throw "Worktree path already exists: $worktreePath"
+}
+
+git worktree add $worktreePath -b $branchName $startPoint
+if ($LASTEXITCODE -ne 0) {
+  throw "git worktree add failed."
+}
+
+Write-Host "Created worktree."
+Write-Host ("Branch:   {0}" -f $branchName)
+Write-Host ("Path:     {0}" -f (Resolve-Path $worktreePath))
+Write-Host ("Base:     {0}" -f $startPoint)
+Write-Host ""
+Write-Host "Next:"
+Write-Host ("1) cd `"{0}`"" -f (Resolve-Path $worktreePath))
+Write-Host "2) implement changes"
+Write-Host "3) git add -A && git commit"
+Write-Host ("4) git push -u {0} {1}" -f $Remote, $branchName)

--- a/scripts/release-preflight.ps1
+++ b/scripts/release-preflight.ps1
@@ -1,0 +1,274 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$Version,
+  [string]$Repo = "V4N1LLA/Eunhye_Hymn",
+  [string]$Branch = "staging",
+  [int]$MaxStagingAgeMinutes = 1440,
+  [switch]$AsJson
+)
+
+$ErrorActionPreference = "Stop"
+
+$checks = @()
+
+function Add-Check {
+  param(
+    [string]$Name,
+    [bool]$Passed,
+    [string]$Detail
+  )
+
+  $script:checks += [PSCustomObject]@{
+    Name   = $Name
+    Passed = $Passed
+    Detail = $Detail
+  }
+}
+
+function Test-CommandExists {
+  param([string]$Name)
+  return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Invoke-GhJson {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$Args
+  )
+
+  $raw = & gh @Args 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    $detail = ($raw -join "`n").Trim()
+    if ([string]::IsNullOrWhiteSpace($detail)) {
+      $detail = "gh command failed"
+    }
+    throw "$detail"
+  }
+
+  if ([string]::IsNullOrWhiteSpace($raw)) {
+    return $null
+  }
+
+  return (($raw -join "`n") | ConvertFrom-Json)
+}
+
+function Invoke-PowerShellFile {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$PowerShellCommand,
+    [Parameter(Mandatory = $true)]
+    [string]$ScriptPath,
+    [string[]]$Arguments = @()
+  )
+
+  $previousErrorAction = $ErrorActionPreference
+  $ErrorActionPreference = "Continue"
+  try {
+    $output = & $PowerShellCommand -NoProfile -File $ScriptPath @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+  } finally {
+    $ErrorActionPreference = $previousErrorAction
+  }
+
+  return [PSCustomObject]@{
+    ExitCode = $exitCode
+    Output = (($output -join "`n") -replace "`e\[[\d;]*[A-Za-z]", "").Trim()
+  }
+}
+
+function Get-FirstUsefulLine {
+  param([string]$Text)
+
+  if ([string]::IsNullOrWhiteSpace($Text)) {
+    return ""
+  }
+
+  $lines = $Text -split "`r?`n" | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  if ($null -eq $lines -or $lines.Count -eq 0) {
+    return ""
+  }
+
+  foreach ($line in $lines) {
+    if ($line -eq "System.Management.Automation.RemoteException") { continue }
+    if ($line -like "At line:*") { continue }
+    if ($line -like "+ CategoryInfo:*") { continue }
+    if ($line -like "+ FullyQualifiedErrorId:*") { continue }
+    return $line
+  }
+
+  return $lines[0]
+}
+
+function Get-LatestRunForWorkflowSha {
+  param(
+    [string]$Repository,
+    [string]$WorkflowName,
+    [string]$TargetBranch,
+    [string]$HeadSha
+  )
+
+  $runs = Invoke-GhJson -Args @(
+    "run", "list",
+    "--repo", $Repository,
+    "--workflow", $WorkflowName,
+    "--branch", $TargetBranch,
+    "--limit", "50",
+    "--json", "databaseId,workflowName,headSha,status,conclusion,url,createdAt"
+  )
+
+  if ($null -eq $runs -or $runs.Count -eq 0) {
+    return $null
+  }
+
+  return $runs |
+    Where-Object { $_.headSha -eq $HeadSha -and $_.status -eq "completed" -and $_.conclusion -eq "success" } |
+    Sort-Object { [DateTime]$_.createdAt } -Descending |
+    Select-Object -First 1
+}
+
+$tag = "v$Version"
+$semverPattern = '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'
+
+Add-Check "gh cli" (Test-CommandExists "gh") "required"
+if (-not (Test-CommandExists "gh")) {
+  $checks | Format-Table -AutoSize
+  exit 1
+}
+
+gh auth status 1>$null 2>$null
+$ghAuthPassed = ($LASTEXITCODE -eq 0)
+if (-not $ghAuthPassed -and -not [string]::IsNullOrWhiteSpace($env:GH_TOKEN)) {
+  # CI can authenticate gh via GH_TOKEN env without a persisted login session.
+  $ghAuthPassed = $true
+}
+Add-Check "gh auth status" $ghAuthPassed "required"
+
+$isSemVer = ($Version -match $semverPattern)
+Add-Check "semver format" $isSemVer ($(if ($isSemVer) { "ok ($Version)" } else { "invalid: use MAJOR.MINOR.PATCH" }))
+
+if ($isSemVer) {
+  try {
+    $tagMatchCount = Invoke-GhJson -Args @("api", "repos/$Repo/git/matching-refs/tags/$tag", "--jq", "length")
+    $tagExists = [int]$tagMatchCount -gt 0
+    Add-Check "tag availability" (-not $tagExists) ($(if ($tagExists) { "$tag already exists" } else { "available ($tag)" }))
+  } catch {
+    Add-Check "tag availability" $false ("failed: " + $_.Exception.Message)
+  }
+} else {
+  Add-Check "tag availability" $false "skipped (invalid semver)"
+}
+
+$stagingSummary = $null
+$deployHeadSha = ""
+$statusScript = Join-Path $PSScriptRoot "staging-latest-status.ps1"
+$powershellCmd = if (Test-CommandExists "powershell.exe") {
+  "powershell.exe"
+} elseif (Test-CommandExists "pwsh") {
+  "pwsh"
+} else {
+  ""
+}
+
+if (-not (Test-Path $statusScript)) {
+  Add-Check "staging deploy gate" $false "missing script: $statusScript"
+} elseif ([string]::IsNullOrWhiteSpace($powershellCmd)) {
+  Add-Check "staging deploy gate" $false "missing powershell command (powershell.exe/pwsh)"
+} else {
+  $statusResult = Invoke-PowerShellFile `
+    -PowerShellCommand $powershellCmd `
+    -ScriptPath $statusScript `
+    -Arguments @(
+      "-Repo", $Repo,
+      "-Branch", $Branch,
+      "-Limit", "20",
+      "-PreferCompleted",
+      "-RequireSuccess",
+      "-RequireDeploySuccess",
+      "-RequireVerifySuccess",
+      "-MaxAgeMinutes", "$MaxStagingAgeMinutes",
+      "-AsJson"
+    )
+
+  if ($statusResult.ExitCode -ne 0) {
+    $tail = Get-FirstUsefulLine -Text $statusResult.Output
+    if ([string]::IsNullOrWhiteSpace($tail)) {
+      $tail = "staging status command failed"
+    }
+    Add-Check "staging deploy gate" $false $tail
+  } else {
+    try {
+      $statusJson = ($statusResult.Output | ConvertFrom-Json)
+      $stagingSummary = $statusJson.summary
+      $deployHeadSha = "$($stagingSummary.HeadSha)"
+      Add-Check "staging deploy gate" $true ("run_id={0}, age_min={1}, sha={2}" -f $stagingSummary.RunId, $stagingSummary.RunAgeMinutes, $deployHeadSha)
+    } catch {
+      Add-Check "staging deploy gate" $false "failed: invalid JSON output"
+    }
+  }
+}
+
+$requiredWorkflows = @(
+  "API CI",
+  "Admin CI",
+  "Mobile CI",
+  "Mobile Release Check"
+)
+
+if ([string]::IsNullOrWhiteSpace($deployHeadSha)) {
+  foreach ($workflow in $requiredWorkflows) {
+    Add-Check ("workflow " + $workflow) $false "skipped (staging sha unavailable)"
+  }
+} else {
+  foreach ($workflow in $requiredWorkflows) {
+    try {
+      $run = Get-LatestRunForWorkflowSha -Repository $Repo -WorkflowName $workflow -TargetBranch $Branch -HeadSha $deployHeadSha
+      if ($null -eq $run) {
+        Add-Check ("workflow " + $workflow) $false ("no success run for sha " + $deployHeadSha)
+      } else {
+        Add-Check ("workflow " + $workflow) $true ("run_id={0}" -f $run.databaseId)
+      }
+    } catch {
+      Add-Check ("workflow " + $workflow) $false ("failed: " + $_.Exception.Message)
+    }
+  }
+}
+
+$failed = @($checks | Where-Object { -not $_.Passed })
+$ready = ($failed.Count -eq 0)
+
+$result = [PSCustomObject]@{
+  Version = $Version
+  Tag = $tag
+  Repo = $Repo
+  Branch = $Branch
+  Ready = $ready
+  StagingRunId = $(if ($null -eq $stagingSummary) { "" } else { "$($stagingSummary.RunId)" })
+  StagingHeadSha = $deployHeadSha
+  StagingUrl = $(if ($null -eq $stagingSummary) { "" } else { "$($stagingSummary.Url)" })
+  Checks = $checks
+}
+
+if ($AsJson) {
+  $result | ConvertTo-Json -Depth 6
+} else {
+  Write-Host "== Release Preflight =="
+  Write-Host ("Version: {0}" -f $Version)
+  Write-Host ("Tag:     {0}" -f $tag)
+  Write-Host ("Repo:    {0}" -f $Repo)
+  Write-Host ("Branch:  {0}" -f $Branch)
+  Write-Host ""
+  $checks | Format-Table -AutoSize
+  Write-Host ""
+  if ($ready) {
+    Write-Host "Decision: READY"
+    Write-Host ("Next: git tag -a {0} -m ""Release {0}"" && git push origin {0}" -f $tag)
+  } else {
+    Write-Host "Decision: HOLD"
+  }
+}
+
+if ($ready) {
+  exit 0
+}
+
+exit 1

--- a/scripts/release-preflight.ps1
+++ b/scripts/release-preflight.ps1
@@ -121,7 +121,7 @@ function Get-LatestRunForWorkflowSha {
   }
 
   return $runs |
-    Where-Object { $_.headSha -eq $HeadSha -and $_.status -eq "completed" -and $_.conclusion -eq "success" } |
+    Where-Object { $_.headSha -eq $HeadSha } |
     Sort-Object { [DateTime]$_.createdAt } -Descending |
     Select-Object -First 1
 }
@@ -223,7 +223,11 @@ if ([string]::IsNullOrWhiteSpace($deployHeadSha)) {
     try {
       $run = Get-LatestRunForWorkflowSha -Repository $Repo -WorkflowName $workflow -TargetBranch $Branch -HeadSha $deployHeadSha
       if ($null -eq $run) {
-        Add-Check ("workflow " + $workflow) $false ("no success run for sha " + $deployHeadSha)
+        Add-Check ("workflow " + $workflow) $true ("no run for sha {0} (likely path-filtered)" -f $deployHeadSha)
+      } elseif ($run.status -ne "completed") {
+        Add-Check ("workflow " + $workflow) $false ("run_id={0}, status={1}" -f $run.databaseId, $run.status)
+      } elseif ($run.conclusion -ne "success") {
+        Add-Check ("workflow " + $workflow) $false ("run_id={0}, conclusion={1}" -f $run.databaseId, $run.conclusion)
       } else {
         Add-Check ("workflow " + $workflow) $true ("run_id={0}" -f $run.databaseId)
       }

--- a/scripts/staging-latest-status.ps1
+++ b/scripts/staging-latest-status.ps1
@@ -1,7 +1,7 @@
 param(
   [string]$Repo = "V4N1LLA/Eunhye_Hymn",
   [string]$Workflow = "deploy-staging.yml",
-  [string]$Branch = "develop",
+  [string]$Branch = "staging",
   [string]$Event = "",
   [int]$Limit = 1,
   [switch]$Wait,

--- a/scripts/staging-ops-cycle.ps1
+++ b/scripts/staging-ops-cycle.ps1
@@ -1,6 +1,6 @@
 param(
   [string]$Repo = "V4N1LLA/Eunhye_Hymn",
-  [string]$Branch = "develop",
+  [string]$Branch = "staging",
   [int]$MaxAgeMinutes = 120,
   [string]$AwsProfile = "",
   [switch]$AutoLogin,

--- a/scripts/staging-rehearsal.ps1
+++ b/scripts/staging-rehearsal.ps1
@@ -1,6 +1,6 @@
 param(
   [string]$Repo = "V4N1LLA/Eunhye_Hymn",
-  [string]$Ref = "develop",
+  [string]$Ref = "staging",
   [string]$Workflow = "deploy-staging.yml",
   [string]$AwsProfile = "",
   [switch]$AutoLogin,


### PR DESCRIPTION
## Summary
- standardize CI triggers for `develop`/`staging`/`production` across API/Admin/Mobile workflows
- add `PR Gate` workflow for monorepo path-based checks with a single required status (`PR Gate / gate`)
- add release automation via `Release Readiness` (manual preflight) and `Release On Tag` (tag-driven GitHub Release)
- switch staging operational scripts/workflow defaults to `staging` branch
- add team docs for SemVer release process, monorepo CI/CD policy, and parallel terminal + PR workflow

## Why
- keep all integration/release work PR-driven while supporting your branch model (`develop` -> `staging` -> `production`)
- reduce CI time in monorepo by running checks only for changed areas
- make release gating repeatable before tagging production versions

## Scope
- [x] Infra/DevOps (`.github/workflows`, `scripts`)
- [x] Docs
- [ ] API
- [ ] Admin
- [ ] Mobile

## Verification
- PowerShell parser syntax check run for staging/release/branch-protection/worktree scripts
- `scripts/release-preflight.ps1` validated previously for both default staging HOLD path and develop branch check path

## Notes
- branch protection can be applied after merge with:
  - `./scripts/apply-branch-protection.ps1 -Repo V4N1LLA/Eunhye_Hymn -RequirePrGateCheck`