### PR TITLE
fix(ops): apply pending review refactors from recent PR comments

### DIFF
--- a/.github/workflows/secrets-rotation-scheduled.yml
+++ b/.github/workflows/secrets-rotation-scheduled.yml
@@ -33,7 +33,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       OPERATOR: ${{ github.event_name == 'workflow_dispatch' && inputs.owner || 'github-actions' }}
       MAX_AGE_DAYS: ${{ github.event_name == 'workflow_dispatch' && inputs.max_age_days || '90' }}
-      INCLUDE_MOBILE_RELEASE_SECRETS: ${{ github.event_name == 'workflow_dispatch' && inputs.include_mobile_release_secrets || 'true' }}
+      INCLUDE_MOBILE_RELEASE_SECRETS: ${{ github.event_name == 'workflow_dispatch' && (inputs.include_mobile_release_secrets && 'true' || 'false') || 'true' }}
       TARGET_BRANCH: develop
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 ﻿# CLAUDE.md - Eunhye Hymn 프로젝트 컨텍스트
 
 > 이 파일은 Claude Code가 프로젝트를 빠르게 파악하고 작업할 수 있도록 작성된 종합 레퍼런스입니다.
-> 마지막 업데이트: 2026-02-23
+> 마지막 업데이트: 2026-02-24
 > 정합성 기준 문서: `docs/api-contract.md`, `docs/data-model.md`, `.env.example`, `apps/api/.env.example`
 
 ---
@@ -757,6 +757,12 @@ develop push → GitHub Actions
   - `docs/deployment-readiness-audit.md` (최신 Actions 실행 근거/잔여 리스크 갱신)
 - 개발 변경 이력 동기화
   - `docs/changelog-dev.md`
+- 리뷰 코멘트 후속 리팩토링 반영 (2026-02-24)
+  - `scripts/ops-health-cycle.ps1`: 수동 스모크 recency 분류 정밀화 + cross-platform 하위 스크립트 실행
+  - `scripts/staging-ops-cycle.ps1`, `scripts/secrets-rotation-cycle.ps1`: cross-platform PowerShell 실행기 선택
+  - `scripts/sync-skills.ps1`: source/destination 경로 겹침 방지 가드 추가
+  - `.github/workflows/secrets-rotation-scheduled.yml`: workflow_dispatch boolean false 보존
+  - `skills/secrets-rotation-auditor/references/commands.md`: 필수 인자 누락 예시 보강
 - 스테이징 실가동 체크리스트/런북 동기화
   - `docs/staging-smoke-checklist.md`
   - `docs/runbook.md`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -2,6 +2,27 @@
 
 작업 단위별 핵심 변경만 기록한다. 상세 구현은 각 PR 본문과 커밋 로그를 참고한다.
 
+## 2026-02-24
+
+### Review-comment refactor follow-up
+- Script reliability hardening
+  - `scripts/ops-health-cycle.ps1`
+  - `scripts/staging-ops-cycle.ps1`
+  - `scripts/secrets-rotation-cycle.ps1`
+  - Switched nested script invocation to cross-platform PowerShell command resolution (`powershell.exe`/`pwsh`)
+- Failure-category precision update
+  - `scripts/ops-health-cycle.ps1`
+  - Narrowed manual-smoke recency detection to explicit recency failure signals only
+- Safety guard for skill sync
+  - `scripts/sync-skills.ps1`
+  - Added source/destination overlap guard to prevent destructive self-sync path combinations
+- Workflow input correctness
+  - `.github/workflows/secrets-rotation-scheduled.yml`
+  - Preserved explicit `false` for `include_mobile_release_secrets` on manual dispatch
+- Skill reference sync
+  - `skills/secrets-rotation-auditor/references/commands.md`
+  - Added required parameters to the `staging-sync-secrets.ps1` command example
+
 ## 2026-02-23
 
 ### Staging manual smoke recency gate + log automation

--- a/scripts/ops-health-cycle.ps1
+++ b/scripts/ops-health-cycle.ps1
@@ -29,6 +29,21 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+function Test-CommandExists {
+  param([string]$Name)
+  return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Get-PowerShellCommand {
+  if (Test-CommandExists "powershell.exe") {
+    return "powershell.exe"
+  }
+  if (Test-CommandExists "pwsh") {
+    return "pwsh"
+  }
+  return ""
+}
+
 function Escape-MarkdownCell {
   param([string]$Value)
 
@@ -120,7 +135,11 @@ function Invoke-PowerShellFile {
     [string[]]$Arguments = @()
   )
 
-  $output = & powershell.exe -NoProfile -File $ScriptPath @Arguments 2>&1
+  if ([string]::IsNullOrWhiteSpace($script:PowerShellCommand)) {
+    throw "missing powershell command (powershell.exe/pwsh)"
+  }
+
+  $output = & $script:PowerShellCommand -NoProfile -File $ScriptPath @Arguments 2>&1
   $merged = ($output -join "`n")
   $json = $null
   if (-not [string]::IsNullOrWhiteSpace($merged)) {
@@ -145,15 +164,18 @@ function Get-FailureCategory {
     [string]$Output
   )
 
+  $manualSmokeRecencyPattern = "ManualSmoke=OVERDUE|manual smoke recency gate failed|manual smoke record missing|manual smoke stale"
+
   if ($Step -eq "staging") {
     if ($null -ne $Json) {
-      if ($Json.ManualSmoke -eq "OVERDUE" -or "$($Json.Notes)" -match "manual smoke") {
+      $notesText = "$($Json.Notes)"
+      if ($Json.ManualSmoke -eq "OVERDUE" -or $notesText -match $manualSmokeRecencyPattern) {
         return "manual_smoke_recency"
       }
-      if ("$($Json.Notes)" -match "run too old") {
+      if ($notesText -match "run too old") {
         return "deploy_freshness"
       }
-      if ("$($Json.Notes)" -match "session expired|credentials missing|profile not found|preflight") {
+      if ($notesText -match "session expired|credentials missing|profile not found|preflight") {
         return "aws_preflight"
       }
       if ("$($Json.ErrorType)" -match "status_") {
@@ -164,7 +186,7 @@ function Get-FailureCategory {
       }
     }
 
-    if ($Output -match "manual smoke") { return "manual_smoke_recency" }
+    if ($Output -match $manualSmokeRecencyPattern) { return "manual_smoke_recency" }
     if ($Output -match "run too old") { return "deploy_freshness" }
     if ($Output -match "session expired|credentials missing|profile not found|preflight") { return "aws_preflight" }
     if ($Output -match "status error|status output is not valid json") { return "status_query_error" }
@@ -186,6 +208,11 @@ function Get-FailureCategory {
   }
 
   return "unknown_error"
+}
+
+$script:PowerShellCommand = Get-PowerShellCommand
+if ([string]::IsNullOrWhiteSpace($script:PowerShellCommand)) {
+  throw "missing powershell command (powershell.exe/pwsh)"
 }
 
 if ($StagingMaxAgeMinutes -lt 0) {

--- a/scripts/secrets-rotation-cycle.ps1
+++ b/scripts/secrets-rotation-cycle.ps1
@@ -13,6 +13,21 @@ if ($MaxAgeDays -lt 1) {
   throw "MaxAgeDays must be >= 1"
 }
 
+function Test-CommandExists {
+  param([string]$Name)
+  return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Get-PowerShellCommand {
+  if (Test-CommandExists "powershell.exe") {
+    return "powershell.exe"
+  }
+  if (Test-CommandExists "pwsh") {
+    return "pwsh"
+  }
+  return ""
+}
+
 function Escape-MarkdownCell {
   param([string]$Value)
 
@@ -82,11 +97,20 @@ function Invoke-PowerShellFile {
     [string[]]$Arguments = @()
   )
 
-  $output = & powershell.exe -NoProfile -File $ScriptPath @Arguments 2>&1
+  if ([string]::IsNullOrWhiteSpace($script:PowerShellCommand)) {
+    throw "missing powershell command (powershell.exe/pwsh)"
+  }
+
+  $output = & $script:PowerShellCommand -NoProfile -File $ScriptPath @Arguments 2>&1
   return [PSCustomObject]@{
     ExitCode = $LASTEXITCODE
     Output = ($output -join "`n")
   }
+}
+
+$script:PowerShellCommand = Get-PowerShellCommand
+if ([string]::IsNullOrWhiteSpace($script:PowerShellCommand)) {
+  throw "missing powershell command (powershell.exe/pwsh)"
 }
 
 $auditScript = Join-Path $PSScriptRoot "staging-secret-rotation-audit.ps1"

--- a/scripts/staging-ops-cycle.ps1
+++ b/scripts/staging-ops-cycle.ps1
@@ -20,6 +20,21 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+function Test-CommandExists {
+  param([string]$Name)
+  return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Get-PowerShellCommand {
+  if (Test-CommandExists "powershell.exe") {
+    return "powershell.exe"
+  }
+  if (Test-CommandExists "pwsh") {
+    return "pwsh"
+  }
+  return ""
+}
+
 function Escape-MarkdownCell {
   param([string]$Value)
 
@@ -93,7 +108,11 @@ function Invoke-PowerShellFile {
     [string[]]$Arguments = @()
   )
 
-  $output = & powershell.exe -NoProfile -File $ScriptPath @Arguments 2>&1
+  if ([string]::IsNullOrWhiteSpace($script:PowerShellCommand)) {
+    throw "missing powershell command (powershell.exe/pwsh)"
+  }
+
+  $output = & $script:PowerShellCommand -NoProfile -File $ScriptPath @Arguments 2>&1
   return [PSCustomObject]@{
     ExitCode = $LASTEXITCODE
     Output = ($output -join "`n")
@@ -162,6 +181,11 @@ function Get-LatestManualSmokeRecord {
   }
 
   return $latest
+}
+
+$script:PowerShellCommand = Get-PowerShellCommand
+if ([string]::IsNullOrWhiteSpace($script:PowerShellCommand)) {
+  throw "missing powershell command (powershell.exe/pwsh)"
 }
 
 if ($MaxAgeMinutes -lt 0) {

--- a/scripts/sync-skills.ps1
+++ b/scripts/sync-skills.ps1
@@ -22,6 +22,39 @@ function Resolve-RepoPath {
   return [System.IO.Path]::GetFullPath((Join-Path $RepoRoot $PathValue))
 }
 
+function Normalize-DirectoryPath {
+  param([string]$PathValue)
+
+  if ([string]::IsNullOrWhiteSpace($PathValue)) {
+    return ""
+  }
+
+  $fullPath = [System.IO.Path]::GetFullPath($PathValue)
+  return $fullPath.TrimEnd('\', '/')
+}
+
+function Test-PathOverlap {
+  param(
+    [string]$PathA,
+    [string]$PathB
+  )
+
+  $normalizedA = Normalize-DirectoryPath -PathValue $PathA
+  $normalizedB = Normalize-DirectoryPath -PathValue $PathB
+  if ([string]::IsNullOrWhiteSpace($normalizedA) -or [string]::IsNullOrWhiteSpace($normalizedB)) {
+    return $false
+  }
+
+  if ($normalizedA -ieq $normalizedB) {
+    return $true
+  }
+
+  $prefixA = $normalizedA + [System.IO.Path]::DirectorySeparatorChar
+  $prefixB = $normalizedB + [System.IO.Path]::DirectorySeparatorChar
+  return $normalizedA.StartsWith($prefixB, [System.StringComparison]::OrdinalIgnoreCase) -or
+    $normalizedB.StartsWith($prefixA, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
 function Get-CodexHome {
   if (-not [string]::IsNullOrWhiteSpace($env:CODEX_HOME)) {
     return $env:CODEX_HOME
@@ -65,6 +98,10 @@ $destRoot = if ([string]::IsNullOrWhiteSpace($DestDir)) {
   Join-Path (Get-CodexHome) "skills"
 } else {
   Resolve-RepoPath -RepoRoot $repoRoot -PathValue $DestDir
+}
+
+if (Test-PathOverlap -PathA $sourceRoot -PathB $destRoot) {
+  throw ("SourceDir and DestDir must not be identical or nested. source={0}, dest={1}" -f $sourceRoot, $destRoot)
 }
 
 $allSkillDirs = Get-ChildItem -LiteralPath $sourceRoot -Directory |

--- a/skills/secrets-rotation-auditor/references/commands.md
+++ b/skills/secrets-rotation-auditor/references/commands.md
@@ -15,7 +15,13 @@
 ## Optional secret sync helper
 
 ```powershell
-.\scripts\staging-sync-secrets.ps1 -Repo V4N1LLA/Eunhye_Hymn
+.\scripts\staging-sync-secrets.ps1 `
+  -Repo V4N1LLA/Eunhye_Hymn `
+  -Ec2Host <ec2-host> `
+  -Ec2SshKeyPath <path-to-pem> `
+  -DbPassword <db-password> `
+  -JwtSecret <jwt-secret> `
+  -InviteCode <invite-code>
 ```
 
 Use only when explicit sync/update is requested.


### PR DESCRIPTION
﻿## Summary
- address remaining review-comment refactors across recent merged PRs (#119/#120/#122/#123)
- make nested PowerShell script invocation cross-platform (`powershell.exe`/`pwsh`) in ops cycle scripts
- narrow manual-smoke recency failure categorization to explicit recency failure signals
- prevent destructive self-sync path overlap in `scripts/sync-skills.ps1`
- preserve explicit `false` for `include_mobile_release_secrets` in `secrets-rotation-scheduled` workflow_dispatch
- update secret rotation skill command reference with required `staging-sync-secrets.ps1` arguments
- sync `docs/changelog-dev.md` and `CLAUDE.md`

## Changed Files
- `.github/workflows/secrets-rotation-scheduled.yml`
- `scripts/ops-health-cycle.ps1`
- `scripts/staging-ops-cycle.ps1`
- `scripts/secrets-rotation-cycle.ps1`
- `scripts/sync-skills.ps1`
- `skills/secrets-rotation-auditor/references/commands.md`
- `docs/changelog-dev.md`
- `CLAUDE.md`

## Validation
- PowerShell parse check
  - `[PASS] scripts/ops-health-cycle.ps1`
  - `[PASS] scripts/staging-ops-cycle.ps1`
  - `[PASS] scripts/secrets-rotation-cycle.ps1`
  - `[PASS] scripts/sync-skills.ps1`
- `powershell -NoProfile -File .\\scripts\\sync-skills.ps1 -Skill secrets-rotation-auditor -DryRun`
- overlap guard negative test (expected failure path) verified
- merge-marker scan: no conflict markers in `README.md`, `docs/**`, `CLAUDE.md`
- `actionlint`: skipped locally (not installed)
