### PR TITLE
feat(ops): add staging secret rotation audit automation

### DIFF
--- a/docs/SECRETS_MANAGEMENT.md
+++ b/docs/SECRETS_MANAGEMENT.md
@@ -44,6 +44,10 @@
   - DB credentials
   - cloud access keys
   - mobile signing credentials
+- Run monthly audit (recommended):
+  - `.\scripts\staging-secret-rotation-audit.ps1 -Repo V4N1LLA/Eunhye_Hymn -MaxAgeDays 90 -IncludeMobileReleaseSecrets`
+  - `STALE` means the secret age exceeded threshold and should be rotated.
+  - `MISSING` means workflow-required secret setup is incomplete.
 - Leak response steps:
   1. Revoke/rotate leaked secret.
   2. Audit access logs and token usage.

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -1265,3 +1265,30 @@
 - `cd apps/admin && npm run build`
 - `powershell -NoProfile -File .\\scripts\\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -AsJson`
 
+## 43. 이번 사이클 기록 (2026-02-22, staging secret rotation audit automation)
+
+### 목표
+- 운영 시크릿 로테이션 점검을 수동 확인에서 자동 기준(`OK/STALE/MISSING`)으로 전환한다.
+
+### 범위
+- 포함: 시크릿 최신성 점검 스크립트 추가, 운영 문서 반영
+- 제외: 실제 시크릿 재발급/교체 작업
+
+### 수행 작업
+1. 시크릿 점검 스크립트 추가
+- `scripts/staging-secret-rotation-audit.ps1`
+- GitHub repo secrets의 `updatedAt`을 조회해 상태 판정
+- 기본 스테이징 필수 시크릿 점검 + `-IncludeMobileReleaseSecrets` 확장 지원
+- `-MaxAgeDays` 초과 시 `STALE` 판정 및 종료코드 1 반환
+
+2. 운영 문서 동기화
+- `docs/runbook.md`: 월간 정기 점검에 자동 점검 명령/조치 기준 추가
+- `docs/SECRETS_MANAGEMENT.md`: 로테이션 자동 점검 명령/상태 해석 추가
+- `infra/aws/README.md`: 운영 점검 루틴에 시크릿 점검 명령 추가
+- `docs/changelog-dev.md`: 변경 이력 기록
+
+### 검증
+- `powershell -NoProfile -File .\\scripts\\staging-secret-rotation-audit.ps1 -Repo V4N1LLA/Eunhye_Hymn -MaxAgeDays 90`
+- `powershell -NoProfile -File .\\scripts\\staging-secret-rotation-audit.ps1 -Repo V4N1LLA/Eunhye_Hymn -MaxAgeDays 90 -IncludeMobileReleaseSecrets`
+- `rg -n "staging-secret-rotation-audit|STALE|MISSING" docs/runbook.md docs/SECRETS_MANAGEMENT.md infra/aws/README.md docs/changelog-dev.md docs/WORK_CYCLE.md`
+

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -2,6 +2,19 @@
 
 작업 단위별 핵심 변경만 기록한다. 상세 구현은 각 PR 본문과 커밋 로그를 참고한다.
 
+## 2026-02-22
+
+### Staging secret rotation audit automation
+- 스크립트 추가
+  - `scripts/staging-secret-rotation-audit.ps1`
+  - GitHub Actions repo secrets의 `updatedAt` 기준으로 `OK/STALE/MISSING/UNKNOWN` 판정
+  - 기본 스테이징 필수 시크릿 점검 + `-IncludeMobileReleaseSecrets` 옵션으로 모바일 배포 시크릿 확장
+  - `-MaxAgeDays` 임계값 기반으로 초과 시 실패(exit 1) 처리
+- 운영 문서 동기화
+  - `docs/runbook.md`
+  - `docs/SECRETS_MANAGEMENT.md`
+  - `infra/aws/README.md`
+
 ## 2026-02-20
 
 ### Auth invite-gated login sync + `/me/account` withdraw endpoint

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -96,4 +96,6 @@
 - 주 1회 스테이징 배포 리허설 + 스모크 체크리스트 1회 수행
 - 주 1회 `staging-ops-cycle.ps1 -WaitForCompletion -AutoLogin` 실행 결과를 기준으로 Go/Hold 근거를 `docs/staging-smoke-log.md`에 누적
 - 월 1회 시크릿 교체 상태 점검
+  - `.\scripts\staging-secret-rotation-audit.ps1 -Repo V4N1LLA/Eunhye_Hymn -MaxAgeDays 90 -IncludeMobileReleaseSecrets`
+  - 결과가 `STALE` 또는 `MISSING`이면 즉시 교체/보완 후 `docs/changelog-dev.md`에 기록
 - 월 1회 롤백 시나리오 점검

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -142,6 +142,17 @@ Terraform 적용 후 아래 스크립트로 필수 Secrets를 한 번에 동기�
 
 `-AutoLogin`은 세션 만료 시 `aws sso login` 또는 `aws login`을 자동 재시도한다.
 
+시크릿 로테이션 상태 점검(월 1회 권장):
+
+```powershell
+.\scripts\staging-secret-rotation-audit.ps1 -Repo V4N1LLA/Eunhye_Hymn -MaxAgeDays 90 -IncludeMobileReleaseSecrets
+```
+
+출력 상태:
+- `OK`: 기준 일수 이내
+- `STALE`: 기준 일수 초과(교체 권장)
+- `MISSING`: 필수 시크릿 누락
+
 리허설 자동 실행(권장):
 
 ```powershell

--- a/scripts/staging-secret-rotation-audit.ps1
+++ b/scripts/staging-secret-rotation-audit.ps1
@@ -126,12 +126,13 @@ foreach ($target in $targets) {
   }
 
   $updatedAtUtc = $updatedAtUtc.ToUniversalTime()
-  $ageDays = [int][Math]::Floor(($nowUtc - $updatedAtUtc).TotalDays)
-  if ($ageDays -lt 0) {
-    $ageDays = 0
+  $ageTotalDays = ($nowUtc - $updatedAtUtc).TotalDays
+  if ($ageTotalDays -lt 0) {
+    $ageTotalDays = 0
   }
 
-  $isStale = $ageDays -gt $MaxAgeDays
+  $ageDays = [Math]::Round($ageTotalDays, 2)
+  $isStale = $ageTotalDays -gt [double]$MaxAgeDays
   $rows += [PSCustomObject]@{
     Scope = $scope
     Secret = $name
@@ -139,7 +140,7 @@ foreach ($target in $targets) {
     AgeDays = $ageDays
     MaxAgeDays = $MaxAgeDays
     Status = $(if ($isStale) { "STALE" } else { "OK" })
-    Detail = $(if ($isStale) { "age exceeds threshold; rotate secret" } else { "within threshold" })
+    Detail = $(if ($isStale) { "age exceeds threshold precisely; rotate secret" } else { "within threshold" })
   }
 }
 

--- a/scripts/staging-secret-rotation-audit.ps1
+++ b/scripts/staging-secret-rotation-audit.ps1
@@ -1,0 +1,167 @@
+param(
+  [string]$Repo = "V4N1LLA/Eunhye_Hymn",
+  [int]$MaxAgeDays = 90,
+  [switch]$IncludeMobileReleaseSecrets,
+  [switch]$AsJson
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($MaxAgeDays -lt 1) {
+  throw "MaxAgeDays must be >= 1"
+}
+
+$requiredStagingSecrets = @(
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_REGION",
+  "ECR_REGISTRY",
+  "EC2_HOST",
+  "EC2_SSH_KEY",
+  "DEPLOY_ENV_FILE"
+)
+
+$mobileReleaseSecrets = @(
+  "MOBILE_ANDROID_KEYSTORE_BASE64",
+  "MOBILE_ANDROID_KEY_ALIAS",
+  "MOBILE_ANDROID_KEY_PASSWORD",
+  "MOBILE_ANDROID_STORE_PASSWORD",
+  "GOOGLE_PLAY_PACKAGE_NAME",
+  "GOOGLE_PLAY_SERVICE_ACCOUNT_JSON",
+  "MOBILE_IOS_BUNDLE_ID",
+  "MOBILE_IOS_TEAM_ID",
+  "MOBILE_IOS_P12_BASE64",
+  "MOBILE_IOS_P12_PASSWORD",
+  "MOBILE_IOS_APPSTORE_ISSUER_ID",
+  "MOBILE_IOS_APPSTORE_API_KEY_ID",
+  "MOBILE_IOS_APPSTORE_API_PRIVATE_KEY"
+)
+
+function Test-CommandExists {
+  param([string]$Name)
+  $command = Get-Command $Name -ErrorAction SilentlyContinue
+  return $null -ne $command
+}
+
+if (-not (Test-CommandExists "gh")) {
+  throw "gh cli is required."
+}
+
+gh auth status 1>$null 2>$null
+if ($LASTEXITCODE -ne 0) {
+  throw "gh auth required. Run: gh auth login"
+}
+
+$secretJson = gh secret list --repo $Repo --json name,updatedAt
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($secretJson)) {
+  throw "Failed to load repo secrets: $Repo"
+}
+
+try {
+  $repoSecrets = $secretJson | ConvertFrom-Json
+} catch {
+  throw "Failed to parse gh secret list response."
+}
+
+$secretByName = @{}
+foreach ($secret in $repoSecrets) {
+  if ($null -eq $secret.name) {
+    continue
+  }
+  $secretByName[$secret.name] = $secret
+}
+
+$targets = @()
+foreach ($name in $requiredStagingSecrets) {
+  $targets += [PSCustomObject]@{
+    Secret = $name
+    Scope = "staging"
+  }
+}
+
+if ($IncludeMobileReleaseSecrets) {
+  foreach ($name in $mobileReleaseSecrets) {
+    $targets += [PSCustomObject]@{
+      Secret = $name
+      Scope = "mobile_release"
+    }
+  }
+}
+
+$targets = $targets | Sort-Object Secret -Unique
+
+$nowUtc = (Get-Date).ToUniversalTime()
+$rows = @()
+
+foreach ($target in $targets) {
+  $name = $target.Secret
+  $scope = $target.Scope
+
+  if (-not $secretByName.ContainsKey($name)) {
+    $rows += [PSCustomObject]@{
+      Scope = $scope
+      Secret = $name
+      UpdatedAt = "-"
+      AgeDays = "-"
+      MaxAgeDays = $MaxAgeDays
+      Status = "MISSING"
+      Detail = "secret not found"
+    }
+    continue
+  }
+
+  $updatedAtRaw = $secretByName[$name].updatedAt
+  [datetime]$updatedAtUtc = [datetime]::MinValue
+  if (-not [datetime]::TryParse($updatedAtRaw, [ref]$updatedAtUtc)) {
+    $rows += [PSCustomObject]@{
+      Scope = $scope
+      Secret = $name
+      UpdatedAt = "$updatedAtRaw"
+      AgeDays = "-"
+      MaxAgeDays = $MaxAgeDays
+      Status = "UNKNOWN"
+      Detail = "invalid updatedAt timestamp"
+    }
+    continue
+  }
+
+  $updatedAtUtc = $updatedAtUtc.ToUniversalTime()
+  $ageDays = [int][Math]::Floor(($nowUtc - $updatedAtUtc).TotalDays)
+  if ($ageDays -lt 0) {
+    $ageDays = 0
+  }
+
+  $isStale = $ageDays -gt $MaxAgeDays
+  $rows += [PSCustomObject]@{
+    Scope = $scope
+    Secret = $name
+    UpdatedAt = $updatedAtUtc.ToString("yyyy-MM-ddTHH:mm:ssZ")
+    AgeDays = $ageDays
+    MaxAgeDays = $MaxAgeDays
+    Status = $(if ($isStale) { "STALE" } else { "OK" })
+    Detail = $(if ($isStale) { "age exceeds threshold; rotate secret" } else { "within threshold" })
+  }
+}
+
+$missing = @($rows | Where-Object { $_.Status -eq "MISSING" })
+$stale = @($rows | Where-Object { $_.Status -eq "STALE" })
+$unknown = @($rows | Where-Object { $_.Status -eq "UNKNOWN" })
+
+if ($AsJson) {
+  $rows | ConvertTo-Json -Depth 4
+} else {
+  Write-Host ("== Secret Rotation Audit ==")
+  Write-Host ("Repo: {0}" -f $Repo)
+  Write-Host ("MaxAgeDays: {0}" -f $MaxAgeDays)
+  Write-Host ("IncludeMobileReleaseSecrets: {0}" -f $IncludeMobileReleaseSecrets)
+  Write-Host ""
+  $rows | Format-Table Scope, Secret, UpdatedAt, AgeDays, MaxAgeDays, Status, Detail -AutoSize
+  Write-Host ""
+  Write-Host ("Summary: OK={0}, STALE={1}, MISSING={2}, UNKNOWN={3}" -f ($rows.Count - $stale.Count - $missing.Count - $unknown.Count), $stale.Count, $missing.Count, $unknown.Count)
+}
+
+if ($missing.Count -gt 0 -or $stale.Count -gt 0 -or $unknown.Count -gt 0) {
+  exit 1
+}
+
+exit 0


### PR DESCRIPTION
## Summary
- add `scripts/staging-secret-rotation-audit.ps1` to audit GitHub Actions secret freshness by `updatedAt`
- classify target secrets as `OK`, `STALE`, `MISSING`, `UNKNOWN` and fail fast when non-OK exists
- sync ops docs for monthly secret-rotation checks (`docs/runbook.md`, `docs/SECRETS_MANAGEMENT.md`, `infra/aws/README.md`)
- record this cycle in `docs/changelog-dev.md` and `docs/WORK_CYCLE.md`

## Validation
- `powershell -NoProfile -File .\\scripts\\staging-secret-rotation-audit.ps1 -Repo V4N1LLA/Eunhye_Hymn -MaxAgeDays 90` (pass)
- `powershell -NoProfile -File .\\scripts\\staging-secret-rotation-audit.ps1 -Repo V4N1LLA/Eunhye_Hymn -MaxAgeDays 90 -IncludeMobileReleaseSecrets` (expected fail; detects missing mobile secrets)
- `rg -n "^(<<<<<<<|>>>>>>>|=======)$" docs README.md CLAUDE.md` (no conflict markers)

## Risks
- the extended audit mode (`-IncludeMobileReleaseSecrets`) currently fails until iOS/Play upload secrets are provisioned
- this change does not rotate secrets automatically; it only enforces visibility and gating
