### PR TITLE
refactor(ops): improve preflight failure diagnostics in cycle scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -768,6 +768,7 @@ develop push → GitHub Actions
   - `scripts/mobile-store-cycle.ps1`: preflight 호출 실행기 cross-platform 처리
   - `scripts/run-mobile-emulator.ps1`: flutter wrapper 호출 실행기 cross-platform 처리
   - `.github/workflows/deploy-staging.yml`, `.github/workflows/ops-health-scheduled.yml`: workflow_dispatch boolean 입력 false 보존식으로 정규화
+  - `scripts/staging-rehearsal.ps1`, `scripts/mobile-store-cycle.ps1`: preflight 실패 시 first-useful-line 추출로 로그/예외 원인 가시성 강화
 - 스테이징 실가동 체크리스트/런북 동기화
   - `docs/staging-smoke-checklist.md`
   - `docs/runbook.md`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -37,6 +37,12 @@
   - `.github/workflows/ops-health-scheduled.yml`
   - Preserved explicit `false` values for workflow_dispatch boolean inputs (`enable_awslogs`, `include_mobile_release_secrets`, `wait_for_completion`)
 
+### Preflight failure diagnostics hardening
+- `scripts/mobile-store-cycle.ps1`
+  - Added first-useful-line extraction for preflight failures and propagated detail into log notes/exception message
+- `scripts/staging-rehearsal.ps1`
+  - Captured preflight output and surfaced first-useful-line detail in log notes/exception message
+
 ## 2026-02-23
 
 ### Staging manual smoke recency gate + log automation

--- a/scripts/mobile-store-cycle.ps1
+++ b/scripts/mobile-store-cycle.ps1
@@ -80,6 +80,29 @@ function Append-LogRow {
   Add-Content -Path $Path -Value $line -Encoding utf8
 }
 
+function Get-FirstUsefulLine {
+  param([string]$Output)
+
+  if ([string]::IsNullOrWhiteSpace($Output)) {
+    return ""
+  }
+
+  $lines = $Output -split "`r?`n" | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  if ($lines.Count -eq 0) {
+    return ""
+  }
+
+  foreach ($line in $lines) {
+    if ($line -eq "System.Management.Automation.RemoteException") { continue }
+    if ($line -like "At line:*") { continue }
+    if ($line -like "+ CategoryInfo:*") { continue }
+    if ($line -like "+ FullyQualifiedErrorId:*") { continue }
+    return $line
+  }
+
+  return $lines[0]
+}
+
 function Invoke-PowerShellFile {
   param(
     [Parameter(Mandatory = $true)]
@@ -147,6 +170,11 @@ if (-not $SkipPreflight) {
   if ($preflightResult.ExitCode -eq 0) {
     $preflightState = "PASS"
   } else {
+    $preflightDetail = Get-FirstUsefulLine -Output $preflightResult.Output
+    if ([string]::IsNullOrWhiteSpace($preflightDetail)) {
+      $preflightDetail = "preflight failed"
+    }
+
     $preflightState = "FAIL"
     Append-LogRow -Path $LogFile -Row @{
       UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
@@ -159,9 +187,9 @@ if (-not $SkipPreflight) {
       RunId = "-"
       Result = "ABORTED"
       Url = "-"
-      Notes = "preflight failed"
+      Notes = "preflight failed: $preflightDetail"
     }
-    throw "mobile store preflight failed; cycle aborted."
+    throw "mobile store preflight failed; cycle aborted. detail: $preflightDetail"
   }
 }
 

--- a/scripts/staging-rehearsal.ps1
+++ b/scripts/staging-rehearsal.ps1
@@ -94,6 +94,29 @@ function Append-LogRow {
   Add-Content -Path $Path -Value "| $utc | $RepoName | $BranchRef | $PreflightStatus | $RunUrl | $Result | $Notes |" -Encoding utf8
 }
 
+function Get-FirstUsefulLine {
+  param([string]$Output)
+
+  if ([string]::IsNullOrWhiteSpace($Output)) {
+    return ""
+  }
+
+  $lines = $Output -split "`r?`n" | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  if ($lines.Count -eq 0) {
+    return ""
+  }
+
+  foreach ($line in $lines) {
+    if ($line -eq "System.Management.Automation.RemoteException") { continue }
+    if ($line -like "At line:*") { continue }
+    if ($line -like "+ CategoryInfo:*") { continue }
+    if ($line -like "+ FullyQualifiedErrorId:*") { continue }
+    return $line
+  }
+
+  return $lines[0]
+}
+
 if (-not (Test-CommandExists "gh")) {
   throw "gh CLI is required."
 }
@@ -127,11 +150,16 @@ if (-not $SkipPreflight) {
     $preflightArgs += "-SkipTerraformPlan"
   }
 
-  & $script:PowerShellCommand @preflightArgs
+  $preflightOutput = & $script:PowerShellCommand @preflightArgs 2>&1
   if ($LASTEXITCODE -ne 0) {
+    $preflightDetail = Get-FirstUsefulLine -Output ($preflightOutput -join "`n")
+    if ([string]::IsNullOrWhiteSpace($preflightDetail)) {
+      $preflightDetail = "preflight failed"
+    }
+
     $preflightStatus = "FAILED"
-    Append-LogRow -Path $LogFile -RepoName $Repo -BranchRef $Ref -PreflightStatus $preflightStatus -RunUrl "-" -Result "ABORTED" -Notes "preflight failed"
-    throw "staging preflight failed; rehearsal aborted."
+    Append-LogRow -Path $LogFile -RepoName $Repo -BranchRef $Ref -PreflightStatus $preflightStatus -RunUrl "-" -Result "ABORTED" -Notes "preflight failed: $preflightDetail"
+    throw "staging preflight failed; rehearsal aborted. detail: $preflightDetail"
   }
   $preflightStatus = "PASS"
 }


### PR DESCRIPTION
﻿## Summary
- improve preflight failure observability in ops cycle scripts by extracting the first useful error line from child-script output
- propagate extracted detail to both markdown log notes and thrown exception messages for faster triage
- keep existing behavior unchanged on success paths
- sync docs (`docs/changelog-dev.md`, `CLAUDE.md`)

## Changed Files
- `scripts/mobile-store-cycle.ps1`
- `scripts/staging-rehearsal.ps1`
- `docs/changelog-dev.md`
- `CLAUDE.md`

## Validation
- PowerShell parse check
  - `[PASS] scripts/mobile-store-cycle.ps1`
  - `[PASS] scripts/staging-rehearsal.ps1`
- `powershell -NoProfile -File .\\scripts\\staging-rehearsal.ps1 -DryRun -SkipPreflight -Repo V4N1LLA/Eunhye_Hymn -Ref staging`
- `powershell -NoProfile -File .\\scripts\\mobile-store-cycle.ps1 -DryRun -SkipPreflight -Repo V4N1LLA/Eunhye_Hymn -Ref develop -Target android`
- merge-marker scan: no conflict markers in `README.md`, `docs/**`, `CLAUDE.md`
