### PR TITLE
feat(ops): add exception-aware ops health monitoring cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ docs/       프로젝트 문서
 - 로컬 셋업: [docs/LOCAL_SETUP.md](./docs/LOCAL_SETUP.md)
 - 개발 가이드: [docs/dev-guide.md](./docs/dev-guide.md)
 - 시크릿 관리: [docs/SECRETS_MANAGEMENT.md](./docs/SECRETS_MANAGEMENT.md)
+- 운영 헬스 로그: [docs/ops-health-log.md](./docs/ops-health-log.md)
 - 릴리즈 관리(SemVer): [docs/release-management.md](./docs/release-management.md)
 - 모노레포 CI/CD 운영: [docs/monorepo-cicd.md](./docs/monorepo-cicd.md)
 - 병렬 터미널 PR 운영: [docs/parallel-pr-workflow.md](./docs/parallel-pr-workflow.md)

--- a/docs/SECRETS_MANAGEMENT.md
+++ b/docs/SECRETS_MANAGEMENT.md
@@ -50,6 +50,9 @@
   - `STALE` means the secret age exceeded threshold and should be rotated.
   - `MISSING` means workflow-required secret setup is incomplete.
   - audit evidence is appended to `docs/secrets-rotation-log.md`.
+- For integrated operations monitoring:
+  - `.\scripts\ops-health-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch staging -Owner <operator>`
+  - consolidated health evidence is appended to `docs/ops-health-log.md`.
 - Leak response steps:
   1. Revoke/rotate leaked secret.
   2. Audit access logs and token usage.

--- a/docs/WORK_CYCLE.md
+++ b/docs/WORK_CYCLE.md
@@ -1354,3 +1354,41 @@
 - `powershell -NoProfile -File .\\scripts\\secrets-rotation-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Owner codex -MaxAgeDays 90 -IncludeMobileReleaseSecrets -LogFile .tmp\\secrets-rotation-cycle\\with-mobile.md` (현재 기준 expected fail)
 - `rg -n "secrets-rotation-cycle|secrets-rotation-log|Decision=HOLD|IncludeMobileReleaseSecrets" scripts/secrets-rotation-cycle.ps1 docs/SECRETS_MANAGEMENT.md docs/runbook.md infra/aws/README.md docs/changelog-dev.md docs/WORK_CYCLE.md docs/current-usable-scope.md`
 
+## 46. 이번 사이클 기록 (2026-02-23, ops health cycle + exception-aware monitoring)
+
+### 목표
+- 운영자가 배포 게이트/시크릿 점검/예외 원인을 한 번에 확인하고, 디버깅 가능한 구조화 출력까지 확보한다.
+
+### 범위
+- 포함: 통합 운영 헬스 사이클 스크립트 추가, JSON 출력 모드 확장, 운영 로그/문서 동기화
+- 제외: AWS 리소스 변경, 실제 시크릿 값 교체
+
+### 수행 작업
+1. 통합 운영 헬스 스크립트 추가
+- `scripts/ops-health-cycle.ps1`
+- `staging-ops-cycle.ps1` + `secrets-rotation-cycle.ps1`를 순차 실행
+- 단계별 결과를 `PASS/HOLD/ERROR`로 정규화하고 `FailureCategory` 분류
+- `docs/ops-health-log.md`에 통합 상태/증빙/노트 누적 기록
+
+2. 예외/디버깅 하드닝
+- `scripts/staging-ops-cycle.ps1`
+  - `-AsJson` 지원
+  - status 조회 실패/JSON 파싱 실패 시 구조화된 에러 payload 출력
+- `scripts/secrets-rotation-cycle.ps1`
+  - `-AsJson` 지원
+  - 집계 결과 + 상세(stale/missing/unknown) 목록 구조화 출력
+
+3. 운영 문서 동기화
+- `docs/ops-health-log.md` 신규 생성
+- `docs/runbook.md`: 통합 운영 헬스 사이클 명령/로그 반영
+- `docs/SECRETS_MANAGEMENT.md`: 통합 모니터링 경로 반영
+- `infra/aws/README.md`: 운영 명령/실패 원인 분류 로그 반영
+- `docs/current-usable-scope.md`, `docs/changelog-dev.md` 갱신
+
+### 검증
+- `powershell -NoProfile -File .\\scripts\\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner codex -SkipPreflight -SkipManualSmokeRecencyGate -MaxAgeMinutes 10000 -LogFile .tmp\\ops-health-cycle\\staging-log.md -AsJson`
+- `powershell -NoProfile -File .\\scripts\\secrets-rotation-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Owner codex -MaxAgeDays 90 -LogFile .tmp\\ops-health-cycle\\secrets-log.md -AsJson`
+- `powershell -NoProfile -File .\\scripts\\ops-health-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner codex -SkipPreflight -SkipManualSmokeRecencyGate -StagingMaxAgeMinutes 10000 -SecretsMaxAgeDays 90 -OpsHealthLogFile .tmp\\ops-health-cycle\\ops-health-log.md -StagingLogFile .tmp\\ops-health-cycle\\staging-log.md -SecretsLogFile .tmp\\ops-health-cycle\\secrets-log.md`
+- `powershell -NoProfile -File .\\scripts\\ops-health-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner codex -SkipPreflight -SkipManualSmokeRecencyGate -StagingMaxAgeMinutes 10000 -SecretsMaxAgeDays 90 -IncludeMobileReleaseSecrets -OpsHealthLogFile .tmp\\ops-health-cycle\\ops-health-log.md -StagingLogFile .tmp\\ops-health-cycle\\staging-log.md -SecretsLogFile .tmp\\ops-health-cycle\\secrets-log.md` (현재 기준 expected fail; secret missing)
+- `rg -n "ops-health-cycle|AsJson|FailureCategory|ops-health-log" scripts docs infra/aws/README.md`
+

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -32,6 +32,22 @@
   - `infra/aws/README.md`
   - `docs/current-usable-scope.md`
 
+### Ops health cycle + exception-aware monitoring hardening
+- 스크립트 추가
+  - `scripts/ops-health-cycle.ps1`
+  - staging 게이트(`staging-ops-cycle`) + 시크릿 점검(`secrets-rotation-cycle`)을 통합 실행
+  - 실패 원인 분류(`FailureCategory`) 및 통합 판정(`PASS/HOLD/ERROR`) 로그 자동 누적
+- 운영 로그 문서 추가
+  - `docs/ops-health-log.md`
+- 예외/디버깅 하드닝
+  - `scripts/staging-ops-cycle.ps1`: `-AsJson` 추가, status 조회 실패/JSON 파싱 실패 시 구조화 에러 출력 지원
+  - `scripts/secrets-rotation-cycle.ps1`: `-AsJson` 추가, 집계 결과/세부 목록 JSON 출력 지원
+- 운영 문서 동기화
+  - `docs/runbook.md`
+  - `docs/SECRETS_MANAGEMENT.md`
+  - `infra/aws/README.md`
+  - `docs/current-usable-scope.md`
+
 ## 2026-02-22
 
 ### Staging secret rotation audit automation

--- a/docs/current-usable-scope.md
+++ b/docs/current-usable-scope.md
@@ -76,6 +76,7 @@
 
 - 스테이징 수동 스모크 자동 누적/지연 게이트 운영 정착 (`staging-ops-cycle.ps1`)
 - 운영 시크릿 로테이션 점검 로그 누적/`MISSING` 항목 해소 (`secrets-rotation-cycle.ps1`)
+- 통합 운영 헬스 로그 정례화 및 실패 원인 분류 기반 대응 (`ops-health-cycle.ps1`)
 - AI 추천 운영 지표(성공률/지연/비용) 관측 지표 확정
 
 ## 5. 빠른 실행 체크리스트

--- a/docs/ops-health-log.md
+++ b/docs/ops-health-log.md
@@ -1,0 +1,6 @@
+# Ops Health Cycle Log
+
+Consolidated operations health log (staging gates + secret rotation audit).
+
+| UTC Time | Repo | Branch | Staging | Secrets | Overall | FailureCategory | Evidence | Owner | Notes |
+|----------|------|--------|---------|---------|---------|-----------------|----------|-------|-------|

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -14,6 +14,7 @@
 - `docs/staging-smoke-checklist.md`
 - `docs/staging-rehearsal-log.md`
 - `docs/staging-smoke-log.md`
+- `docs/ops-health-log.md`
 - `docs/deployment-readiness-audit.md`
 - `docs/staging-admin-login.md`
 - `infra/aws/README.md`
@@ -36,6 +37,9 @@
   - preflight + 최신 배포 게이트 + 수동 스모크 최신성(기본 7일) 게이트 + `docs/staging-smoke-log.md` 기록을 일괄 수행
   - 수동 스모크 완료 후 결과 기록:
     - `.\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch staging -Owner <담당자> -SkipPreflight -ManualSmokeResult PASS -ManualSmokeEvidence <증빙URL> [-ManualSmokeNotes "<요약>"]`
+- [ ] 통합 운영 헬스 사이클 실행(권장)
+  - `.\scripts\ops-health-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch staging -Owner <담당자> [-AutoLogin] [-WaitForCompletion]`
+  - staging 게이트 + 시크릿 로테이션 점검을 함께 실행하고 `docs/ops-health-log.md`에 결과를 누적
 - [ ] GitHub Actions 필수 Secrets 등록 확인
   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `ECR_REGISTRY`, `EC2_HOST`, `EC2_SSH_KEY`, `DEPLOY_ENV_FILE`
 - [ ] GitHub Actions 배포 워크플로 최신 성공 이력 확인
@@ -98,6 +102,9 @@
 ## 9. 정기 점검 (권장)
 - 주 1회 스테이징 배포 리허설 + 스모크 체크리스트 1회 수행
 - 주 1회 `staging-ops-cycle.ps1 -WaitForCompletion -AutoLogin` 실행 결과를 기준으로 Go/Hold 근거를 `docs/staging-smoke-log.md`에 누적
+- 주 1회 통합 운영 헬스 점검
+  - `.\scripts\ops-health-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch staging -Owner <담당자> -AutoLogin -WaitForCompletion`
+  - 결과는 `docs/ops-health-log.md`에 자동 누적되고, 실패 원인은 `FailureCategory`로 분류됨
 - 월 1회 시크릿 교체 상태 점검
   - `.\scripts\secrets-rotation-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Owner <담당자> -MaxAgeDays 90`
   - 모바일 릴리즈 시크릿 포함 점검: `.\scripts\secrets-rotation-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Owner <담당자> -MaxAgeDays 90 -IncludeMobileReleaseSecrets`

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -197,6 +197,19 @@ Terraform 적용 후 아래 스크립트로 필수 Secrets를 한 번에 동기�
   [-ManualSmokeNotes "<summary>"]
 ```
 
+통합 운영 헬스 사이클(게이트 + 시크릿 점검)을 함께 실행하려면:
+
+```powershell
+.\scripts\ops-health-cycle.ps1 `
+  -Repo V4N1LLA/Eunhye_Hymn `
+  -Branch staging `
+  -Owner <operator> `
+  [-AutoLogin] `
+  [-WaitForCompletion]
+```
+
+결과는 `docs/ops-health-log.md`에 자동 누적되며, 실패 원인은 `FailureCategory`로 분류된다.
+
 최신 배포 run 상태(특히 deploy/verify 성공 여부) 확인:
 
 ```powershell

--- a/scripts/ops-health-cycle.ps1
+++ b/scripts/ops-health-cycle.ps1
@@ -1,0 +1,385 @@
+param(
+  [string]$Repo = "V4N1LLA/Eunhye_Hymn",
+  [string]$Branch = "staging",
+  [string]$Owner = "codex",
+  [string]$OpsHealthLogFile = "docs/ops-health-log.md",
+  [switch]$SkipStagingOps,
+  [switch]$SkipSecretsRotation,
+  [int]$StagingMaxAgeMinutes = 120,
+  [int]$ManualSmokeMaxAgeDays = 7,
+  [switch]$SkipManualSmokeRecencyGate,
+  [switch]$WaitForCompletion,
+  [switch]$SkipPreflight,
+  [switch]$SkipTerraformPlan,
+  [string]$AwsProfile = "",
+  [switch]$AutoLogin,
+  [ValidateSet("", "PASS", "FAIL")]
+  [string]$ManualSmokeResult = "",
+  [string]$ManualSmokeEvidence = "",
+  [string]$ManualSmokeNotes = "",
+  [string]$StagingLogFile = "docs/staging-smoke-log.md",
+  [int]$SecretsMaxAgeDays = 90,
+  [switch]$IncludeMobileReleaseSecrets,
+  [string]$SecretsLogFile = "docs/secrets-rotation-log.md",
+  [switch]$AsJson
+)
+
+$ErrorActionPreference = "Stop"
+
+function Escape-MarkdownCell {
+  param([string]$Value)
+
+  if ($null -eq $Value) {
+    return ""
+  }
+
+  return $Value.Replace("|", "\|").Trim()
+}
+
+function Ensure-LogFile {
+  param([string]$Path)
+
+  if (Test-Path $Path) {
+    return
+  }
+
+  @"
+# Ops Health Cycle Log
+
+Consolidated operations health log (staging gates + secret rotation audit).
+
+| UTC Time | Repo | Branch | Staging | Secrets | Overall | FailureCategory | Evidence | Owner | Notes |
+|----------|------|--------|---------|---------|---------|-----------------|----------|-------|-------|
+"@ | Set-Content -Path $Path -Encoding utf8
+}
+
+function Append-LogRow {
+  param(
+    [string]$Path,
+    [hashtable]$Row
+  )
+
+  Ensure-LogFile -Path $Path
+
+  $line = "| {0} | {1} | {2} | {3} | {4} | {5} | {6} | {7} | {8} | {9} |" -f `
+    (Escape-MarkdownCell $Row.UtcTime),
+    (Escape-MarkdownCell $Row.Repo),
+    (Escape-MarkdownCell $Row.Branch),
+    (Escape-MarkdownCell $Row.Staging),
+    (Escape-MarkdownCell $Row.Secrets),
+    (Escape-MarkdownCell $Row.Overall),
+    (Escape-MarkdownCell $Row.FailureCategory),
+    (Escape-MarkdownCell $Row.Evidence),
+    (Escape-MarkdownCell $Row.Owner),
+    (Escape-MarkdownCell $Row.Notes)
+
+  Add-Content -Path $Path -Value $line -Encoding utf8
+}
+
+function Get-FirstUsefulLine {
+  param([string]$Output)
+
+  if ([string]::IsNullOrWhiteSpace($Output)) {
+    return ""
+  }
+
+  $lines = $Output -split "`r?`n" | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  if ($lines.Count -eq 0) {
+    return ""
+  }
+
+  foreach ($line in $lines) {
+    if ($line -eq "System.Management.Automation.RemoteException") { continue }
+    if ($line -like "At line:*") { continue }
+    if ($line -like "+ CategoryInfo:*") { continue }
+    if ($line -like "+ FullyQualifiedErrorId:*") { continue }
+    return $line
+  }
+
+  return $lines[0]
+}
+
+function Invoke-PowerShellFile {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ScriptPath,
+    [string[]]$Arguments = @()
+  )
+
+  $output = & powershell.exe -NoProfile -File $ScriptPath @Arguments 2>&1
+  $merged = ($output -join "`n")
+  $json = $null
+  if (-not [string]::IsNullOrWhiteSpace($merged)) {
+    try {
+      $json = $merged | ConvertFrom-Json
+    } catch {
+      $json = $null
+    }
+  }
+
+  return [PSCustomObject]@{
+    ExitCode = $LASTEXITCODE
+    Output = $merged
+    Json = $json
+  }
+}
+
+function Get-FailureCategory {
+  param(
+    [string]$Step,
+    [object]$Json,
+    [string]$Output
+  )
+
+  if ($Step -eq "staging") {
+    if ($null -ne $Json) {
+      if ($Json.ManualSmoke -eq "OVERDUE" -or "$($Json.Notes)" -match "manual smoke") {
+        return "manual_smoke_recency"
+      }
+      if ("$($Json.Notes)" -match "run too old") {
+        return "deploy_freshness"
+      }
+      if ("$($Json.Notes)" -match "session expired|credentials missing|profile not found|preflight") {
+        return "aws_preflight"
+      }
+      if ("$($Json.ErrorType)" -match "status_") {
+        return "status_query_error"
+      }
+      if ($Json.Decision -eq "HOLD") {
+        return "staging_hold"
+      }
+    }
+
+    if ($Output -match "manual smoke") { return "manual_smoke_recency" }
+    if ($Output -match "run too old") { return "deploy_freshness" }
+    if ($Output -match "session expired|credentials missing|profile not found|preflight") { return "aws_preflight" }
+    if ($Output -match "status error|status output is not valid json") { return "status_query_error" }
+    return "staging_error"
+  }
+
+  if ($Step -eq "secrets") {
+    if ($null -ne $Json) {
+      if ([int]$Json.MissingCount -gt 0) { return "secret_missing" }
+      if ([int]$Json.StaleCount -gt 0) { return "secret_stale" }
+      if ([int]$Json.UnknownCount -gt 0) { return "secret_unknown" }
+      if ($Json.Decision -eq "HOLD") { return "secrets_hold" }
+    }
+
+    if ($Output -match "missing:") { return "secret_missing" }
+    if ($Output -match "stale:") { return "secret_stale" }
+    if ($Output -match "unknown:") { return "secret_unknown" }
+    return "secrets_error"
+  }
+
+  return "unknown_error"
+}
+
+if ($StagingMaxAgeMinutes -lt 0) {
+  throw "StagingMaxAgeMinutes must be >= 0"
+}
+if ($ManualSmokeMaxAgeDays -lt 1) {
+  throw "ManualSmokeMaxAgeDays must be >= 1"
+}
+if ($SecretsMaxAgeDays -lt 1) {
+  throw "SecretsMaxAgeDays must be >= 1"
+}
+if ([string]::IsNullOrWhiteSpace($ManualSmokeResult) -and (
+    -not [string]::IsNullOrWhiteSpace($ManualSmokeEvidence) -or
+    -not [string]::IsNullOrWhiteSpace($ManualSmokeNotes)
+  )) {
+  throw "ManualSmokeEvidence/ManualSmokeNotes requires ManualSmokeResult."
+}
+if ($SkipStagingOps -and $SkipSecretsRotation) {
+  throw "At least one step must run. Remove -SkipStagingOps or -SkipSecretsRotation."
+}
+
+$stagingScript = Join-Path $PSScriptRoot "staging-ops-cycle.ps1"
+$secretsScript = Join-Path $PSScriptRoot "secrets-rotation-cycle.ps1"
+if (-not $SkipStagingOps -and -not (Test-Path $stagingScript)) {
+  throw "staging-ops-cycle.ps1 not found: $stagingScript"
+}
+if (-not $SkipSecretsRotation -and -not (Test-Path $secretsScript)) {
+  throw "secrets-rotation-cycle.ps1 not found: $secretsScript"
+}
+
+$stagingResult = [PSCustomObject]@{
+  Step = "staging"
+  Result = "SKIPPED"
+  Decision = "SKIPPED"
+  Category = ""
+  Evidence = "-"
+  Notes = ""
+  RawError = ""
+}
+
+$secretsResult = [PSCustomObject]@{
+  Step = "secrets"
+  Result = "SKIPPED"
+  Decision = "SKIPPED"
+  Category = ""
+  Evidence = "-"
+  Notes = ""
+  RawError = ""
+}
+
+if (-not $SkipStagingOps) {
+  $stagingArgs = @(
+    "-Repo", $Repo,
+    "-Branch", $Branch,
+    "-Owner", $Owner,
+    "-MaxAgeMinutes", "$StagingMaxAgeMinutes",
+    "-ManualSmokeMaxAgeDays", "$ManualSmokeMaxAgeDays",
+    "-LogFile", $StagingLogFile,
+    "-AsJson"
+  )
+  if ($SkipPreflight) { $stagingArgs += "-SkipPreflight" }
+  if ($SkipTerraformPlan) { $stagingArgs += "-SkipTerraformPlan" }
+  if ($WaitForCompletion) { $stagingArgs += "-WaitForCompletion" }
+  if ($AutoLogin) { $stagingArgs += "-AutoLogin" }
+  if (-not [string]::IsNullOrWhiteSpace($AwsProfile)) { $stagingArgs += @("-AwsProfile", $AwsProfile) }
+  if ($SkipManualSmokeRecencyGate) { $stagingArgs += "-SkipManualSmokeRecencyGate" }
+  if (-not [string]::IsNullOrWhiteSpace($ManualSmokeResult)) { $stagingArgs += @("-ManualSmokeResult", $ManualSmokeResult) }
+  if (-not [string]::IsNullOrWhiteSpace($ManualSmokeEvidence)) { $stagingArgs += @("-ManualSmokeEvidence", $ManualSmokeEvidence) }
+  if (-not [string]::IsNullOrWhiteSpace($ManualSmokeNotes)) { $stagingArgs += @("-ManualSmokeNotes", $ManualSmokeNotes) }
+
+  $stagingInvocation = Invoke-PowerShellFile -ScriptPath $stagingScript -Arguments $stagingArgs
+  if ($null -ne $stagingInvocation.Json) {
+    $stagingResult.Decision = "$($stagingInvocation.Json.Decision)"
+    $stagingResult.Evidence = if ([string]::IsNullOrWhiteSpace("$($stagingInvocation.Json.Evidence)")) { "-" } else { "$($stagingInvocation.Json.Evidence)" }
+    $stagingResult.Notes = "$($stagingInvocation.Json.Notes)"
+  } else {
+    $stagingResult.Notes = "json parse failed"
+    $stagingResult.RawError = Get-FirstUsefulLine -Output $stagingInvocation.Output
+  }
+
+  if ($stagingInvocation.ExitCode -eq 0) {
+    $stagingResult.Result = "PASS"
+    $stagingResult.Category = ""
+  } else {
+    $stagingResult.Result = if ($null -ne $stagingInvocation.Json) { "HOLD" } else { "ERROR" }
+    $stagingResult.Category = Get-FailureCategory -Step "staging" -Json $stagingInvocation.Json -Output $stagingInvocation.Output
+    if ($stagingResult.Result -eq "ERROR" -and [string]::IsNullOrWhiteSpace($stagingResult.RawError)) {
+      $stagingResult.RawError = Get-FirstUsefulLine -Output $stagingInvocation.Output
+    }
+  }
+}
+
+if (-not $SkipSecretsRotation) {
+  $secretsArgs = @(
+    "-Repo", $Repo,
+    "-MaxAgeDays", "$SecretsMaxAgeDays",
+    "-Owner", $Owner,
+    "-LogFile", $SecretsLogFile,
+    "-AsJson"
+  )
+  if ($IncludeMobileReleaseSecrets) {
+    $secretsArgs += "-IncludeMobileReleaseSecrets"
+  }
+
+  $secretsInvocation = Invoke-PowerShellFile -ScriptPath $secretsScript -Arguments $secretsArgs
+  if ($null -ne $secretsInvocation.Json) {
+    $secretsResult.Decision = "$($secretsInvocation.Json.Decision)"
+    $secretsResult.Evidence = $SecretsLogFile
+    $secretsResult.Notes = "$($secretsInvocation.Json.Notes)"
+  } else {
+    $secretsResult.Notes = "json parse failed"
+    $secretsResult.RawError = Get-FirstUsefulLine -Output $secretsInvocation.Output
+  }
+
+  if ($secretsInvocation.ExitCode -eq 0) {
+    $secretsResult.Result = "PASS"
+    $secretsResult.Category = ""
+  } else {
+    $secretsResult.Result = if ($null -ne $secretsInvocation.Json) { "HOLD" } else { "ERROR" }
+    $secretsResult.Category = Get-FailureCategory -Step "secrets" -Json $secretsInvocation.Json -Output $secretsInvocation.Output
+    if ($secretsResult.Result -eq "ERROR" -and [string]::IsNullOrWhiteSpace($secretsResult.RawError)) {
+      $secretsResult.RawError = Get-FirstUsefulLine -Output $secretsInvocation.Output
+    }
+  }
+}
+
+$overall = if ($stagingResult.Result -eq "ERROR" -or $secretsResult.Result -eq "ERROR") {
+  "ERROR"
+} elseif ($stagingResult.Result -eq "HOLD" -or $secretsResult.Result -eq "HOLD") {
+  "HOLD"
+} else {
+  "PASS"
+}
+
+$failureCategories = @()
+if (-not [string]::IsNullOrWhiteSpace($stagingResult.Category)) { $failureCategories += $stagingResult.Category }
+if (-not [string]::IsNullOrWhiteSpace($secretsResult.Category)) { $failureCategories += $secretsResult.Category }
+$failureCategory = if ($failureCategories.Count -eq 0) { "-" } else { ($failureCategories -join ",") }
+
+$notes = @()
+if ($stagingResult.Result -ne "SKIPPED") {
+  $notes += ("staging={0}/{1}" -f $stagingResult.Result, $stagingResult.Decision)
+}
+if ($secretsResult.Result -ne "SKIPPED") {
+  $notes += ("secrets={0}/{1}" -f $secretsResult.Result, $secretsResult.Decision)
+}
+if ($stagingResult.Result -eq "ERROR" -and -not [string]::IsNullOrWhiteSpace($stagingResult.RawError)) {
+  $notes += ("stagingError=" + $stagingResult.RawError)
+}
+if ($secretsResult.Result -eq "ERROR" -and -not [string]::IsNullOrWhiteSpace($secretsResult.RawError)) {
+  $notes += ("secretsError=" + $secretsResult.RawError)
+}
+
+$evidenceItems = @()
+if (-not [string]::IsNullOrWhiteSpace($stagingResult.Evidence) -and $stagingResult.Evidence -ne "-") {
+  $evidenceItems += $stagingResult.Evidence
+}
+if (-not [string]::IsNullOrWhiteSpace($secretsResult.Evidence) -and $secretsResult.Evidence -ne "-") {
+  $evidenceItems += $secretsResult.Evidence
+}
+$evidence = if ($evidenceItems.Count -eq 0) { "-" } else { ($evidenceItems -join " ; ") }
+
+$utcNow = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+Append-LogRow -Path $OpsHealthLogFile -Row @{
+  UtcTime = $utcNow
+  Repo = $Repo
+  Branch = $Branch
+  Staging = $stagingResult.Result
+  Secrets = $secretsResult.Result
+  Overall = $overall
+  FailureCategory = $failureCategory
+  Evidence = $evidence
+  Owner = $Owner
+  Notes = ($notes -join "; ")
+}
+
+$resultPayload = [PSCustomObject]@{
+  UtcTime = $utcNow
+  Repo = $Repo
+  Branch = $Branch
+  Owner = $Owner
+  Overall = $overall
+  FailureCategory = $failureCategory
+  Evidence = $evidence
+  Notes = ($notes -join "; ")
+  LogFile = $OpsHealthLogFile
+  Steps = [PSCustomObject]@{
+    Staging = $stagingResult
+    Secrets = $secretsResult
+  }
+}
+
+if ($AsJson) {
+  $resultPayload | ConvertTo-Json -Depth 8
+} else {
+  Write-Host "== Ops Health Cycle =="
+  Write-Host ("Repo: {0}" -f $Repo)
+  Write-Host ("Branch: {0}" -f $Branch)
+  Write-Host ("Staging: {0} ({1})" -f $stagingResult.Result, $stagingResult.Decision)
+  Write-Host ("Secrets: {0} ({1})" -f $secretsResult.Result, $secretsResult.Decision)
+  Write-Host ("Overall: {0}" -f $overall)
+  Write-Host ("FailureCategory: {0}" -f $failureCategory)
+  Write-Host ("Evidence: {0}" -f $evidence)
+  Write-Host ("Log: {0}" -f $OpsHealthLogFile)
+}
+
+if ($overall -eq "PASS") {
+  exit 0
+}
+
+exit 1

--- a/scripts/secrets-rotation-cycle.ps1
+++ b/scripts/secrets-rotation-cycle.ps1
@@ -3,7 +3,8 @@ param(
   [int]$MaxAgeDays = 90,
   [switch]$IncludeMobileReleaseSecrets,
   [string]$Owner = "codex",
-  [string]$LogFile = "docs/secrets-rotation-log.md"
+  [string]$LogFile = "docs/secrets-rotation-log.md",
+  [switch]$AsJson
 )
 
 $ErrorActionPreference = "Stop"
@@ -143,13 +144,37 @@ Append-LogRow -Path $LogFile -Row @{
   Notes = ($notes -join "; ")
 }
 
-Write-Host "== Secrets Rotation Cycle =="
-Write-Host ("Repo: {0}" -f $Repo)
-Write-Host ("Scope: {0}" -f $scope)
-Write-Host ("MaxAgeDays: {0}" -f $MaxAgeDays)
-Write-Host ("Summary: OK={0}, STALE={1}, MISSING={2}, UNKNOWN={3}" -f $okRows.Count, $staleRows.Count, $missingRows.Count, $unknownRows.Count)
-Write-Host ("Decision: {0}" -f $decision)
-Write-Host ("Log: {0}" -f $LogFile)
+$resultPayload = [PSCustomObject]@{
+  UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+  Repo = $Repo
+  Scope = $scope
+  MaxAgeDays = $MaxAgeDays
+  OkCount = $okRows.Count
+  StaleCount = $staleRows.Count
+  MissingCount = $missingRows.Count
+  UnknownCount = $unknownRows.Count
+  Decision = $decision
+  Owner = $Owner
+  Notes = ($notes -join "; ")
+  LogFile = $LogFile
+  Details = [PSCustomObject]@{
+    Stale = @($staleRows | Select-Object Scope, Secret, UpdatedAt, AgeDays, Status, Detail)
+    Missing = @($missingRows | Select-Object Scope, Secret, UpdatedAt, AgeDays, Status, Detail)
+    Unknown = @($unknownRows | Select-Object Scope, Secret, UpdatedAt, AgeDays, Status, Detail)
+  }
+}
+
+if ($AsJson) {
+  $resultPayload | ConvertTo-Json -Depth 8
+} else {
+  Write-Host "== Secrets Rotation Cycle =="
+  Write-Host ("Repo: {0}" -f $Repo)
+  Write-Host ("Scope: {0}" -f $scope)
+  Write-Host ("MaxAgeDays: {0}" -f $MaxAgeDays)
+  Write-Host ("Summary: OK={0}, STALE={1}, MISSING={2}, UNKNOWN={3}" -f $okRows.Count, $staleRows.Count, $missingRows.Count, $unknownRows.Count)
+  Write-Host ("Decision: {0}" -f $decision)
+  Write-Host ("Log: {0}" -f $LogFile)
+}
 
 if ($decision -eq "PASS") {
   exit 0

--- a/scripts/staging-ops-cycle.ps1
+++ b/scripts/staging-ops-cycle.ps1
@@ -14,7 +14,8 @@ param(
   [string]$ManualSmokeEvidence = "",
   [string]$ManualSmokeNotes = "",
   [int]$ManualSmokeMaxAgeDays = 7,
-  [switch]$SkipManualSmokeRecencyGate
+  [switch]$SkipManualSmokeRecencyGate,
+  [switch]$AsJson
 )
 
 $ErrorActionPreference = "Stop"
@@ -222,8 +223,9 @@ if ($WaitForCompletion) {
 $statusResult = Invoke-PowerShellFile -ScriptPath $statusScript -Arguments $statusArgs
 if ($statusResult.ExitCode -ne 0) {
   $tail = if ([string]::IsNullOrWhiteSpace($statusResult.Output)) { "status command failed" } else { $statusResult.Output.Split("`n")[-1].Trim() }
+  $errorUtc = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
   Append-LogRow -Path $LogFile -Row @{
-    UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    UtcTime = $errorUtc
     Repo = $Repo
     Branch = $Branch
     RunId = "-"
@@ -239,14 +241,37 @@ if ($statusResult.ExitCode -ne 0) {
     Owner = $Owner
     Notes = "status error: $tail"
   }
+  if ($AsJson) {
+    [PSCustomObject]@{
+      UtcTime = $errorUtc
+      Repo = $Repo
+      Branch = $Branch
+      RunId = "-"
+      HeadSha = "-"
+      Preflight = $preflightState
+      RunGate = "FAIL"
+      DeployGate = "FAIL"
+      VerifyGate = "FAIL"
+      AgeMin = "-"
+      Decision = "HOLD"
+      ManualSmoke = "NOT_STARTED"
+      ManualSmokeAgeDays = "-"
+      Evidence = "-"
+      Owner = $Owner
+      Notes = "status error: $tail"
+      ErrorType = "status_command_failed"
+    } | ConvertTo-Json -Depth 6
+    exit 1
+  }
   throw "staging status check failed: $tail"
 }
 
 try {
   $statusPayload = $statusResult.Output | ConvertFrom-Json
 } catch {
+  $errorUtc = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
   Append-LogRow -Path $LogFile -Row @{
-    UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    UtcTime = $errorUtc
     Repo = $Repo
     Branch = $Branch
     RunId = "-"
@@ -261,6 +286,28 @@ try {
     Evidence = "-"
     Owner = $Owner
     Notes = "status output is not valid json"
+  }
+  if ($AsJson) {
+    [PSCustomObject]@{
+      UtcTime = $errorUtc
+      Repo = $Repo
+      Branch = $Branch
+      RunId = "-"
+      HeadSha = "-"
+      Preflight = $preflightState
+      RunGate = "FAIL"
+      DeployGate = "FAIL"
+      VerifyGate = "FAIL"
+      AgeMin = "-"
+      Decision = "HOLD"
+      ManualSmoke = "NOT_STARTED"
+      ManualSmokeAgeDays = "-"
+      Evidence = "-"
+      Owner = $Owner
+      Notes = "status output is not valid json"
+      ErrorType = "status_json_parse_failed"
+    } | ConvertTo-Json -Depth 6
+    exit 1
   }
   throw "failed to parse status json output"
 }
@@ -368,22 +415,64 @@ Append-LogRow -Path $LogFile -Row @{
   Notes = ($notes -join "; ")
 }
 
-Write-Host "== Staging Ops Cycle =="
-Write-Host ("Repo: {0}" -f $Repo)
-Write-Host ("Branch: {0}" -f $Branch)
-Write-Host ("RunId: {0}" -f $summary.RunId)
-Write-Host ("HeadSha: {0}" -f $summary.HeadSha)
-Write-Host ("Preflight: {0}" -f $preflightState)
-Write-Host ("Gate(run/deploy/verify/age/manualRecency/manualOutcome): {0}/{1}/{2}/{3}/{4}/{5}" -f $runGate, $deployGate, $verifyGate, $ageGate, $manualSmokeRecencyGate, $manualSmokeOutcomeGate)
-Write-Host ("Decision: {0}" -f $decision)
-Write-Host ("ManualSmoke: {0}" -f $manualSmoke)
-Write-Host ("ManualSmokeAgeDays: {0}" -f $manualSmokeAgeDaysDisplay)
-Write-Host ("Log: {0}" -f $LogFile)
-Write-Host ""
-Write-Host "Update manual smoke results in:"
-Write-Host "- docs/staging-smoke-checklist.md"
-Write-Host "- docs/staging-feedback-checklist.md"
-Write-Host "- or run staging-ops-cycle with -ManualSmokeResult PASS/FAIL"
+$resultPayload = [PSCustomObject]@{
+  UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+  Repo = $Repo
+  Branch = $Branch
+  RunId = "$($summary.RunId)"
+  HeadSha = "$($summary.HeadSha)"
+  Preflight = $preflightState
+  RunGate = $(if ($runGate) { "PASS" } else { "FAIL" })
+  DeployGate = $(if ($deployGate) { "PASS" } else { "FAIL" })
+  VerifyGate = $(if ($verifyGate) { "PASS" } else { "FAIL" })
+  AgeMin = "$($summary.RunAgeMinutes)"
+  Decision = $decision
+  ManualSmoke = $manualSmoke
+  ManualSmokeAgeDays = "$manualSmokeAgeDaysDisplay"
+  Evidence = $evidence
+  Owner = $Owner
+  Notes = ($notes -join "; ")
+  Gates = [PSCustomObject]@{
+    Run = $runGate
+    Deploy = $deployGate
+    Verify = $verifyGate
+    Age = $ageGate
+    ManualRecency = $manualSmokeRecencyGate
+    ManualOutcome = $manualSmokeOutcomeGate
+  }
+  LatestManualSmoke = if ($null -eq $latestManualSmoke) {
+    $null
+  } else {
+    [PSCustomObject]@{
+      UtcTime = $latestManualSmoke.UtcTime.ToString("yyyy-MM-ddTHH:mm:ssZ")
+      ManualSmoke = $latestManualSmoke.ManualSmoke
+      Evidence = $latestManualSmoke.Evidence
+      Owner = $latestManualSmoke.Owner
+      Notes = $latestManualSmoke.Notes
+    }
+  }
+}
+
+if ($AsJson) {
+  $resultPayload | ConvertTo-Json -Depth 8
+} else {
+  Write-Host "== Staging Ops Cycle =="
+  Write-Host ("Repo: {0}" -f $Repo)
+  Write-Host ("Branch: {0}" -f $Branch)
+  Write-Host ("RunId: {0}" -f $summary.RunId)
+  Write-Host ("HeadSha: {0}" -f $summary.HeadSha)
+  Write-Host ("Preflight: {0}" -f $preflightState)
+  Write-Host ("Gate(run/deploy/verify/age/manualRecency/manualOutcome): {0}/{1}/{2}/{3}/{4}/{5}" -f $runGate, $deployGate, $verifyGate, $ageGate, $manualSmokeRecencyGate, $manualSmokeOutcomeGate)
+  Write-Host ("Decision: {0}" -f $decision)
+  Write-Host ("ManualSmoke: {0}" -f $manualSmoke)
+  Write-Host ("ManualSmokeAgeDays: {0}" -f $manualSmokeAgeDaysDisplay)
+  Write-Host ("Log: {0}" -f $LogFile)
+  Write-Host ""
+  Write-Host "Update manual smoke results in:"
+  Write-Host "- docs/staging-smoke-checklist.md"
+  Write-Host "- docs/staging-feedback-checklist.md"
+  Write-Host "- or run staging-ops-cycle with -ManualSmokeResult PASS/FAIL"
+}
 
 if ($decision -eq "CONDITIONAL_GO") {
   exit 0

--- a/skills/secrets-rotation-auditor/SKILL.md
+++ b/skills/secrets-rotation-auditor/SKILL.md
@@ -12,8 +12,9 @@ Use this skill to perform periodic secret audit cycles and track follow-up actio
 1. Run secret rotation audit script for core staging secrets.
 2. Include mobile release secrets when requested.
 3. Classify findings into `PASS`, `STALE`, `MISSING`.
-4. Propose or execute secret sync steps when policy allows.
-5. Record remediation outcomes in docs.
+4. Run `secrets-rotation-cycle.ps1` for repeatable logging and decision tracking.
+5. Propose or execute secret sync steps when policy allows.
+6. Record remediation outcomes in docs.
 
 Read `references/commands.md` for command templates.
 
@@ -29,6 +30,7 @@ Read `references/commands.md` for command templates.
 - `docs/SECRETS_MANAGEMENT.md`
 - `docs/runbook.md`
 - `infra/aws/README.md`
+- `docs/secrets-rotation-log.md`
 - `docs/changelog-dev.md`
 
 ## Return output

--- a/skills/secrets-rotation-auditor/references/commands.md
+++ b/skills/secrets-rotation-auditor/references/commands.md
@@ -1,6 +1,6 @@
 # Secrets Rotation Commands
 
-## Core audit
+## Core audit (raw)
 
 ```powershell
 .\scripts\staging-secret-rotation-audit.ps1 -Repo V4N1LLA/Eunhye_Hymn -MaxAgeDays 90
@@ -20,8 +20,27 @@
 
 Use only when explicit sync/update is requested.
 
+## Rotation cycle (recommended)
+
+```powershell
+.\scripts\secrets-rotation-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Owner <operator> -MaxAgeDays 90
+```
+
+Include mobile release scope:
+
+```powershell
+.\scripts\secrets-rotation-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Owner <operator> -MaxAgeDays 90 -IncludeMobileReleaseSecrets
+```
+
+JSON output for automation/debugging:
+
+```powershell
+.\scripts\secrets-rotation-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Owner <operator> -MaxAgeDays 90 -AsJson
+```
+
 ## Documentation targets
 
 - `docs/SECRETS_MANAGEMENT.md`
 - `docs/runbook.md`
+- `docs/secrets-rotation-log.md`
 - `docs/changelog-dev.md`

--- a/skills/staging-ops-runner/SKILL.md
+++ b/skills/staging-ops-runner/SKILL.md
@@ -14,7 +14,8 @@ Use this skill to run staging checks in a consistent order and leave auditable e
 3. Run deploy gate check with `staging-latest-status.ps1`.
 4. Run full cycle with `staging-ops-cycle.ps1` when Go/Hold evidence is needed.
 5. Run rehearsal with `staging-rehearsal.ps1` when dispatch verification is needed.
-6. Record run IDs, conclusions, and decision in staging logs.
+6. Run `ops-health-cycle.ps1` when consolidated ops health evidence is needed.
+7. Record run IDs, conclusions, and decision in staging logs.
 
 Read `references/commands.md` for exact command templates.
 
@@ -28,6 +29,7 @@ Read `references/commands.md` for exact command templates.
 
 - `docs/staging-smoke-log.md`
 - `docs/staging-rehearsal-log.md`
+- `docs/ops-health-log.md`
 - `docs/staging-smoke-checklist.md`
 - `docs/runbook.md`
 - `docs/changelog-dev.md`

--- a/skills/staging-ops-runner/references/commands.md
+++ b/skills/staging-ops-runner/references/commands.md
@@ -22,6 +22,18 @@ Use `-AsMarkdown` for log-ready table output.
 .\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner <owner> -AutoLogin -WaitForCompletion
 ```
 
+Record manual smoke result:
+
+```powershell
+.\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner <owner> -SkipPreflight -ManualSmokeResult PASS -ManualSmokeEvidence <evidence-url>
+```
+
+JSON output for automation/debugging:
+
+```powershell
+.\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner <owner> -SkipPreflight -AsJson
+```
+
 ## Rehearsal dispatch
 
 ```powershell
@@ -38,3 +50,12 @@ Dry-run:
 
 - `docs/staging-smoke-log.md`
 - `docs/staging-rehearsal-log.md`
+- `docs/ops-health-log.md`
+
+## Consolidated health cycle
+
+```powershell
+.\scripts\ops-health-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner <owner> -AutoLogin -WaitForCompletion
+```
+
+This combines staging gates + secrets rotation checks and classifies failures.


### PR DESCRIPTION
## Summary
- add `scripts/ops-health-cycle.ps1` to consolidate staging gate checks and secret-rotation checks into one ops health run
- classify failures with `FailureCategory` and append evidence rows to new `docs/ops-health-log.md`
- harden debugging/exception visibility by adding JSON output mode to:
  - `scripts/staging-ops-cycle.ps1` (`-AsJson`, including structured error payload for status/parse failures)
  - `scripts/secrets-rotation-cycle.ps1` (`-AsJson`, including stale/missing/unknown detail lists)
- sync operations docs and skill references for new monitoring flow

## Validation
- `powershell -NoProfile -File .\\scripts\\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner codex -SkipPreflight -SkipManualSmokeRecencyGate -MaxAgeMinutes 10000 -LogFile .tmp\\ops-health-cycle\\staging-log.md -AsJson` (pass)
- `powershell -NoProfile -File .\\scripts\\secrets-rotation-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Owner codex -MaxAgeDays 90 -LogFile .tmp\\ops-health-cycle\\secrets-log.md -AsJson` (pass)
- `powershell -NoProfile -File .\\scripts\\ops-health-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner codex -SkipPreflight -SkipManualSmokeRecencyGate -StagingMaxAgeMinutes 10000 -SecretsMaxAgeDays 90 -OpsHealthLogFile .tmp\\ops-health-cycle\\ops-health-log.md -StagingLogFile .tmp\\ops-health-cycle\\staging-log.md -SecretsLogFile .tmp\\ops-health-cycle\\secrets-log.md -AsJson` (pass)
- `powershell -NoProfile -File .\\scripts\\ops-health-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner codex -SkipPreflight -SkipManualSmokeRecencyGate -StagingMaxAgeMinutes 10000 -SecretsMaxAgeDays 90 -IncludeMobileReleaseSecrets -OpsHealthLogFile .tmp\\ops-health-cycle\\ops-health-log.md -StagingLogFile .tmp\\ops-health-cycle\\staging-log.md -SecretsLogFile .tmp\\ops-health-cycle\\secrets-log.md -AsJson` (expected fail; secret missing)
- `rg -n "ops-health-cycle|ops-health-log|AsJson|FailureCategory" README.md docs infra/aws/README.md scripts skills` (pass)
- `rg -n "^(<<<<<<<|>>>>>>>|=======)$" README.md docs CLAUDE.md scripts/ops-health-cycle.ps1 scripts/staging-ops-cycle.ps1 scripts/secrets-rotation-cycle.ps1` (pass; no matches)

## Risks
- `-IncludeMobileReleaseSecrets` mode intentionally returns `HOLD` until missing mobile secrets are provisioned
- `ops-health-cycle` depends on markdown log schemas for staging/secrets scripts; column-order changes should keep parsers aligned
