### PR TITLE
chore: add codex skills and sync script workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,173 @@
+# AGENTS.md
+
+Practical operating guide for agentic coding assistants in this repository.
+Use this as the default execution and style baseline.
+
+## 1) Repository Snapshot
+
+- Monorepo with three apps:
+  - `apps/api`: Spring Boot (Java 17, Gradle wrapper)
+  - `apps/admin`: React + TypeScript + Vite
+  - `apps/mobile`: Flutter/Dart
+- Infra and ops:
+  - `infra/aws`: Terraform + deploy scripts
+  - `infra/docker`: local docker-compose stack
+- API base path is always `/api/v1`.
+- Architectural intent is Clean Architecture (domain -> application -> presentation/adapters -> infrastructure).
+
+## 2) Rule Sources Checked
+
+- Checked for Cursor rules: `.cursor/rules/` and `.cursorrules` -> **not present**.
+- Checked for Copilot rules: `.github/copilot-instructions.md` -> **not present**.
+- Project-specific operational guidance exists in `CLAUDE.md` and `docs/WORK_CYCLE.md`.
+
+## 3) Setup and Toolchain
+
+- Java: 17
+- Node.js: 20+
+- npm: 10+
+- Flutter/Dart: Flutter stable, Dart >= 3.4
+- Preferred wrappers/tools:
+  - API: `./gradlew` (or `gradlew.bat` on Windows)
+  - Mobile on Windows/local CI parity: `scripts/flutterw.ps1`
+
+## 4) Build / Lint / Test Commands
+
+Run commands from repo root unless noted.
+
+### 4.1 API (`apps/api`)
+
+- Build/test (CI parity):
+  - `cd apps/api && ./gradlew test --no-daemon --stacktrace`
+- Run app locally:
+  - `cd apps/api && ./gradlew bootRun`
+- Run a single test class:
+  - `cd apps/api && ./gradlew test --tests "com.eunhyehymn.presentation.controllers.AdminEventApiTest" --no-daemon --stacktrace`
+- Run a single test method:
+  - `cd apps/api && ./gradlew test --tests "com.eunhyehymn.presentation.controllers.AdminEventApiTest.adminCanListEventsAndSummary" --no-daemon --stacktrace`
+- Alternative pattern filter:
+  - `cd apps/api && ./gradlew test --tests "*AdminEventApiTest*" --no-daemon --stacktrace`
+
+### 4.2 Admin (`apps/admin`)
+
+- Install deps:
+  - `cd apps/admin && npm ci`
+- Dev server:
+  - `cd apps/admin && npm run dev`
+- Type-check (used as lint gate in CI):
+  - `cd apps/admin && npx tsc --noEmit`
+- Production build:
+  - `cd apps/admin && npm run build`
+- Tests:
+  - No frontend test runner is currently configured in `package.json`.
+  - If adding tests, also add CI step + script in `apps/admin/package.json`.
+
+### 4.3 Mobile (`apps/mobile`)
+
+- Install deps:
+  - `cd apps/mobile && ..\\..\\scripts\\flutterw.ps1 pub get`
+- Analyze (lint):
+  - `cd apps/mobile && ..\\..\\scripts\\flutterw.ps1 analyze`
+- Run all tests:
+  - `cd apps/mobile && ..\\..\\scripts\\flutterw.ps1 test`
+- Run a single test file:
+  - `cd apps/mobile && ..\\..\\scripts\\flutterw.ps1 test test/app_config_test.dart`
+- Run one named test case:
+  - `cd apps/mobile && ..\\..\\scripts\\flutterw.ps1 test test/app_config_test.dart --plain-name "app env defaults to local"`
+
+### 4.4 Workflow/Script Validation
+
+- GitHub workflow lint: `actionlint` in `.github/workflows/workflow-lint.yml`
+- Bash syntax checks:
+  - `bash -n infra/aws/deploy.sh`
+  - `bash -n infra/aws/verify-staging.sh`
+- PowerShell syntax checks are defined in `.github/workflows/workflow-lint.yml`.
+
+## 5) Coding Guidelines (Cross-cutting)
+
+- Keep changes minimal, local, and consistent with existing code.
+- Preserve Clean Architecture boundaries:
+  - Domain layer must not depend on framework/infrastructure.
+  - Use ports/interfaces for external dependencies.
+- Avoid speculative abstractions (YAGNI); prefer simple, readable code.
+- Do not hardcode secrets, credentials, or environment-specific private values.
+- Keep API contracts stable; if changed, update docs:
+  - `docs/api-contract.md`
+  - `docs/data-model.md`
+  - related README/docs as needed.
+
+## 6) Java (API) Style
+
+- Use constructor injection; avoid field injection.
+- Use `record` for simple immutable DTO/domain carriers where already adopted.
+- Package conventions:
+  - `domain.model`, `domain.repository`
+  - `application.usecases`, `application.ports`
+  - `presentation.controllers`
+  - `infrastructure.*`
+- Naming:
+  - UseCase classes end with `UseCase`.
+  - Repository interfaces end with `Repository`; JPA adapters include `JpaRepository`/`RepositoryAdapter`.
+  - Enums in `UPPER_SNAKE_CASE` values.
+- Error handling:
+  - Throw `ApiException` for expected API errors.
+  - Return envelope via `ApiResponse.success(...)` / `ApiResponse.failure(...)`.
+  - Prefer specific exception mapping in `GlobalExceptionHandler`.
+- Validation:
+  - Use Jakarta validation annotations (`@NotBlank`, etc.) on request DTOs/records.
+- Transactions:
+  - Mark multi-write use case operations with `@Transactional`.
+
+## 7) TypeScript/React (Admin) Style
+
+- TypeScript is `strict`; avoid `any`.
+- Prefer explicit interfaces/types for API request and response payloads.
+- Keep API access centralized in `src/api/*` using shared client helpers.
+- Handle async errors as:
+  - `catch (err) { ... err instanceof Error ? err.message : fallback ... }`
+- Naming conventions:
+  - Components/pages: `PascalCase` file + symbol names.
+  - Hooks/utils/functions/vars: `camelCase`.
+  - Shared type aliases/interfaces: `PascalCase`.
+- Imports:
+  - Group React/library imports first, then local imports.
+  - Prefer `type` imports where helpful (already used in places).
+- Formatting conventions seen in repo:
+  - Double quotes, semicolons, trailing commas where formatter applies.
+  - Keep JSX readable; avoid deeply nested conditional complexity.
+
+## 8) Dart/Flutter (Mobile) Style
+
+- Lints come from `flutter_lints`; explicit rule `avoid_print: true`.
+- Use single quotes and trailing commas for multiline widget trees/args.
+- Prefer named parameters and `required` for clarity.
+- Keep async/network error handling user-safe:
+  - Throw/propagate `ApiException` with actionable messages.
+  - Provide graceful fallback where pattern already exists (cache/offline paths).
+- Naming:
+  - Classes/widgets: `PascalCase`
+  - Members/functions/locals: `camelCase`
+  - Private symbols: `_leadingUnderscore`
+- Keep API URL handling consistent with `AppConfig` (`/api/v1` normalization).
+
+## 9) Testing Conventions
+
+- API tests use JUnit 5 + Spring Boot test + MockMvc + AssertJ.
+- Prefer deterministic setup/teardown; isolate DB state in each test.
+- Add tests near changed behavior (controller/use case/repository level as appropriate).
+- For mobile, keep tests small and focused (`test/*_test.dart` pattern).
+- For admin, if introducing test tooling, align with existing CI gates and add script(s).
+
+## 10) Agent Workflow Expectations
+
+- Before editing, inspect nearby code for local conventions and follow them.
+- After edits, run the smallest meaningful validation first, then broader checks.
+- If behavior/contracts changed, update docs in the same change.
+- Keep commits/PRs scoped and explain why, not just what.
+
+## 11) Quick Command Matrix
+
+- API all tests: `cd apps/api && ./gradlew test --no-daemon --stacktrace`
+- API single test: `cd apps/api && ./gradlew test --tests "*ClassName*" --no-daemon --stacktrace`
+- Admin typecheck+build: `cd apps/admin && npm ci && npx tsc --noEmit && npm run build`
+- Mobile analyze+test: `cd apps/mobile && ..\\..\\scripts\\flutterw.ps1 analyze && ..\\..\\scripts\\flutterw.ps1 test`

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -108,3 +108,27 @@ cd apps/mobile
 - Admin: 타입체크 + 빌드
 - Mobile: analyze + test
 - Staging deploy 및 mobile release readiness workflow는 별도 문서(`docs/runbook.md`, `docs/mobile/README.md`) 기준으로 운영한다.
+
+## 9. Codex 스킬 동기화 (다른 PC 포함)
+
+저장소의 `skills/`를 로컬 Codex 스킬 디렉터리(`$CODEX_HOME/skills` 또는 `~/.codex/skills`)로 동기화한다.
+
+전체 동기화:
+
+```powershell
+.\scripts\sync-skills.ps1
+```
+
+특정 스킬만 동기화:
+
+```powershell
+.\scripts\sync-skills.ps1 -Skill staging-ops-runner,docs-sync-enforcer
+```
+
+적용 전 확인(드라이런):
+
+```powershell
+.\scripts\sync-skills.ps1 -DryRun
+```
+
+동기화 후 Codex를 재시작한다.

--- a/scripts/sync-skills.ps1
+++ b/scripts/sync-skills.ps1
@@ -1,0 +1,157 @@
+param(
+  [string]$SourceDir = "skills",
+  [string]$DestDir = "",
+  [string[]]$Skill = @(),
+  [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-RepoPath {
+  param(
+    [string]$RepoRoot,
+    [string]$PathValue
+  )
+
+  if ([string]::IsNullOrWhiteSpace($PathValue)) {
+    return $RepoRoot
+  }
+  if ([System.IO.Path]::IsPathRooted($PathValue)) {
+    return [System.IO.Path]::GetFullPath($PathValue)
+  }
+  return [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $PathValue))
+}
+
+function Get-CodexHome {
+  if (-not [string]::IsNullOrWhiteSpace($env:CODEX_HOME)) {
+    return $env:CODEX_HOME
+  }
+  return (Join-Path ([Environment]::GetFolderPath("UserProfile")) ".codex")
+}
+
+function Test-SkillFolder {
+  param([string]$Path)
+  return (Test-Path (Join-Path $Path "SKILL.md"))
+}
+
+function Get-FrontmatterName {
+  param([string]$SkillMdPath)
+
+  $lines = Get-Content -Encoding UTF8 $SkillMdPath
+  if ($lines.Count -lt 3 -or $lines[0].Trim() -ne "---") {
+    return $null
+  }
+
+  for ($i = 1; $i -lt $lines.Count; $i++) {
+    $line = $lines[$i]
+    if ($line.Trim() -eq "---") {
+      break
+    }
+    if ($line -match '^\s*name\s*:\s*(.+?)\s*$') {
+      return $Matches[1].Trim()
+    }
+  }
+  return $null
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$sourceRoot = Resolve-RepoPath -RepoRoot $repoRoot -PathValue $SourceDir
+
+if (-not (Test-Path -LiteralPath $sourceRoot)) {
+  throw "SourceDir not found: $sourceRoot"
+}
+
+$destRoot = if ([string]::IsNullOrWhiteSpace($DestDir)) {
+  Join-Path (Get-CodexHome) "skills"
+} else {
+  Resolve-RepoPath -RepoRoot $repoRoot -PathValue $DestDir
+}
+
+$allSkillDirs = Get-ChildItem -LiteralPath $sourceRoot -Directory |
+  Where-Object { $_.Name -ne ".system" -and (Test-SkillFolder -Path $_.FullName) } |
+  Sort-Object Name
+
+if (-not $allSkillDirs -or $allSkillDirs.Count -eq 0) {
+  throw "No skill folders with SKILL.md found under: $sourceRoot"
+}
+
+$selectedSkillDirs = $allSkillDirs
+
+if ($Skill.Count -gt 0) {
+  $wanted = @{}
+  foreach ($skillName in $Skill) {
+    if (-not [string]::IsNullOrWhiteSpace($skillName)) {
+      $wanted[$skillName.Trim()] = $true
+    }
+  }
+  if ($wanted.Count -eq 0) {
+    throw "Skill parameter is empty after trimming."
+  }
+
+  $selectedSkillDirs = $allSkillDirs | Where-Object { $wanted.ContainsKey($_.Name) }
+
+  $missing = @()
+  foreach ($name in $wanted.Keys) {
+    if (-not ($selectedSkillDirs | Where-Object { $_.Name -eq $name })) {
+      $missing += $name
+    }
+  }
+  if ($missing.Count -gt 0) {
+    $available = ($allSkillDirs | Select-Object -ExpandProperty Name) -join ", "
+    throw ("Unknown skills: {0}. Available: {1}" -f ($missing -join ", "), $available)
+  }
+}
+
+if (-not (Test-Path -LiteralPath $destRoot)) {
+  if (-not $DryRun) {
+    New-Item -ItemType Directory -Path $destRoot | Out-Null
+  }
+}
+
+Write-Host ("Source: {0}" -f $sourceRoot)
+Write-Host ("Destination: {0}" -f $destRoot)
+Write-Host ("Skills: {0}" -f (($selectedSkillDirs | Select-Object -ExpandProperty Name) -join ", "))
+Write-Host ""
+
+$synced = 0
+$warnings = @()
+
+foreach ($skillDir in $selectedSkillDirs) {
+  $skillName = $skillDir.Name
+  $sourcePath = $skillDir.FullName
+  $targetPath = Join-Path $destRoot $skillName
+  $skillMd = Join-Path $sourcePath "SKILL.md"
+  $frontmatterName = Get-FrontmatterName -SkillMdPath $skillMd
+
+  if (-not [string]::IsNullOrWhiteSpace($frontmatterName) -and $frontmatterName -ne $skillName) {
+    $warnings += ("name mismatch: folder '{0}' vs frontmatter '{1}'" -f $skillName, $frontmatterName)
+  }
+
+  if ($DryRun) {
+    Write-Host ("[DRYRUN] sync {0} -> {1}" -f $sourcePath, $targetPath)
+    continue
+  }
+
+  if (Test-Path -LiteralPath $targetPath) {
+    Remove-Item -LiteralPath $targetPath -Recurse -Force
+  }
+  Copy-Item -LiteralPath $sourcePath -Destination $targetPath -Recurse -Force
+  Write-Host ("[OK] synced {0}" -f $skillName)
+  $synced++
+}
+
+Write-Host ""
+if ($DryRun) {
+  Write-Host "Dry-run complete."
+} else {
+  Write-Host ("Sync complete. {0} skill(s) updated." -f $synced)
+}
+
+if ($warnings.Count -gt 0) {
+  Write-Host ""
+  foreach ($w in $warnings) {
+    Write-Host ("[WARN] {0}" -f $w)
+  }
+}
+
+Write-Host "Restart Codex to pick up new skills."

--- a/skills/docs-sync-enforcer/SKILL.md
+++ b/skills/docs-sync-enforcer/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: docs-sync-enforcer
+description: Enforce document synchronization for Eunhye Hymn changes. Use when code, scripts, workflows, or operations are modified and Codex must update matching docs (README, contracts, runbook, changelog, CLAUDE, WORK_CYCLE) in the same cycle.
+---
+
+# Docs Sync Enforcer
+
+Use this skill to prevent code-doc drift during implementation cycles.
+
+## Execute workflow
+
+1. Classify changed files by area (`api`, `admin`, `mobile`, `ops`, `ci`, `docs`).
+2. Load required target docs from `references/sync-matrix.md`.
+3. Update docs in the same change when behavior, commands, or contracts changed.
+4. Run conflict and stale-marker checks from `references/checks.md`.
+5. Summarize synced docs and any intentionally deferred updates.
+
+## Enforce hard rules
+
+- Keep `docs/api-contract.md` as API source of truth.
+- Keep `docs/data-model.md` as schema source of truth.
+- Update `docs/changelog-dev.md` and `CLAUDE.md` for meaningful cycle outcomes.
+- Scan for merge markers before finishing.
+
+## Return output
+
+Always return:
+
+- changed code paths
+- docs updated
+- verification commands and results
+- deferred docs with reason

--- a/skills/docs-sync-enforcer/agents/openai.yaml
+++ b/skills/docs-sync-enforcer/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Docs Sync Enforcer"
+  short_description: "Map code changes to required document updates."
+  default_prompt: "Use $docs-sync-enforcer to sync docs for this code and ops change."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/docs-sync-enforcer/references/checks.md
+++ b/skills/docs-sync-enforcer/references/checks.md
@@ -1,0 +1,27 @@
+# Docs Consistency Checks
+
+## Merge marker check
+
+```powershell
+rg -n "^(<<<<<<<|=======|>>>>>>>)+$" README.md docs CLAUDE.md
+```
+
+## Stale keyword scans (example)
+
+```powershell
+rg -n "TODO|TBD|placeholder|FIXME" docs README.md CLAUDE.md
+```
+
+## Required files touched check (example)
+
+```powershell
+git diff --name-only
+```
+
+Review whether changed areas from `references/sync-matrix.md` are reflected in doc updates.
+
+## Reporting format
+
+- list checks run
+- list pass/fail per check
+- list unresolved doc sync items

--- a/skills/docs-sync-enforcer/references/sync-matrix.md
+++ b/skills/docs-sync-enforcer/references/sync-matrix.md
@@ -1,0 +1,35 @@
+# Sync Matrix
+
+## API changes (`apps/api/**`)
+
+- `docs/api-contract.md`
+- `docs/data-model.md`
+- relevant `docs/usecases/*.md`
+- `docs/changelog-dev.md`
+
+## Admin changes (`apps/admin/**`)
+
+- `docs/admin/README.md`
+- relevant API contract sections in `docs/api-contract.md`
+- `docs/changelog-dev.md`
+
+## Mobile changes (`apps/mobile/**`)
+
+- `docs/mobile/README.md`
+- `apps/mobile/README.md`
+- relevant API contract sections in `docs/api-contract.md`
+- `docs/changelog-dev.md`
+
+## Ops/infra/script changes (`scripts/**`, `infra/**`, workflows)
+
+- `docs/runbook.md`
+- `docs/staging-smoke-checklist.md`
+- `docs/staging-feedback-checklist.md`
+- `docs/monorepo-cicd.md`
+- `docs/SECRETS_MANAGEMENT.md` (if secrets/rotation affected)
+- `docs/changelog-dev.md`
+
+## Cycle policy changes
+
+- `docs/WORK_CYCLE.md`
+- `CLAUDE.md`

--- a/skills/eunhye-hymn-dev-workflow/SKILL.md
+++ b/skills/eunhye-hymn-dev-workflow/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: eunhye-hymn-dev-workflow
+description: Workstream guide for the Eunhye Hymn monorepo. Use when Codex is changing or reviewing code/docs in apps/api, apps/admin, apps/mobile, docs, scripts, or infra; especially for local setup, API/admin/mobile feature work, CI/CD or staging operations, and required document synchronization.
+---
+
+# Eunhye Hymn Dev Workflow
+
+Use this skill to execute repository work with minimal context loading and consistent validation.
+
+## Execute core flow
+
+1. Classify the request into one primary area: `api`, `admin`, `mobile`, `ops`, or `docs`.
+2. Read `AGENTS.md` and `README.md`, then load only the area-specific files listed in `references/doc-routing.md`.
+3. Apply the smallest change that satisfies the request while preserving:
+   - API base path `/api/v1`
+   - Clean Architecture dependency direction in `apps/api`
+4. Run focused checks from `references/validation-matrix.md` for touched areas.
+5. Sync required docs when behavior/contracts/operations changed.
+6. Return a concise report with changed files, commands run, and any skipped checks.
+
+## Keep document updates consistent
+
+Update docs in the same change when applicable:
+
+- API contract or request/response changes: `docs/api-contract.md`
+- DB schema/entity changes: `docs/data-model.md`
+- Local setup/command changes: `README.md`, `docs/LOCAL_SETUP.md`, `docs/dev-guide.md`
+- Staging/release/ops changes: `docs/runbook.md`, `docs/monorepo-cicd.md`, related staging logs/checklists
+- Work-cycle policy changes: `docs/WORK_CYCLE.md`, `CLAUDE.md`
+
+## Apply execution defaults
+
+- Prefer wrappers and repo-standard commands:
+  - API: `apps/api\\gradlew.bat`
+  - Mobile: `scripts\\flutterw.ps1`
+- Prefer narrow verification before broad verification.
+- Avoid broad refactors unless requested.
+- Treat `docs/api-contract.md` and `docs/data-model.md` as source-of-truth for API/data behavior.

--- a/skills/eunhye-hymn-dev-workflow/agents/openai.yaml
+++ b/skills/eunhye-hymn-dev-workflow/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Eunhye Hymn Dev Workflow"
+  short_description: "Route docs, apply changes, and validate safely."
+  default_prompt: "Use $eunhye-hymn-dev-workflow to implement and validate this Eunhye Hymn monorepo task."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/eunhye-hymn-dev-workflow/references/doc-routing.md
+++ b/skills/eunhye-hymn-dev-workflow/references/doc-routing.md
@@ -1,0 +1,66 @@
+# Doc Routing
+
+Load only what is needed for the current task.
+
+## Always read first
+
+- `AGENTS.md`
+- `README.md`
+
+## Area-based loading
+
+### API backend (`apps/api`)
+
+- `docs/api-contract.md`
+- `docs/data-model.md`
+- `docs/architecture.md`
+- `docs/dev-guide.md`
+- `docs/usecases/README.md` and relevant `docs/usecases/*.md`
+
+### Admin web (`apps/admin`)
+
+- `docs/admin/README.md`
+- `docs/api-contract.md`
+- `docs/current-usable-scope.md`
+
+### Mobile app (`apps/mobile`)
+
+- `docs/mobile/README.md`
+- `apps/mobile/README.md`
+- `docs/usecases/ai-hymn-recommendations.md` and other relevant `docs/usecases/*.md`
+
+### Local environment and troubleshooting
+
+- `docs/LOCAL_SETUP.md`
+- `docs/TEAM_LOCAL_DEVELOPMENT.md`
+- `infra/docker/README.md`
+- `docs/SECRETS_MANAGEMENT.md`
+
+### CI/CD, release, branch flow
+
+- `docs/monorepo-cicd.md`
+- `docs/release-management.md`
+- `docs/parallel-pr-workflow.md`
+- `docs/parallel-task-board.md`
+
+### Staging and operations
+
+- `docs/runbook.md`
+- `docs/staging-smoke-checklist.md`
+- `docs/staging-feedback-checklist.md`
+- `docs/staging-rehearsal-log.md`
+- `docs/staging-smoke-log.md`
+- `docs/deployment-readiness-audit.md`
+- `infra/aws/README.md`
+
+### Work-cycle and documentation policy
+
+- `docs/WORK_CYCLE.md`
+- `CLAUDE.md`
+- `docs/changelog-dev.md`
+
+## Priority rules
+
+- Treat `docs/api-contract.md` as API source-of-truth.
+- Treat `docs/data-model.md` as schema/entity source-of-truth.
+- If docs conflict, update stale documents in the same change.

--- a/skills/eunhye-hymn-dev-workflow/references/validation-matrix.md
+++ b/skills/eunhye-hymn-dev-workflow/references/validation-matrix.md
@@ -1,0 +1,46 @@
+# Validation Matrix
+
+Run the smallest meaningful validation set for changed areas, then expand only if needed.
+
+## API changes (`apps/api`)
+
+- Targeted class:
+  - `cd apps/api`
+  - `.\gradlew.bat test --tests "*ClassName*" --no-daemon --stacktrace`
+- Full API test suite:
+  - `cd apps/api`
+  - `.\gradlew.bat test --no-daemon --stacktrace`
+
+## Admin changes (`apps/admin`)
+
+- `cd apps/admin`
+- `npm ci`
+- `npx tsc --noEmit`
+- `npm run build`
+
+If `npm ci` is not appropriate for the current local state, use `npm install`.
+
+## Mobile changes (`apps/mobile`)
+
+- `cd apps/mobile`
+- `..\..\scripts\flutterw.ps1 analyze`
+- `..\..\scripts\flutterw.ps1 test`
+
+## Cross-area changes
+
+- Validate each touched area with its own matrix above.
+- For API contract/schema changes, run API tests plus at least one affected client check (admin or mobile).
+
+## Docs or script-only changes
+
+- Conflict marker scan:
+  - `rg -n "^(<<<<<<<|=======|>>>>>>>)+$" README.md docs CLAUDE.md`
+- For staging script changes, run safe checks where available:
+  - `powershell -NoProfile -File .\scripts\staging-preflight.ps1 -Repo <owner/repo> -SkipTerraformPlan`
+  - `powershell -NoProfile -File .\scripts\staging-rehearsal.ps1 -Repo <owner/repo> -Ref <branch> -SkipPreflight -DryRun`
+
+## Report format
+
+- List commands run.
+- List pass/fail per command.
+- State any skipped checks with reason.

--- a/skills/mobile-store-release-runner/SKILL.md
+++ b/skills/mobile-store-release-runner/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: mobile-store-release-runner
+description: Execute and verify mobile store release readiness cycles for Eunhye Hymn. Use when Codex runs mobile store preflight, workflow dispatch, run watch, and release log updates for Android/iOS release paths.
+---
+
+# Mobile Store Release Runner
+
+Use this skill to run mobile release readiness cycles with repeatable evidence.
+
+## Execute workflow
+
+1. Collect target (`android`, `ios`, `both`) and distribution modes.
+2. Run preflight with `scripts/mobile-store-preflight.ps1`.
+3. Run full cycle with `scripts/mobile-store-cycle.ps1`.
+4. Capture workflow run IDs and conclusions.
+5. Ensure `docs/mobile-store-release-log.md` reflects each run.
+
+Read `references/commands.md` for command templates.
+
+## Enforce release-readiness rules
+
+- Block on preflight failure.
+- Treat missing required secrets as blocking.
+- Keep `build_only` as default safe path unless upload is explicitly requested.
+- Record `ABORTED` entries when cycle stops before dispatch.
+
+## Sync documents when changed
+
+- `docs/mobile/README.md`
+- `apps/mobile/README.md`
+- `docs/mobile-store-release-log.md`
+- `docs/changelog-dev.md`
+
+## Return output
+
+Always return:
+
+- target/mode used
+- preflight status
+- run ID and URL
+- final cycle result
+- updated log/doc files

--- a/skills/mobile-store-release-runner/agents/openai.yaml
+++ b/skills/mobile-store-release-runner/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Mobile Store Release Runner"
+  short_description: "Run mobile release preflight, dispatch, and logging."
+  default_prompt: "Use $mobile-store-release-runner to run mobile store release readiness."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/mobile-store-release-runner/references/commands.md
+++ b/skills/mobile-store-release-runner/references/commands.md
@@ -1,0 +1,35 @@
+# Mobile Store Release Commands
+
+## Android preflight (`build_only`)
+
+```powershell
+.\scripts\mobile-store-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn -Target android -AndroidDistributionMode build_only
+```
+
+## iOS preflight (`testflight`)
+
+```powershell
+.\scripts\mobile-store-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn -Target ios -IosDistributionMode testflight
+```
+
+## Full cycle (recommended)
+
+```powershell
+.\scripts\mobile-store-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref develop -Target android -AndroidDistributionMode build_only -IosDistributionMode build_only
+```
+
+## Dry run
+
+```powershell
+.\scripts\mobile-store-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref develop -Target both -DryRun
+```
+
+## Verify workflow runs
+
+```powershell
+gh run list --repo V4N1LLA/Eunhye_Hymn --workflow mobile-store-release.yml --limit 10 --json databaseId,status,conclusion,url,headSha
+```
+
+## Log file
+
+- `docs/mobile-store-release-log.md`

--- a/skills/parallel-worktree-manager/SKILL.md
+++ b/skills/parallel-worktree-manager/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: parallel-worktree-manager
+description: Manage parallel terminal task setup for Eunhye Hymn. Use when Codex should create isolated worktrees/branches, register task ownership, prevent branch or path collisions, and prepare PR-safe parallel execution.
+---
+
+# Parallel Worktree Manager
+
+Use this skill to start and control parallel feature cycles safely.
+
+## Execute workflow
+
+1. Collect task name, base branch, and owner.
+2. Create worktree/branch with `scripts/new-worktree-task.ps1`.
+3. Register ownership row in `docs/parallel-task-board.md`.
+4. Confirm no active collision on claimed paths.
+5. Share worktree path, branch name, and next commands.
+
+Read `references/commands.md` for templates.
+
+## Enforce parallel rules
+
+- Use one branch per terminal.
+- Avoid multi-terminal edits on the same branch.
+- Highlight shared-file risk for `README.md`, `docs/*`, and workflow files.
+- Keep PR scope limited to one task unit.
+
+## Return output
+
+Always return:
+
+- created branch/worktree path
+- task board row added or updated
+- conflict warnings (if any)
+- recommended next validation commands

--- a/skills/parallel-worktree-manager/agents/openai.yaml
+++ b/skills/parallel-worktree-manager/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Parallel Worktree Manager"
+  short_description: "Create isolated worktrees and track task ownership."
+  default_prompt: "Use $parallel-worktree-manager to set up a new parallel task worktree."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/parallel-worktree-manager/references/commands.md
+++ b/skills/parallel-worktree-manager/references/commands.md
@@ -1,0 +1,35 @@
+# Parallel Worktree Commands
+
+## Create task worktree
+
+```powershell
+.\scripts\new-worktree-task.ps1 -TaskName "admin-user-filter" -BaseBranch develop
+```
+
+## Check active worktrees
+
+```powershell
+git worktree list
+```
+
+## Check branch list
+
+```powershell
+git branch --all
+```
+
+## Task board file
+
+Register or update:
+
+- `docs/parallel-task-board.md`
+
+Include:
+
+- owner
+- task
+- branch
+- worktree path
+- claimed paths
+- status
+- updated UTC timestamp

--- a/skills/release-readiness-manager/SKILL.md
+++ b/skills/release-readiness-manager/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: release-readiness-manager
+description: Manage SemVer release readiness and release execution for Eunhye Hymn. Use when Codex validates version tags, runs release preflight, checks staging deploy health, and prepares tag-based GitHub releases.
+---
+
+# Release Readiness Manager
+
+Use this skill to prepare and execute release steps with consistent preflight gates.
+
+## Execute workflow
+
+1. Parse release target version (`MAJOR.MINOR.PATCH`).
+2. Run release preflight and inspect failed checks first.
+3. Confirm latest staging deploy and verify gates are healthy.
+4. Confirm CI evidence for the staging head SHA.
+5. Create/push annotated release tag only when all gates pass.
+6. Record release decision and evidence in docs when required.
+
+Read `references/commands.md` for command templates.
+
+## Enforce release rules
+
+- Reject invalid SemVer strings.
+- Reject duplicate tags.
+- Block release when staging gate is stale or failing.
+- Use PR-driven branch flow (`develop -> staging -> production`).
+
+## Sync documents when changed
+
+- `docs/release-management.md`
+- `docs/changelog-dev.md`
+- `docs/current-usable-scope.md`
+- `docs/deployment-readiness-audit.md`
+
+## Return output
+
+Always return:
+
+- version checked
+- gate status per check
+- release decision (`READY`, `BLOCKED`)
+- tag action taken or skipped

--- a/skills/release-readiness-manager/agents/openai.yaml
+++ b/skills/release-readiness-manager/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Release Readiness Manager"
+  short_description: "Validate SemVer release gates before tagging."
+  default_prompt: "Use $release-readiness-manager to run release preflight for this version."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/release-readiness-manager/references/commands.md
+++ b/skills/release-readiness-manager/references/commands.md
@@ -1,0 +1,33 @@
+# Release Readiness Commands
+
+## Release preflight
+
+```powershell
+.\scripts\release-preflight.ps1 -Version 1.2.3 -Repo V4N1LLA/Eunhye_Hymn -Branch staging
+```
+
+## Staging gate check
+
+```powershell
+.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch staging -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 1440 -AsJson
+```
+
+## Optional workflow run inspection
+
+```powershell
+gh run list --repo V4N1LLA/Eunhye_Hymn --workflow release-readiness.yml --limit 10 --json databaseId,status,conclusion,url,headSha
+```
+
+## Tag and push
+
+```powershell
+git checkout production
+git pull origin production
+git tag -a v1.2.3 -m "Release v1.2.3"
+git push origin v1.2.3
+```
+
+## Required docs
+
+- `docs/release-management.md`
+- `docs/changelog-dev.md`

--- a/skills/secrets-rotation-auditor/SKILL.md
+++ b/skills/secrets-rotation-auditor/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: secrets-rotation-auditor
+description: Audit and drive secret rotation hygiene for Eunhye Hymn staging/release operations. Use when Codex checks stale or missing GitHub Actions secrets, runs secret audit scripts, and updates remediation logs or security docs.
+---
+
+# Secrets Rotation Auditor
+
+Use this skill to perform periodic secret audit cycles and track follow-up actions.
+
+## Execute workflow
+
+1. Run secret rotation audit script for core staging secrets.
+2. Include mobile release secrets when requested.
+3. Classify findings into `PASS`, `STALE`, `MISSING`.
+4. Propose or execute secret sync steps when policy allows.
+5. Record remediation outcomes in docs.
+
+Read `references/commands.md` for command templates.
+
+## Enforce security policy
+
+- Never print or store raw secret values.
+- Record only status and age evidence.
+- Treat `MISSING` as blocking for related workflows.
+- Treat `STALE` as rotate-now when above policy threshold.
+
+## Sync documents when changed
+
+- `docs/SECRETS_MANAGEMENT.md`
+- `docs/runbook.md`
+- `infra/aws/README.md`
+- `docs/changelog-dev.md`
+
+## Return output
+
+Always return:
+
+- audit scope
+- stale/missing summary
+- remediation actions performed or pending
+- docs updated

--- a/skills/secrets-rotation-auditor/agents/openai.yaml
+++ b/skills/secrets-rotation-auditor/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Secrets Rotation Auditor"
+  short_description: "Audit stale or missing secrets and track rotation."
+  default_prompt: "Use $secrets-rotation-auditor to run the monthly secret rotation audit."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/secrets-rotation-auditor/references/commands.md
+++ b/skills/secrets-rotation-auditor/references/commands.md
@@ -1,0 +1,27 @@
+# Secrets Rotation Commands
+
+## Core audit
+
+```powershell
+.\scripts\staging-secret-rotation-audit.ps1 -Repo V4N1LLA/Eunhye_Hymn -MaxAgeDays 90
+```
+
+## Include mobile release secrets
+
+```powershell
+.\scripts\staging-secret-rotation-audit.ps1 -Repo V4N1LLA/Eunhye_Hymn -MaxAgeDays 90 -IncludeMobileReleaseSecrets
+```
+
+## Optional secret sync helper
+
+```powershell
+.\scripts\staging-sync-secrets.ps1 -Repo V4N1LLA/Eunhye_Hymn
+```
+
+Use only when explicit sync/update is requested.
+
+## Documentation targets
+
+- `docs/SECRETS_MANAGEMENT.md`
+- `docs/runbook.md`
+- `docs/changelog-dev.md`

--- a/skills/staging-ops-runner/SKILL.md
+++ b/skills/staging-ops-runner/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: staging-ops-runner
+description: Run and evaluate the Eunhye Hymn staging operations cycle. Use when Codex needs to execute or verify staging preflight, deploy status gates, rehearsal runs, smoke log updates, and Go/Hold decisions for staging.
+---
+
+# Staging Ops Runner
+
+Use this skill to run staging checks in a consistent order and leave auditable evidence.
+
+## Execute workflow
+
+1. Confirm target repo/branch and operator.
+2. Run preflight first unless user explicitly skips it.
+3. Run deploy gate check with `staging-latest-status.ps1`.
+4. Run full cycle with `staging-ops-cycle.ps1` when Go/Hold evidence is needed.
+5. Run rehearsal with `staging-rehearsal.ps1` when dispatch verification is needed.
+6. Record run IDs, conclusions, and decision in staging logs.
+
+Read `references/commands.md` for exact command templates.
+
+## Enforce decision policy
+
+- Mark `HOLD` when preflight fails or deploy/verify gate fails.
+- Mark `CONDITIONAL_GO` when automation passes but manual smoke is pending.
+- Mark `GO` only after required manual smoke checks pass.
+
+## Sync documents when changed
+
+- `docs/staging-smoke-log.md`
+- `docs/staging-rehearsal-log.md`
+- `docs/staging-smoke-checklist.md`
+- `docs/runbook.md`
+- `docs/changelog-dev.md`
+
+## Return output
+
+Always return:
+
+- commands run
+- preflight result
+- deploy/verify gate result
+- final decision (`GO`, `CONDITIONAL_GO`, `HOLD`)
+- log/doc files updated

--- a/skills/staging-ops-runner/agents/openai.yaml
+++ b/skills/staging-ops-runner/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Staging Ops Runner"
+  short_description: "Run preflight, gate checks, and staging decisions."
+  default_prompt: "Use $staging-ops-runner to execute staging preflight and Go/Hold checks."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/staging-ops-runner/references/commands.md
+++ b/skills/staging-ops-runner/references/commands.md
@@ -1,0 +1,40 @@
+# Staging Ops Commands
+
+## Preflight
+
+```powershell
+.\scripts\staging-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn -AutoLogin
+```
+
+Use `-AwsProfile <profile>` when needed.
+
+## Latest deploy gate
+
+```powershell
+.\scripts\staging-latest-status.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -RequireSuccess -RequireDeploySuccess -RequireVerifySuccess -MaxAgeMinutes 120 -AsJson
+```
+
+Use `-AsMarkdown` for log-ready table output.
+
+## Full ops cycle (recommended)
+
+```powershell
+.\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner <owner> -AutoLogin -WaitForCompletion
+```
+
+## Rehearsal dispatch
+
+```powershell
+.\scripts\staging-rehearsal.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref develop -AutoLogin
+```
+
+Dry-run:
+
+```powershell
+.\scripts\staging-rehearsal.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref develop -SkipPreflight -DryRun
+```
+
+## Log files
+
+- `docs/staging-smoke-log.md`
+- `docs/staging-rehearsal-log.md`


### PR DESCRIPTION
﻿## Summary
- add repository-level Codex skill pack under `skills/` for repeatable project workflows
- add `scripts/sync-skills.ps1` to sync repo skills into local `$CODEX_HOME/skills` (or `~/.codex/skills`)
- document cross-machine skill sync usage in `docs/dev-guide.md`
- add `AGENTS.md` as a practical operator guide for coding agents in this repo

## What Changed
- new skill bundles:
  - `skills/eunhye-hymn-dev-workflow`
  - `skills/staging-ops-runner`
  - `skills/release-readiness-manager`
  - `skills/docs-sync-enforcer`
  - `skills/parallel-worktree-manager`
  - `skills/mobile-store-release-runner`
  - `skills/secrets-rotation-auditor`
- new sync script:
  - `scripts/sync-skills.ps1`
- docs update:
  - `docs/dev-guide.md` (Codex skill sync section)

## Validation
- `powershell -NoProfile -File .\scripts\sync-skills.ps1 -DryRun`
- `powershell -NoProfile -File .\scripts\sync-skills.ps1 -Skill staging-ops-runner -DryRun`
- `powershell -NoProfile -File .\scripts\sync-skills.ps1 -Skill staging-ops-runner`
- `rg -n "^(<<<<<<<|=======|>>>>>>>)+$" AGENTS.md docs scripts skills`

## Notes
- this PR intentionally includes all currently local skill-related additions requested for remote sync
