### PR TITLE
refactor(ops): harden script invocation compatibility and run detection

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -174,7 +174,7 @@ jobs:
         env:
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
           IMAGE_TAG: ${{ github.sha }}
-          ENABLE_AWSLOGS: ${{ github.event_name == 'workflow_dispatch' && inputs.enable_awslogs || secrets.ENABLE_AWSLOGS }}
+          ENABLE_AWSLOGS: ${{ github.event_name == 'workflow_dispatch' && (inputs.enable_awslogs && 'true' || 'false') || secrets.ENABLE_AWSLOGS }}
         run: |
           ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
             ec2-user@${{ secrets.EC2_HOST }} \

--- a/.github/workflows/ops-health-scheduled.yml
+++ b/.github/workflows/ops-health-scheduled.yml
@@ -54,8 +54,8 @@ jobs:
       STAGING_MAX_AGE_MINUTES: ${{ github.event_name == 'workflow_dispatch' && inputs.staging_max_age_minutes || '240' }}
       MANUAL_SMOKE_MAX_AGE_DAYS: ${{ github.event_name == 'workflow_dispatch' && inputs.manual_smoke_max_age_days || '7' }}
       SECRETS_MAX_AGE_DAYS: ${{ github.event_name == 'workflow_dispatch' && inputs.secrets_max_age_days || '90' }}
-      INCLUDE_MOBILE_RELEASE_SECRETS: ${{ github.event_name == 'workflow_dispatch' && inputs.include_mobile_release_secrets || 'false' }}
-      WAIT_FOR_COMPLETION: ${{ github.event_name == 'workflow_dispatch' && inputs.wait_for_completion || 'false' }}
+      INCLUDE_MOBILE_RELEASE_SECRETS: ${{ github.event_name == 'workflow_dispatch' && (inputs.include_mobile_release_secrets && 'true' || 'false') || 'false' }}
+      WAIT_FOR_COMPLETION: ${{ github.event_name == 'workflow_dispatch' && (inputs.wait_for_completion && 'true' || 'false') || 'false' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -763,6 +763,10 @@ develop push → GitHub Actions
   - `scripts/sync-skills.ps1`: source/destination 경로 겹침 방지 가드 추가
   - `.github/workflows/secrets-rotation-scheduled.yml`: workflow_dispatch boolean false 보존
   - `skills/secrets-rotation-auditor/references/commands.md`: 필수 인자 누락 예시 보강
+- 운영 스크립트 호환성 후속 반영 (2026-02-24)
+  - `scripts/staging-rehearsal.ps1`: preflight 실행기 cross-platform 처리 + 동시 dispatch 환경 run 선택 안정화(earliest/new-run 기준)
+  - `scripts/mobile-store-cycle.ps1`: preflight 호출 실행기 cross-platform 처리
+  - `scripts/run-mobile-emulator.ps1`: flutter wrapper 호출 실행기 cross-platform 처리
 - 스테이징 실가동 체크리스트/런북 동기화
   - `docs/staging-smoke-checklist.md`
   - `docs/runbook.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -767,6 +767,7 @@ develop push → GitHub Actions
   - `scripts/staging-rehearsal.ps1`: preflight 실행기 cross-platform 처리 + 동시 dispatch 환경 run 선택 안정화(earliest/new-run 기준)
   - `scripts/mobile-store-cycle.ps1`: preflight 호출 실행기 cross-platform 처리
   - `scripts/run-mobile-emulator.ps1`: flutter wrapper 호출 실행기 cross-platform 처리
+  - `.github/workflows/deploy-staging.yml`, `.github/workflows/ops-health-scheduled.yml`: workflow_dispatch boolean 입력 false 보존식으로 정규화
 - 스테이징 실가동 체크리스트/런북 동기화
   - `docs/staging-smoke-checklist.md`
   - `docs/runbook.md`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -32,6 +32,10 @@
 - Rehearsal run-detection reliability
   - `scripts/staging-rehearsal.ps1`
   - Added baseline run-id tracking and earliest-post-dispatch selection to reduce concurrent workflow run misattribution
+- Workflow dispatch boolean hardening
+  - `.github/workflows/deploy-staging.yml`
+  - `.github/workflows/ops-health-scheduled.yml`
+  - Preserved explicit `false` values for workflow_dispatch boolean inputs (`enable_awslogs`, `include_mobile_release_secrets`, `wait_for_completion`)
 
 ## 2026-02-23
 

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -23,6 +23,16 @@
   - `skills/secrets-rotation-auditor/references/commands.md`
   - Added required parameters to the `staging-sync-secrets.ps1` command example
 
+### Ops script compatibility follow-up
+- Cross-platform PowerShell invocation hardening
+  - `scripts/mobile-store-cycle.ps1`
+  - `scripts/staging-rehearsal.ps1`
+  - `scripts/run-mobile-emulator.ps1`
+  - Replaced remaining direct `powershell.exe` script-launch usage with `powershell.exe`/`pwsh` resolution
+- Rehearsal run-detection reliability
+  - `scripts/staging-rehearsal.ps1`
+  - Added baseline run-id tracking and earliest-post-dispatch selection to reduce concurrent workflow run misattribution
+
 ## 2026-02-23
 
 ### Staging manual smoke recency gate + log automation

--- a/scripts/mobile-store-cycle.ps1
+++ b/scripts/mobile-store-cycle.ps1
@@ -87,7 +87,11 @@ function Invoke-PowerShellFile {
     [string[]]$Arguments = @()
   )
 
-  $output = & powershell.exe -NoProfile -File $ScriptPath @Arguments 2>&1
+  if ([string]::IsNullOrWhiteSpace($script:PowerShellCommand)) {
+    throw "missing powershell command (powershell.exe/pwsh)"
+  }
+
+  $output = & $script:PowerShellCommand -NoProfile -File $ScriptPath @Arguments 2>&1
   return [PSCustomObject]@{
     ExitCode = $LASTEXITCODE
     Output = ($output -join "`n")
@@ -99,8 +103,23 @@ function Test-CommandExists {
   return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
 }
 
+function Get-PowerShellCommand {
+  if (Test-CommandExists "powershell.exe") {
+    return "powershell.exe"
+  }
+  if (Test-CommandExists "pwsh") {
+    return "pwsh"
+  }
+  return ""
+}
+
 if (-not (Test-CommandExists "gh")) {
   throw "gh CLI is required."
+}
+
+$script:PowerShellCommand = Get-PowerShellCommand
+if ([string]::IsNullOrWhiteSpace($script:PowerShellCommand)) {
+  throw "missing powershell command (powershell.exe/pwsh)"
 }
 
 $preflightState = "SKIPPED"

--- a/scripts/mobile-store-cycle.ps1
+++ b/scripts/mobile-store-cycle.ps1
@@ -179,9 +179,6 @@ if ($DryRun) {
   exit 0
 }
 
-$triggeredAfter = (Get-Date).ToUniversalTime()
-# Use a small skew buffer for fallback in case local and GitHub API clocks differ slightly.
-$dispatchWindowStart = $triggeredAfter.AddMinutes(-2)
 $baselineRuns = gh run list --repo $Repo --workflow $Workflow --branch $Ref --event workflow_dispatch --limit 30 --json databaseId 2>$null
 $knownRunIds = @{}
 if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($baselineRuns)) {
@@ -197,6 +194,10 @@ if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($baselineRuns)) {
     # Best-effort baseline only.
   }
 }
+
+$triggeredAfter = (Get-Date).ToUniversalTime()
+# Use a small skew buffer for fallback in case local and GitHub API clocks differ slightly.
+$dispatchWindowStart = $triggeredAfter.AddMinutes(-2)
 
 $workflowArgs = @(
   "workflow", "run", $Workflow,

--- a/scripts/run-mobile-emulator.ps1
+++ b/scripts/run-mobile-emulator.ps1
@@ -47,23 +47,38 @@ function Read-EnvValue {
 }
 
 function Read-JsonValue {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string] $Path,
-        [Parameter(Mandatory = $true)]
-        [string] $Name
-    )
+  param(
+    [Parameter(Mandatory = $true)]
+    [string] $Path,
+    [Parameter(Mandatory = $true)]
+    [string] $Name
+  )
 
-    $raw = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
-    if ([string]::IsNullOrWhiteSpace($raw)) {
-        return $null
-    }
-    $json = $raw | ConvertFrom-Json
-    $value = $json.$Name
-    if ($null -eq $value) {
-        return $null
-    }
-    return $value.ToString()
+  $raw = Get-Content -LiteralPath $Path -Raw -Encoding UTF8
+  if ([string]::IsNullOrWhiteSpace($raw)) {
+    return $null
+  }
+  $json = $raw | ConvertFrom-Json
+  $value = $json.$Name
+  if ($null -eq $value) {
+    return $null
+  }
+  return $value.ToString()
+}
+
+function Test-CommandExists {
+  param([string] $Name)
+  return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Get-PowerShellCommand {
+  if (Test-CommandExists "powershell.exe") {
+    return "powershell.exe"
+  }
+  if (Test-CommandExists "pwsh") {
+    return "pwsh"
+  }
+  return ""
 }
 
 $profileApiBaseUrl = Read-JsonValue -Path $profileFile -Name "API_BASE_URL"
@@ -100,6 +115,11 @@ if ([string]::IsNullOrWhiteSpace($resolvedKakaoKey)) {
     throw "KAKAO_NATIVE_APP_KEY is required. Set it in apps/mobile/.env, .env, or pass -KakaoNativeAppKey."
 }
 
+$powerShellCommand = Get-PowerShellCommand
+if ([string]::IsNullOrWhiteSpace($powerShellCommand)) {
+    throw "missing powershell command (powershell.exe/pwsh)"
+}
+
 $dartDefines = @(
     "--dart-define-from-file=" + $profileFile
     "--dart-define=KAKAO_NATIVE_APP_KEY=" + $resolvedKakaoKey.Trim()
@@ -112,7 +132,7 @@ if ($resolvedApiBaseUrl.Trim() -ne $profileApiBaseUrl) {
 Push-Location $mobileDir
 try {
     Write-Host ("[run-mobile-emulator] environment={0} api={1}" -f $Environment, $resolvedApiBaseUrl.Trim())
-    & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $flutterWrapper run -d $DeviceId @dartDefines
+    & $powerShellCommand -NoProfile -ExecutionPolicy Bypass -File $flutterWrapper run -d $DeviceId @dartDefines
 } finally {
     Pop-Location
 }

--- a/scripts/staging-rehearsal.ps1
+++ b/scripts/staging-rehearsal.ps1
@@ -113,6 +113,7 @@ if (-not $SkipPreflight) {
   }
 
   $preflightArgs = @(
+    "-NoProfile",
     "-File", $preflightScript,
     "-Repo", $Repo
   )
@@ -135,8 +136,6 @@ if (-not $SkipPreflight) {
   $preflightStatus = "PASS"
 }
 
-$triggeredAfter = (Get-Date).ToUniversalTime()
-$dispatchWindowStart = $triggeredAfter.AddMinutes(-2)
 $enableValue = if ($EnableAwsLogs) { "true" } else { "false" }
 
 if (Test-CommitShaRef -Value $Ref) {
@@ -168,6 +167,9 @@ if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($baselineRuns)) {
     # Best-effort baseline only.
   }
 }
+
+$triggeredAfter = (Get-Date).ToUniversalTime()
+$dispatchWindowStart = $triggeredAfter.AddMinutes(-2)
 
 Invoke-CommandStrict -Name "gh workflow run" -Command {
   gh workflow run $Workflow --repo $Repo --ref $Ref -f "enable_awslogs=$enableValue"

--- a/scripts/staging-rehearsal.ps1
+++ b/scripts/staging-rehearsal.ps1
@@ -21,6 +21,16 @@ function Test-CommandExists {
   return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
 }
 
+function Get-PowerShellCommand {
+  if (Test-CommandExists "powershell.exe") {
+    return "powershell.exe"
+  }
+  if (Test-CommandExists "pwsh") {
+    return "pwsh"
+  }
+  return ""
+}
+
 function Invoke-CommandStrict {
   param(
     [string]$Name,
@@ -88,6 +98,11 @@ if (-not (Test-CommandExists "gh")) {
   throw "gh CLI is required."
 }
 
+$script:PowerShellCommand = Get-PowerShellCommand
+if ([string]::IsNullOrWhiteSpace($script:PowerShellCommand)) {
+  throw "missing powershell command (powershell.exe/pwsh)"
+}
+
 $preflightStatus = "SKIPPED"
 $notes = "enable_awslogs=$($EnableAwsLogs.IsPresent.ToString().ToLower())"
 
@@ -111,7 +126,7 @@ if (-not $SkipPreflight) {
     $preflightArgs += "-SkipTerraformPlan"
   }
 
-  & powershell.exe @preflightArgs
+  & $script:PowerShellCommand @preflightArgs
   if ($LASTEXITCODE -ne 0) {
     $preflightStatus = "FAILED"
     Append-LogRow -Path $LogFile -RepoName $Repo -BranchRef $Ref -PreflightStatus $preflightStatus -RunUrl "-" -Result "ABORTED" -Notes "preflight failed"
@@ -121,6 +136,7 @@ if (-not $SkipPreflight) {
 }
 
 $triggeredAfter = (Get-Date).ToUniversalTime()
+$dispatchWindowStart = $triggeredAfter.AddMinutes(-2)
 $enableValue = if ($EnableAwsLogs) { "true" } else { "false" }
 
 if (Test-CommitShaRef -Value $Ref) {
@@ -137,6 +153,22 @@ if ($DryRun) {
   exit 0
 }
 
+$baselineRuns = gh run list --repo $Repo --workflow $Workflow --event workflow_dispatch --limit 30 --json databaseId 2>$null
+$knownRunIds = @{}
+if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($baselineRuns)) {
+  try {
+    $known = $baselineRuns | ConvertFrom-Json
+    foreach ($run in $known) {
+      $id = "$($run.databaseId)"
+      if (-not [string]::IsNullOrWhiteSpace($id)) {
+        $knownRunIds[$id] = $true
+      }
+    }
+  } catch {
+    # Best-effort baseline only.
+  }
+}
+
 Invoke-CommandStrict -Name "gh workflow run" -Command {
   gh workflow run $Workflow --repo $Repo --ref $Ref -f "enable_awslogs=$enableValue"
 }
@@ -144,17 +176,38 @@ Invoke-CommandStrict -Name "gh workflow run" -Command {
 $runId = $null
 $runUrl = $null
 for ($i = 0; $i -lt $RunDetectRetries; $i++) {
-  $runJson = gh run list --repo $Repo --workflow $Workflow --branch $Ref --event workflow_dispatch --limit 5 --json databaseId,createdAt,url,status
+  $runJson = gh run list --repo $Repo --workflow $Workflow --event workflow_dispatch --limit 30 --json databaseId,createdAt,url,status,headBranch
   if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($runJson)) {
     $runs = $runJson | ConvertFrom-Json
-    $candidate = $runs |
-      Where-Object { ([DateTime]$_.createdAt).ToUniversalTime() -ge $triggeredAfter.AddSeconds(-5) } |
-      Sort-Object { [DateTime]$_.createdAt } -Descending |
-      Select-Object -First 1
+    $runsWithCreatedAt = $runs | ForEach-Object {
+      [PSCustomObject]@{
+        Run = $_
+        CreatedAtUtc = ([DateTime]$_.createdAt).ToUniversalTime()
+      }
+    }
 
-    if ($null -ne $candidate) {
-      $runId = "$($candidate.databaseId)"
-      $runUrl = "$($candidate.url)"
+    $strictCandidates = $runsWithCreatedAt |
+      Where-Object {
+        (-not $knownRunIds.ContainsKey("$($_.Run.databaseId)")) -and
+        ($_.CreatedAtUtc -ge $triggeredAfter) -and
+        ([string]::IsNullOrWhiteSpace($_.Run.headBranch) -or $_.Run.headBranch -eq $Ref)
+      }
+    # Select the earliest matching run after dispatch to avoid attaching to later concurrent runs.
+    $selected = $strictCandidates | Sort-Object CreatedAtUtc | Select-Object -First 1
+
+    if ($null -eq $selected) {
+      $fallbackCandidates = $runsWithCreatedAt |
+        Where-Object {
+          (-not $knownRunIds.ContainsKey("$($_.Run.databaseId)")) -and
+          ($_.CreatedAtUtc -ge $dispatchWindowStart) -and
+          ([string]::IsNullOrWhiteSpace($_.Run.headBranch) -or $_.Run.headBranch -eq $Ref)
+        }
+      $selected = $fallbackCandidates | Sort-Object CreatedAtUtc | Select-Object -First 1
+    }
+
+    if ($null -ne $selected) {
+      $runId = "$($selected.Run.databaseId)"
+      $runUrl = "$($selected.Run.url)"
       break
     }
   }


### PR DESCRIPTION
﻿## Summary
- harden remaining orchestration scripts to resolve PowerShell runtime command dynamically (`powershell.exe`/`pwsh`) instead of direct `powershell.exe` invocation
- improve `staging-rehearsal.ps1` workflow run correlation in concurrent dispatch scenarios by:
  - snapshotting baseline run IDs before dispatch
  - setting dispatch timestamp/window immediately after baseline snapshot
  - selecting the earliest new run after dispatch time
  - using a bounded fallback window for API clock skew
- align `mobile-store-cycle.ps1` dispatch timestamp/window placement with baseline snapshot timing to reduce cross-run misattribution risk
- normalize workflow_dispatch boolean env mappings to preserve explicit `false` in:
  - `deploy-staging.yml` (`enable_awslogs`)
  - `ops-health-scheduled.yml` (`include_mobile_release_secrets`, `wait_for_completion`)
- sync cycle docs (`docs/changelog-dev.md`, `CLAUDE.md`)

## Changed Files
- `scripts/staging-rehearsal.ps1`
- `scripts/mobile-store-cycle.ps1`
- `scripts/run-mobile-emulator.ps1`
- `.github/workflows/deploy-staging.yml`
- `.github/workflows/ops-health-scheduled.yml`
- `docs/changelog-dev.md`
- `CLAUDE.md`

## Validation
- PowerShell parse check
  - `[PASS] scripts/mobile-store-cycle.ps1`
  - `[PASS] scripts/staging-rehearsal.ps1`
  - `[PASS] scripts/run-mobile-emulator.ps1`
- `powershell -NoProfile -File .\\scripts\\staging-rehearsal.ps1 -DryRun -SkipPreflight -Repo V4N1LLA/Eunhye_Hymn -Ref staging`
- `powershell -NoProfile -File .\\scripts\\mobile-store-cycle.ps1 -DryRun -SkipPreflight -Repo V4N1LLA/Eunhye_Hymn -Ref develop -Target android`
- expression update verification via `rg` on workflow env lines
- merge-marker scan: no conflict markers in `README.md`, `docs/**`, `CLAUDE.md`
