### PR TITLE
feat(auth): sync invite-gated flow and account withdraw endpoint

### DIFF
--- a/apps/api/src/main/java/com/eunhyehymn/application/usecases/UserPasswordSignupUseCase.java
+++ b/apps/api/src/main/java/com/eunhyehymn/application/usecases/UserPasswordSignupUseCase.java
@@ -24,6 +24,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserPasswordSignupUseCase {
     static final String PROVIDER_LOCAL_USER = "LOCAL_USER";
     private static final Pattern LOGIN_ID_PATTERN = Pattern.compile("^[a-z0-9._-]{3,100}$");
+    private static final Pattern EMAIL_LOGIN_ID_PATTERN =
+        Pattern.compile("^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$");
+    private static final int MIN_LOGIN_ID_LENGTH = 3;
+    private static final int MAX_LOGIN_ID_LENGTH = 100;
     private static final int MIN_PASSWORD_LENGTH = 8;
 
     private final AuthIdentityRepository authIdentityRepository;
@@ -122,8 +126,14 @@ public class UserPasswordSignupUseCase {
     }
 
     private void validateCredentialFormat(String loginId, String password) {
-        if (!LOGIN_ID_PATTERN.matcher(loginId).matches()) {
-            throw new InvalidCredentialFormatException("로그인 ID는 영문/숫자/._- 조합 3-100자여야 합니다.");
+        if (loginId == null
+            || loginId.length() < MIN_LOGIN_ID_LENGTH
+            || loginId.length() > MAX_LOGIN_ID_LENGTH
+            || (!LOGIN_ID_PATTERN.matcher(loginId).matches()
+            && !EMAIL_LOGIN_ID_PATTERN.matcher(loginId).matches())) {
+            throw new InvalidCredentialFormatException(
+                "로그인 ID는 영문/숫자/._- 조합 또는 이메일 형식 3-100자여야 합니다."
+            );
         }
         if (password == null || password.length() < MIN_PASSWORD_LENGTH) {
             throw new InvalidCredentialFormatException("비밀번호는 최소 8자 이상이어야 합니다.");

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AuthController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/AuthController.java
@@ -119,12 +119,12 @@ public class AuthController {
         } catch (SocialLoginException e) {
             authRateLimitService.recordOutcome("social_login", false);
             throw new ApiException(HttpStatus.UNAUTHORIZED, "social_auth_failed", e.getMessage(), null);
-        } catch (SocialLoginUseCase.AdminOnlyException e) {
-            authRateLimitService.recordOutcome("social_login", false);
-            throw new ApiException(HttpStatus.FORBIDDEN, "admin_only", e.getMessage(), null);
         } catch (SocialLoginUseCase.AccountDisabledException e) {
             authRateLimitService.recordOutcome("social_login", false);
             throw new ApiException(HttpStatus.FORBIDDEN, "account_disabled", e.getMessage(), null);
+        } catch (SocialLoginUseCase.AdminOnlyException e) {
+            authRateLimitService.recordOutcome("social_login", false);
+            throw new ApiException(HttpStatus.FORBIDDEN, "admin_only", e.getMessage(), null);
         }
     }
 

--- a/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/MeController.java
+++ b/apps/api/src/main/java/com/eunhyehymn/presentation/controllers/MeController.java
@@ -9,6 +9,7 @@ import com.eunhyehymn.application.usecases.RequestMyProfileChangeUseCase;
 import com.eunhyehymn.application.usecases.SaveHymnNoteUseCase;
 import com.eunhyehymn.application.usecases.ToggleFavoriteUseCase;
 import com.eunhyehymn.application.usecases.UpsertMyProfileUseCase;
+import com.eunhyehymn.application.usecases.WithdrawAccountUseCase;
 import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.common.response.ApiResponse;
 import com.eunhyehymn.domain.model.ProfileChangeRequest;
@@ -19,6 +20,7 @@ import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,6 +42,7 @@ public class MeController {
     private final UpsertMyProfileUseCase upsertMyProfileUseCase;
     private final RequestMyProfileChangeUseCase requestMyProfileChangeUseCase;
     private final GetLatestMyProfileChangeRequestUseCase getLatestMyProfileChangeRequestUseCase;
+    private final WithdrawAccountUseCase withdrawAccountUseCase;
     private final UserVerificationRepository userVerificationRepository;
 
     public MeController(
@@ -52,6 +55,7 @@ public class MeController {
         UpsertMyProfileUseCase upsertMyProfileUseCase,
         RequestMyProfileChangeUseCase requestMyProfileChangeUseCase,
         GetLatestMyProfileChangeRequestUseCase getLatestMyProfileChangeRequestUseCase,
+        WithdrawAccountUseCase withdrawAccountUseCase,
         UserVerificationRepository userVerificationRepository
     ) {
         this.toggleFavoriteUseCase = toggleFavoriteUseCase;
@@ -63,6 +67,7 @@ public class MeController {
         this.upsertMyProfileUseCase = upsertMyProfileUseCase;
         this.requestMyProfileChangeUseCase = requestMyProfileChangeUseCase;
         this.getLatestMyProfileChangeRequestUseCase = getLatestMyProfileChangeRequestUseCase;
+        this.withdrawAccountUseCase = withdrawAccountUseCase;
         this.userVerificationRepository = userVerificationRepository;
     }
 
@@ -120,6 +125,13 @@ public class MeController {
         UUID userId = parseUserId(authentication);
         boolean favorite = toggleFavoriteUseCase.toggle(userId, hymnId).favorite();
         return ApiResponse.success(new FavoriteResponse(favorite));
+    }
+
+    @DeleteMapping("/account")
+    public ApiResponse<Void> withdraw(Authentication authentication) {
+        UUID userId = parseUserId(authentication);
+        withdrawAccountUseCase.withdraw(userId);
+        return ApiResponse.success(null);
     }
 
     @GetMapping("/favorites/{hymnId}")

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/MeProfileApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/MeProfileApiTest.java
@@ -1,5 +1,7 @@
 package com.eunhyehymn.presentation.controllers;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -12,6 +14,7 @@ import com.eunhyehymn.infrastructure.persistence.EventJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.HymnJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.HymnNoteJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.InviteCodeJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.RefreshTokenEntity;
 import com.eunhyehymn.infrastructure.persistence.RefreshTokenJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.UserEntity;
 import com.eunhyehymn.infrastructure.persistence.UserHymnStateJpaRepository;
@@ -112,5 +115,34 @@ class MeProfileApiTest {
             .andExpect(jsonPath("$.data.churchName").value("은혜교회"))
             .andExpect(jsonPath("$.data.name").value("홍길동"))
             .andExpect(jsonPath("$.data.group").value("청년A"));
+    }
+
+    @Test
+    void withdrawDisablesAccountAndRevokesRefreshTokens() throws Exception {
+        UUID refreshTokenId = UUID.randomUUID();
+        refreshTokenJpaRepository.save(new RefreshTokenEntity(
+            refreshTokenId,
+            userId,
+            "hash-1",
+            Instant.now().plusSeconds(3600),
+            null,
+            Instant.now()
+        ));
+
+        mockMvc.perform(delete("/me/account")
+                .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true));
+
+        UserEntity withdrawn = userJpaRepository.findById(userId).orElseThrow();
+        assertThat(withdrawn.getStatus()).isEqualTo(UserStatus.DISABLED);
+
+        RefreshTokenEntity token = refreshTokenJpaRepository.findById(refreshTokenId).orElseThrow();
+        assertThat(token.getRevokedAt()).isNotNull();
+
+        mockMvc.perform(get("/me/profile")
+                .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.error.code").value("unauthorized"));
     }
 }

--- a/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/UserPasswordAuthApiTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/presentation/controllers/UserPasswordAuthApiTest.java
@@ -15,9 +15,11 @@ import com.eunhyehymn.infrastructure.persistence.HymnNoteJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.InviteCodeEntity;
 import com.eunhyehymn.infrastructure.persistence.InviteCodeJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.RefreshTokenJpaRepository;
+import com.eunhyehymn.infrastructure.persistence.UserEntity;
 import com.eunhyehymn.infrastructure.persistence.UserHymnStateJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.UserJpaRepository;
 import com.eunhyehymn.infrastructure.persistence.UserPasswordCredentialJpaRepository;
+import com.eunhyehymn.domain.model.UserStatus;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
@@ -86,6 +88,22 @@ class UserPasswordAuthApiTest {
         assertThat(identity.getProvider()).isEqualTo("LOCAL_USER");
         assertThat(identity.getProviderSubject()).isEqualTo("member.one");
         assertThat(inviteCodeJpaRepository.findById("SIGNUP-CODE").orElseThrow().getUsedCount()).isEqualTo(1);
+    }
+
+    @Test
+    void signupAcceptsEmailLoginId() throws Exception {
+        inviteCodeJpaRepository.save(new InviteCodeEntity(
+            "EMAIL-CODE", null, "email", null, 0, true, null, Instant.now()
+        ));
+
+        String response = signup("qa.user+1@example.com", "password-123!", "email-code");
+        JsonNode data = objectMapper.readTree(response).path("data");
+        String accessToken = data.path("accessToken").asText();
+
+        mockMvc.perform(get("/me/profile")
+                .header("Authorization", "Bearer " + accessToken))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.displayName").value("qa.user+1@example.com"));
     }
 
     @Test
@@ -160,6 +178,33 @@ class UserPasswordAuthApiTest {
                 ))))
             .andExpect(status().isUnauthorized())
             .andExpect(jsonPath("$.error.code").value("user_login_failed"));
+    }
+
+    @Test
+    void loginFailsWhenAccountIsDisabled() throws Exception {
+        inviteCodeJpaRepository.save(new InviteCodeEntity(
+            "DISABLED-CODE", null, "disabled", null, 0, true, null, Instant.now()
+        ));
+        signup("member.disabled", "password-123!", "disabled-code");
+
+        UserEntity existing = userJpaRepository.findAll().get(0);
+        userJpaRepository.save(new UserEntity(
+            existing.getId(),
+            existing.getDisplayName(),
+            existing.getRole(),
+            UserStatus.DISABLED,
+            existing.getCreatedAt(),
+            existing.getLastLoginAt()
+        ));
+
+        mockMvc.perform(post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of(
+                    "loginId", "member.disabled",
+                    "password", "password-123!"
+                ))))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.error.code").value("account_disabled"));
     }
 
     private String signup(String loginId, String password, String inviteCode) throws Exception {

--- a/apps/mobile/lib/src/features/auth/auth_repository.dart
+++ b/apps/mobile/lib/src/features/auth/auth_repository.dart
@@ -286,6 +286,14 @@ class AuthRepository {
     await tokenStorage.clear();
   }
 
+  Future<void> withdraw() async {
+    try {
+      await apiClient.delete('/me/account');
+    } finally {
+      await tokenStorage.clear();
+    }
+  }
+
   Future<void> clearSession() {
     return tokenStorage.clear();
   }

--- a/apps/mobile/lib/src/features/auth/email_login_page.dart
+++ b/apps/mobile/lib/src/features/auth/email_login_page.dart
@@ -2,58 +2,41 @@ import 'package:flutter/material.dart';
 
 import '../../core/network/api_exception.dart';
 import 'auth_repository.dart';
-import 'invite_gate_page.dart';
+import 'sign_up_page.dart';
 
-class SignUpPage extends StatefulWidget {
+class EmailLoginPage extends StatefulWidget {
   final AuthRepository authRepository;
 
-  const SignUpPage({
+  const EmailLoginPage({
     super.key,
     required this.authRepository,
   });
 
   @override
-  State<SignUpPage> createState() => _SignUpPageState();
+  State<EmailLoginPage> createState() => _EmailLoginPageState();
 }
 
-class _SignUpPageState extends State<SignUpPage> {
+class _EmailLoginPageState extends State<EmailLoginPage> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
-  final _confirmPasswordController = TextEditingController();
 
-  String? _error;
   bool _submitting = false;
+  String? _error;
 
   @override
   void dispose() {
     _emailController.dispose();
     _passwordController.dispose();
-    _confirmPasswordController.dispose();
     super.dispose();
   }
 
-  Future<void> _handleSubmit() async {
+  Future<void> _handleLogin() async {
     final email = _emailController.text.trim();
     final password = _passwordController.text;
-    final confirm = _confirmPasswordController.text;
 
-    if (email.isEmpty || password.isEmpty || confirm.isEmpty) {
+    if (email.isEmpty || password.isEmpty) {
       setState(() {
-        _error = '이메일, 비밀번호를 모두 입력해 주세요.';
-      });
-      return;
-    }
-
-    if (password.length < 8) {
-      setState(() {
-        _error = '비밀번호는 최소 8자 이상이어야 합니다.';
-      });
-      return;
-    }
-
-    if (password != confirm) {
-      setState(() {
-        _error = '비밀번호가 일치하지 않습니다.';
+        _error = '이메일과 비밀번호를 모두 입력해 주세요.';
       });
       return;
     }
@@ -64,28 +47,13 @@ class _SignUpPageState extends State<SignUpPage> {
     });
 
     try {
-      final profile = await Navigator.of(context).push<SessionProfile>(
-        MaterialPageRoute<SessionProfile>(
-          builder: (_) => InviteGatePage(
-            title: '초대 코드 입력',
-            description: '회원가입을 완료하려면 초대 코드를 입력해 주세요.',
-            submitLabel: '코드 확인 후 회원가입',
-            onSubmit: (inviteCode) {
-              return widget.authRepository.signupWithAccount(
-                loginId: email,
-                password: password,
-                inviteCode: inviteCode,
-              );
-            },
-            onWithdraw: () => widget.authRepository.withdraw(),
-          ),
-        ),
+      final profile = await widget.authRepository.loginWithAccount(
+        loginId: email,
+        password: password,
       );
-
-      if (!mounted || profile == null) {
+      if (!mounted) {
         return;
       }
-
       Navigator.of(context).pop(profile);
     } on ApiException catch (e) {
       if (!mounted) {
@@ -99,7 +67,7 @@ class _SignUpPageState extends State<SignUpPage> {
         return;
       }
       setState(() {
-        _error = '회원가입 처리 중 오류가 발생했습니다. 다시 시도해 주세요.';
+        _error = '로그인 처리 중 문제가 발생했습니다. 다시 시도해 주세요.';
       });
     } finally {
       if (mounted) {
@@ -110,11 +78,31 @@ class _SignUpPageState extends State<SignUpPage> {
     }
   }
 
+  Future<void> _openSignUpPage() async {
+    if (_submitting) {
+      return;
+    }
+
+    final profile = await Navigator.of(context).push<SessionProfile>(
+      MaterialPageRoute<SessionProfile>(
+        builder: (_) => SignUpPage(
+          authRepository: widget.authRepository,
+        ),
+      ),
+    );
+
+    if (!mounted || profile == null) {
+      return;
+    }
+
+    Navigator.of(context).pop(profile);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('회원가입')),
       backgroundColor: const Color(0xFFF6F7F9),
+      appBar: AppBar(title: const Text('이메일 로그인')),
       body: SafeArea(
         child: Center(
           child: SingleChildScrollView(
@@ -128,7 +116,7 @@ class _SignUpPageState extends State<SignUpPage> {
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                       const Text(
-                        '회원가입',
+                        '이메일 로그인',
                         style: TextStyle(
                           fontSize: 18,
                           fontWeight: FontWeight.w700,
@@ -136,7 +124,7 @@ class _SignUpPageState extends State<SignUpPage> {
                       ),
                       const SizedBox(height: 6),
                       const Text(
-                        '이메일과 비밀번호를 입력하면 다음 단계에서 초대 코드를 확인합니다.',
+                        '이메일과 비밀번호를 입력해 로그인해 주세요.',
                         style: TextStyle(color: Color(0xFF5B6572)),
                       ),
                       const SizedBox(height: 16),
@@ -160,16 +148,6 @@ class _SignUpPageState extends State<SignUpPage> {
                           border: OutlineInputBorder(),
                         ),
                       ),
-                      const SizedBox(height: 12),
-                      TextField(
-                        controller: _confirmPasswordController,
-                        enabled: !_submitting,
-                        obscureText: true,
-                        decoration: const InputDecoration(
-                          labelText: '비밀번호 확인',
-                          border: OutlineInputBorder(),
-                        ),
-                      ),
                       if (_error != null) ...[
                         const SizedBox(height: 10),
                         Text(
@@ -184,8 +162,16 @@ class _SignUpPageState extends State<SignUpPage> {
                       SizedBox(
                         height: 52,
                         child: FilledButton(
-                          onPressed: _submitting ? null : _handleSubmit,
-                          child: Text(_submitting ? '처리 중...' : '다음'),
+                          onPressed: _submitting ? null : _handleLogin,
+                          child: Text(_submitting ? '처리 중...' : '로그인'),
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      SizedBox(
+                        height: 48,
+                        child: OutlinedButton(
+                          onPressed: _submitting ? null : _openSignUpPage,
+                          child: const Text('회원가입'),
                         ),
                       ),
                     ],

--- a/apps/mobile/lib/src/features/auth/invite_gate_page.dart
+++ b/apps/mobile/lib/src/features/auth/invite_gate_page.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/material.dart';
+
+import '../../core/network/api_exception.dart';
+import 'auth_repository.dart';
+
+typedef InviteCodeSubmit = Future<SessionProfile> Function(String inviteCode);
+
+class InviteGatePage extends StatefulWidget {
+  final String title;
+  final String description;
+  final String submitLabel;
+  final InviteCodeSubmit onSubmit;
+  final Future<void> Function()? onWithdraw;
+
+  const InviteGatePage({
+    super.key,
+    required this.title,
+    required this.description,
+    required this.submitLabel,
+    required this.onSubmit,
+    this.onWithdraw,
+  });
+
+  @override
+  State<InviteGatePage> createState() => _InviteGatePageState();
+}
+
+class _InviteGatePageState extends State<InviteGatePage> {
+  final _inviteCodeController = TextEditingController();
+
+  bool _submitting = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _inviteCodeController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleSubmit() async {
+    final inviteCode = _inviteCodeController.text.trim().toUpperCase();
+    if (inviteCode.isEmpty) {
+      setState(() {
+        _error = '초대 코드를 입력해 주세요.';
+      });
+      return;
+    }
+
+    setState(() {
+      _submitting = true;
+      _error = null;
+    });
+
+    try {
+      final profile = await widget.onSubmit(inviteCode);
+      if (!mounted) {
+        return;
+      }
+      Navigator.of(context).pop(profile);
+    } on ApiException catch (e) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = e.message;
+      });
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = '초대 코드 확인 중 문제가 발생했습니다. 다시 시도해 주세요.';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _submitting = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _handleWithdraw() async {
+    if (widget.onWithdraw == null || _submitting) {
+      return;
+    }
+
+    final confirmed = await showDialog<bool>(
+          context: context,
+          builder: (_) => AlertDialog(
+            title: const Text('회원탈퇴'),
+            content: const Text('정말 회원탈퇴 하시겠어요?'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('취소'),
+              ),
+              FilledButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('탈퇴'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+
+    if (!confirmed) {
+      return;
+    }
+
+    setState(() {
+      _submitting = true;
+      _error = null;
+    });
+
+    try {
+      await widget.onWithdraw!.call();
+      if (!mounted) {
+        return;
+      }
+      Navigator.of(context).pop();
+    } on ApiException catch (e) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = e.message;
+      });
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = '회원탈퇴 처리 중 문제가 발생했습니다. 다시 시도해 주세요.';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _submitting = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF6F7F9),
+      appBar: AppBar(title: Text(widget.title)),
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(20),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 480),
+              child: Card(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 20, 16, 16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Text(
+                        widget.title,
+                        style: const TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        widget.description,
+                        style: const TextStyle(color: Color(0xFF5B6572)),
+                      ),
+                      const SizedBox(height: 14),
+                      TextField(
+                        controller: _inviteCodeController,
+                        enabled: !_submitting,
+                        textCapitalization: TextCapitalization.characters,
+                        decoration: const InputDecoration(
+                          labelText: '초대 코드',
+                          hintText: '예: ABC123',
+                          border: OutlineInputBorder(),
+                        ),
+                      ),
+                      if (_error != null) ...[
+                        const SizedBox(height: 10),
+                        Text(
+                          _error!,
+                          style: const TextStyle(
+                            color: Color(0xFFC2291E),
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                      const SizedBox(height: 16),
+                      SizedBox(
+                        height: 52,
+                        child: FilledButton(
+                          onPressed: _submitting ? null : _handleSubmit,
+                          child: Text(
+                              _submitting ? '처리 중...' : widget.submitLabel),
+                        ),
+                      ),
+                      if (widget.onWithdraw != null) ...[
+                        const SizedBox(height: 8),
+                        Center(
+                          child: TextButton(
+                            onPressed: _submitting ? null : _handleWithdraw,
+                            style: TextButton.styleFrom(
+                              foregroundColor: const Color(0xFF6B7280),
+                              textStyle: const TextStyle(fontSize: 12),
+                            ),
+                            child: const Text('회원탈퇴'),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/lib/src/features/auth/login_page.dart
+++ b/apps/mobile/lib/src/features/auth/login_page.dart
@@ -65,10 +65,6 @@ class _LoginPageState extends State<LoginPage> {
     }
   }
 
-  Future<void> _handleWithdrawRequested() async {
-    await widget.authRepository.withdraw();
-  }
-
   Future<void> _openEmailLoginPage() async {
     if (_loading) {
       return;
@@ -133,7 +129,6 @@ class _LoginPageState extends State<LoginPage> {
                   inviteCode: inviteCode,
                 );
               },
-              onWithdraw: _handleWithdrawRequested,
             ),
           ),
         );

--- a/apps/mobile/lib/src/features/auth/login_page.dart
+++ b/apps/mobile/lib/src/features/auth/login_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import '../../core/config/app_config.dart';
 import '../../core/network/api_exception.dart';
 import 'auth_repository.dart';
+import 'email_login_page.dart';
+import 'invite_gate_page.dart';
 import 'social_sdk_service.dart';
 
 class LoginPage extends StatefulWidget {
@@ -15,8 +17,8 @@ class LoginPage extends StatefulWidget {
     super.key,
     required this.authRepository,
     required this.socialSdkService,
-    required this.onLoggedIn,
     this.initialError,
+    required this.onLoggedIn,
   });
 
   @override
@@ -24,242 +26,218 @@ class LoginPage extends StatefulWidget {
 }
 
 class _LoginPageState extends State<LoginPage> {
-  final _emailController = TextEditingController();
-  final _passwordController = TextEditingController();
-
-  bool _socialLoading = false;
-  bool _emailLoading = false;
+  bool _loading = false;
   String? _error;
 
-  bool get _loading => _socialLoading || _emailLoading;
+  bool get _hasKakaoKey => AppConfig.kakaoNativeAppKey.trim().isNotEmpty;
 
-  @override
-  void dispose() {
-    _emailController.dispose();
-    _passwordController.dispose();
-    super.dispose();
+  bool _requiresInviteCode(ApiException exception) {
+    return (exception.code ?? '').toLowerCase() == 'invalid_invite_code';
   }
 
-  Future<void> _handleKakaoLogin() async {
+  Future<void> _runWithLoading(Future<void> Function() action) async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      await action();
+    } on ApiException catch (e) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = e.message;
+      });
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _error = '작업 중 오류가 발생했습니다. 다시 시도해 주세요.';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _handleWithdrawRequested() async {
+    await widget.authRepository.withdraw();
+  }
+
+  Future<void> _openEmailLoginPage() async {
     if (_loading) {
       return;
     }
 
-    setState(() {
-      _socialLoading = true;
-      _error = null;
-    });
+    final profile = await Navigator.of(context).push<SessionProfile>(
+      MaterialPageRoute<SessionProfile>(
+        builder: (_) => EmailLoginPage(
+          authRepository: widget.authRepository,
+        ),
+      ),
+    );
 
-    try {
-      if (AppConfig.kakaoNativeAppKey.trim().isEmpty) {
+    if (!mounted || profile == null) {
+      return;
+    }
+
+    await _runWithLoading(() async {
+      await widget.onLoggedIn(profile);
+    });
+  }
+
+  Future<void> _handleKakaoLogin() async {
+    await _runWithLoading(() async {
+      if (!_hasKakaoKey) {
         throw ApiException(
-          '카카오 로그인 설정이 비어 있어요. 잠시 후 다시 시도해 주세요.',
+          'KAKAO_NATIVE_APP_KEY가 비어 있습니다. 앱 실행 시 '
+          '--dart-define=KAKAO_NATIVE_APP_KEY=... 로 키를 전달해야 합니다.',
         );
       }
 
       final token = await widget.socialSdkService.fetchToken().timeout(
             const Duration(seconds: 45),
-            onTimeout: () => throw ApiException('로그인 시간이 초과됐어요. 다시 시도해 주세요.'),
+            onTimeout: () => throw ApiException(
+              '카카오 로그인 응답이 지연되고 있습니다. 다시 시도해 주세요.',
+            ),
           );
-      final profile = await widget.authRepository.loginWithKakao(token: token);
-      await widget.onLoggedIn(profile);
-    } on ApiException catch (e) {
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _error = e.message;
-      });
-    } catch (_) {
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _error = '로그인에 실패했어요. 다시 시도해 주세요.';
-      });
-    } finally {
-      if (mounted) {
-        setState(() {
-          _socialLoading = false;
-        });
-      }
-    }
-  }
 
-  Future<void> _handleEmailLogin() async {
-    if (_loading) {
-      return;
-    }
+      try {
+        final profile = await widget.authRepository.loginWithSocial(
+          token: token,
+        );
+        await widget.onLoggedIn(profile);
+      } on ApiException catch (e) {
+        if (!_requiresInviteCode(e)) {
+          rethrow;
+        }
 
-    final loginId = _emailController.text.trim();
-    final password = _passwordController.text;
-    if (loginId.isEmpty || password.isEmpty) {
-      setState(() {
-        _error = '이메일(또는 아이디)과 비밀번호를 입력해 주세요.';
-      });
-      return;
-    }
+        if (!mounted) {
+          return;
+        }
 
-    setState(() {
-      _emailLoading = true;
-      _error = null;
+        final profile = await Navigator.of(context).push<SessionProfile>(
+          MaterialPageRoute<SessionProfile>(
+            builder: (_) => InviteGatePage(
+              title: '초대 코드 입력',
+              description: '로그인을 완료하려면 초대 코드를 입력해 주세요.',
+              submitLabel: '코드 확인 후 입장',
+              onSubmit: (inviteCode) {
+                return widget.authRepository.loginWithSocial(
+                  token: token,
+                  inviteCode: inviteCode,
+                );
+              },
+              onWithdraw: _handleWithdrawRequested,
+            ),
+          ),
+        );
+
+        if (!mounted || profile == null) {
+          return;
+        }
+
+        await widget.onLoggedIn(profile);
+      }
     });
-
-    try {
-      final profile = await widget.authRepository.loginWithAccount(
-        loginId: loginId,
-        password: password,
-      );
-      await widget.onLoggedIn(profile);
-    } on ApiException catch (e) {
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _error = e.message;
-      });
-    } catch (_) {
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _error = '로그인에 실패했어요. 다시 시도해 주세요.';
-      });
-    } finally {
-      if (mounted) {
-        setState(() {
-          _emailLoading = false;
-        });
-      }
-    }
   }
 
   @override
   Widget build(BuildContext context) {
     final visibleError = _error ?? widget.initialError;
-
     return Scaffold(
       backgroundColor: const Color(0xFFF6F7F9),
       body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(20, 12, 20, 24),
-          child: Column(
-            children: [
-              const Spacer(),
-              const _LoginHero(),
-              const SizedBox(height: 12),
-              const Text(
-                '은혜를 더 가까이, 찬양을 더 편하게',
-                style: TextStyle(
-                  color: Color(0xFF5B6572),
-                  fontSize: 14,
-                ),
-              ),
-              const Spacer(),
-              if (visibleError != null) ...[
-                Container(
-                  width: double.infinity,
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-                  decoration: BoxDecoration(
-                    color: const Color(0xFFFFF1F0),
-                    borderRadius: BorderRadius.circular(12),
-                    border: Border.all(color: const Color(0xFFFFD1CC)),
-                  ),
-                  child: Text(
-                    visibleError,
-                    style: const TextStyle(
-                      color: Color(0xFFC2291E),
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 12),
-              ],
-              SizedBox(
-                width: double.infinity,
-                height: 56,
-                child: FilledButton(
-                  onPressed: _loading ? null : _handleKakaoLogin,
-                  style: FilledButton.styleFrom(
-                    backgroundColor: const Color(0xFFFEE500),
-                    foregroundColor: Colors.black87,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(14),
-                    ),
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Container(
-                        width: 24,
-                        height: 24,
-                        decoration: const BoxDecoration(
-                          color: Colors.black87,
-                          shape: BoxShape.circle,
-                        ),
-                        child: const Icon(
-                          Icons.chat_bubble_rounded,
-                          color: Color(0xFFFEE500),
-                          size: 14,
-                        ),
-                      ),
-                      const SizedBox(width: 10),
-                      Text(
-                        _socialLoading ? '카카오 로그인 중...' : '카카오로 시작하기',
-                        style: const TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              const SizedBox(height: 14),
-              const Row(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(20),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 480),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  Expanded(child: Divider()),
-                  Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 10),
-                    child: Text(
-                      '또는',
-                      style: TextStyle(color: Color(0xFF6B7280)),
+                  const _LoginHero(),
+                  const SizedBox(height: 16),
+                  Card(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 20, 16, 16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          const Text(
+                            '로그인',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(height: 6),
+                          const Text(
+                            '카카오 또는 이메일 로그인을 선택해 주세요.',
+                            style: TextStyle(color: Color(0xFF5B6572)),
+                          ),
+                          const SizedBox(height: 14),
+                          _ActionButton(
+                            onPressed: _loading ? null : _handleKakaoLogin,
+                            label: _loading ? '처리 중...' : '카카오로 시작하기',
+                            icon: const Icon(Icons.chat_bubble_rounded),
+                            background: const Color(0xFFFEE500),
+                            foreground: Colors.black87,
+                          ),
+                          const SizedBox(height: 10),
+                          _ActionButton(
+                            onPressed: _loading ? null : _openEmailLoginPage,
+                            label: '이메일 로그인',
+                            icon: const Icon(Icons.mail_outline),
+                            background: Colors.white,
+                            foreground: const Color(0xFF111827),
+                            border: const Color(0xFFE5E7EB),
+                          ),
+                          if (!_hasKakaoKey && !_loading)
+                            const Padding(
+                              padding: EdgeInsets.only(top: 10),
+                              child: Text(
+                                '카카오 앱키가 없어서 카카오 로그인은 비활성화됩니다.',
+                                style:
+                                    TextStyle(fontSize: 12, color: Colors.red),
+                              ),
+                            ),
+                        ],
+                      ),
                     ),
                   ),
-                  Expanded(child: Divider()),
+                  if (visibleError != null) ...[
+                    const SizedBox(height: 10),
+                    Container(
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFFFF1F0),
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(color: const Color(0xFFFFD1CC)),
+                      ),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 10,
+                      ),
+                      child: Text(
+                        visibleError,
+                        style: const TextStyle(
+                          color: Color(0xFFC2291E),
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                  ],
                 ],
               ),
-              const SizedBox(height: 14),
-              TextField(
-                controller: _emailController,
-                enabled: !_loading,
-                keyboardType: TextInputType.emailAddress,
-                textInputAction: TextInputAction.next,
-                decoration: const InputDecoration(
-                  labelText: '이메일(또는 아이디)',
-                ),
-              ),
-              const SizedBox(height: 10),
-              TextField(
-                controller: _passwordController,
-                enabled: !_loading,
-                obscureText: true,
-                onSubmitted: (_) => _handleEmailLogin(),
-                decoration: const InputDecoration(
-                  labelText: '비밀번호',
-                ),
-              ),
-              const SizedBox(height: 10),
-              SizedBox(
-                width: double.infinity,
-                child: FilledButton.icon(
-                  onPressed: _loading ? null : _handleEmailLogin,
-                  icon: const Icon(Icons.mail_outline),
-                  label: Text(_emailLoading ? '로그인 중...' : '이메일로 로그인'),
-                ),
-              ),
-            ],
+            ),
           ),
         ),
       ),
@@ -275,27 +253,68 @@ class _LoginHero extends StatelessWidget {
     return Column(
       children: [
         Container(
-          width: 84,
-          height: 84,
+          width: 72,
+          height: 72,
           decoration: const BoxDecoration(
             color: Color(0xFFFF6F0F),
             shape: BoxShape.circle,
           ),
-          child: const Icon(
-            Icons.music_note_rounded,
-            color: Colors.white,
-            size: 42,
-          ),
+          child: const Icon(Icons.music_note_rounded,
+              color: Colors.white, size: 36),
         ),
-        const SizedBox(height: 14),
+        const SizedBox(height: 12),
         const Text(
-          '은혜찬송',
-          style: TextStyle(
-            fontSize: 30,
-            fontWeight: FontWeight.w800,
-          ),
+          '은혜찬양',
+          style: TextStyle(fontSize: 28, fontWeight: FontWeight.w800),
+        ),
+        const SizedBox(height: 4),
+        const Text(
+          '카카오 또는 이메일로 시작하세요.',
+          style: TextStyle(color: Color(0xFF5B6572)),
         ),
       ],
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  final VoidCallback? onPressed;
+  final String label;
+  final Widget icon;
+  final Color background;
+  final Color foreground;
+  final Color border;
+
+  const _ActionButton({
+    required this.onPressed,
+    required this.label,
+    required this.icon,
+    required this.background,
+    required this.foreground,
+    this.border = Colors.transparent,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 54,
+      child: FilledButton.icon(
+        onPressed: onPressed,
+        icon: icon,
+        label: Text(
+          label,
+          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+        ),
+        style: FilledButton.styleFrom(
+          backgroundColor: background,
+          foregroundColor: foreground,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          side: border == Colors.transparent ? null : BorderSide(color: border),
+          textStyle: const TextStyle(fontWeight: FontWeight.w600),
+        ),
+      ),
     );
   }
 }

--- a/apps/mobile/lib/src/features/auth/onboarding_page.dart
+++ b/apps/mobile/lib/src/features/auth/onboarding_page.dart
@@ -157,6 +157,11 @@ class _OnboardingPageState extends State<OnboardingPage> {
               '입력한 정보는 관리자 승인 및 안내 표시에 사용됩니다.',
               style: TextStyle(color: Color(0xFF6B7280)),
             ),
+            const SizedBox(height: 4),
+            const Text(
+              '회원/교회 정보는 첫 사용 시 1회만 입력합니다.',
+              style: TextStyle(color: Color(0xFF6B7280), fontSize: 12),
+            ),
             const SizedBox(height: 18),
             TextField(
               controller: _churchController,

--- a/apps/mobile/lib/src/features/auth/sign_up_page.dart
+++ b/apps/mobile/lib/src/features/auth/sign_up_page.dart
@@ -77,7 +77,6 @@ class _SignUpPageState extends State<SignUpPage> {
                 inviteCode: inviteCode,
               );
             },
-            onWithdraw: () => widget.authRepository.withdraw(),
           ),
         ),
       );

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -49,7 +49,7 @@ Base URL: `/api/v1`
 - `POST /auth/signup`
   ```json
   {
-    "loginId": "member.one",
+    "loginId": "qa.user@example.com",
     "password": "password-123!",
     "inviteCode": "ABC123"
   }
@@ -57,10 +57,11 @@ Base URL: `/api/v1`
 - `POST /auth/login`
   ```json
   {
-    "loginId": "member.one",
+    "loginId": "qa.user@example.com",
     "password": "password-123!"
   }
   ```
+- `loginId`는 영문/숫자/`._-` 조합 또는 이메일 형식(3~100자)을 지원
 - 공통 응답:
   ```json
   {
@@ -132,6 +133,7 @@ Base URL: `/api/v1`
 
 ### 1.7 회원 탈퇴
 - `POST /auth/withdraw` (인증 필요)
+- `DELETE /me/account` (인증 필요, `POST /auth/withdraw`와 동일 처리)
 - 요청 본문 없음
 - 응답 `data`: `null`
 

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -4,6 +4,23 @@
 
 ## 2026-02-20
 
+### Auth invite-gated login sync + `/me/account` withdraw endpoint
+- API/Auth
+  - `UserPasswordSignupUseCase` 로그인 ID 검증에 이메일 형식(3~100자) 허용
+  - `MeController`에 `DELETE /me/account` 추가 (기존 `POST /auth/withdraw`와 동일 탈퇴 처리)
+  - `AuthController` social login 예외 매핑 정리 (`account_disabled` 유지)
+- Mobile auth UX
+  - 로그인 화면에서 이메일/카카오 진입 분리 (`login_page.dart` + `email_login_page.dart`)
+  - 이메일 회원가입 시 초대코드 확인을 별도 단계(`invite_gate_page.dart`)로 분리
+  - 온보딩 화면에 "회원/교회 정보 1회 입력" 안내 문구 추가
+  - `AuthRepository.withdraw()`가 `/me/account` 호출 후 로컬 토큰 정리
+- 스크립트
+  - `scripts/run-mobile-emulator.ps1`가 `scripts/flutterw.ps1` 래퍼 경유로 실행되도록 변경
+- 검증
+  - `./gradlew.bat test --no-daemon --tests "com.eunhyehymn.presentation.controllers.UserPasswordAuthApiTest" --tests "com.eunhyehymn.presentation.controllers.MeProfileApiTest"`
+  - `..\..\scripts\flutterw.ps1 analyze`
+  - `..\..\scripts\flutterw.ps1 test`
+
 ### Documentation full sync (env/API/data-model)
 - 문서 기준선 재정렬
   - `README.md`, `docs/current-usable-scope.md`, `current_update.md`

--- a/docs/current-usable-scope.md
+++ b/docs/current-usable-scope.md
@@ -37,6 +37,7 @@
   - `POST /auth/refresh`
   - `POST /auth/logout`
   - `POST /auth/withdraw`
+  - `DELETE /me/account`
 - 멤버:
   - `GET/PUT /me/profile`
   - `POST /me/profile-change-requests`

--- a/scripts/run-mobile-emulator.ps1
+++ b/scripts/run-mobile-emulator.ps1
@@ -14,17 +14,9 @@ $mobileEnv = Join-Path $mobileDir ".env"
 $repoEnv = Join-Path $repoRoot ".env"
 $profileFile = Join-Path $mobileDir ("env/{0}.json" -f $Environment)
 
-$preferredFlutter = Join-Path $repoRoot "tools/flutter/bin/flutter.bat"
-$flutter = Get-Command "flutter" -ErrorAction SilentlyContinue
-if ($flutter) {
-    $flutter = $flutter.Source
-}
-if (-not $flutter) {
-    $flutter = $preferredFlutter
-}
-
-if (-not (Test-Path -LiteralPath $flutter)) {
-    throw "Flutter executable not found: $flutter"
+$flutterWrapper = Join-Path $PSScriptRoot "flutterw.ps1"
+if (-not (Test-Path -LiteralPath $flutterWrapper)) {
+    throw "Flutter wrapper not found: $flutterWrapper"
 }
 if (-not (Test-Path -LiteralPath $profileFile)) {
     throw "Environment profile not found: $profileFile"
@@ -120,7 +112,7 @@ if ($resolvedApiBaseUrl.Trim() -ne $profileApiBaseUrl) {
 Push-Location $mobileDir
 try {
     Write-Host ("[run-mobile-emulator] environment={0} api={1}" -f $Environment, $resolvedApiBaseUrl.Trim())
-    & $flutter run -d $DeviceId @dartDefines
+    & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $flutterWrapper run -d $DeviceId @dartDefines
 } finally {
     Pop-Location
 }


### PR DESCRIPTION
﻿## Summary
- sync invite-gated auth flow on latest `develop` while preserving current verification architecture
- add `DELETE /me/account` endpoint in `MeController` using existing `WithdrawAccountUseCase` (keeps `POST /auth/withdraw` compatible)
- expand signup `loginId` validation to accept email format (3~100 chars)
- update mobile auth UX:
  - split email login into dedicated `EmailLoginPage`
  - add reusable `InviteGatePage` for signup/login invite-code step
  - move first-use member/church guidance text to onboarding page
- update `scripts/run-mobile-emulator.ps1` to execute through `scripts/flutterw.ps1`
- sync docs: `docs/api-contract.md`, `docs/current-usable-scope.md`, `docs/changelog-dev.md`

## Why
- the handover auth changes were not yet integrated on top of latest `develop`
- this PR ports those changes with conflict resolution against recent auth/profile verification updates

## Verification
- `./gradlew.bat test --no-daemon --tests "com.eunhyehymn.presentation.controllers.UserPasswordAuthApiTest" --tests "com.eunhyehymn.presentation.controllers.MeProfileApiTest"` (`apps/api`) ✅
- `..\..\scripts\flutterw.ps1 analyze` (`apps/mobile`) ✅
- `..\..\scripts\flutterw.ps1 test` (`apps/mobile`) ✅

## Notes
- removed temporary handover-only doc/log artifacts from the original handover commit while porting
- kept API compatibility by supporting both withdraw routes:
  - `POST /auth/withdraw`
  - `DELETE /me/account`
