### PR TITLE
refactor(ops): dedupe repeated staging/ops health log writes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -769,6 +769,7 @@ develop push → GitHub Actions
   - `scripts/run-mobile-emulator.ps1`: flutter wrapper 호출 실행기 cross-platform 처리
   - `.github/workflows/deploy-staging.yml`, `.github/workflows/ops-health-scheduled.yml`: workflow_dispatch boolean 입력 false 보존식으로 정규화
   - `scripts/staging-rehearsal.ps1`, `scripts/mobile-store-cycle.ps1`: preflight 실패 시 first-useful-line 추출로 로그/예외 원인 가시성 강화
+  - `scripts/staging-ops-cycle.ps1`, `scripts/ops-health-cycle.ps1`: `-LogDedupWindowMinutes`(기본 30) 기반 중복 로그 쓰기 억제
 - 스테이징 실가동 체크리스트/런북 동기화
   - `docs/staging-smoke-checklist.md`
   - `docs/runbook.md`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -43,6 +43,13 @@
 - `scripts/staging-rehearsal.ps1`
   - Captured preflight output and surfaced first-useful-line detail in log notes/exception message
 
+### Ops log dedup hardening
+- `scripts/staging-ops-cycle.ps1`
+  - Added log dedup window (`-LogDedupWindowMinutes`, default 30) to skip repeated writes for the same run/gate decision within a short interval
+- `scripts/ops-health-cycle.ps1`
+  - Added log dedup window (`-LogDedupWindowMinutes`, default 30) for repeated consolidated health rows
+  - Passed dedup window through to nested `staging-ops-cycle.ps1` invocation
+
 ## 2026-02-23
 
 ### Staging manual smoke recency gate + log automation

--- a/scripts/ops-health-cycle.ps1
+++ b/scripts/ops-health-cycle.ps1
@@ -21,6 +21,7 @@ param(
   [int]$SecretsMaxAgeDays = 90,
   [switch]$IncludeMobileReleaseSecrets,
   [string]$SecretsLogFile = "docs/secrets-rotation-log.md",
+  [int]$LogDedupWindowMinutes = 30,
   [switch]$AlertOnFailure,
   [string]$AlertRepo = "",
   [switch]$AlertDryRun,
@@ -103,6 +104,81 @@ function Append-LogRow {
     (Escape-MarkdownCell $Row.Notes)
 
   Add-Content -Path $Path -Value $line -Encoding utf8
+}
+
+function Get-LatestLogRow {
+  param([string]$Path)
+
+  if (-not (Test-Path $Path)) {
+    return $null
+  }
+
+  $lines = Get-Content -Path $Path -Encoding utf8
+  for ($index = $lines.Count - 1; $index -ge 0; $index--) {
+    $line = $lines[$index]
+    $trimmed = $line.Trim()
+    if (-not $trimmed.StartsWith("|")) {
+      continue
+    }
+    if ($trimmed -match "^\|\s*-+\s*\|") {
+      continue
+    }
+
+    $parts = $line.Split("|")
+    if ($parts.Count -lt 11) {
+      continue
+    }
+
+    [datetime]$rowUtc = [datetime]::MinValue
+    if (-not [datetime]::TryParse($parts[1].Trim(), [ref]$rowUtc)) {
+      continue
+    }
+
+    return [PSCustomObject]@{
+      UtcTime = $rowUtc.ToUniversalTime()
+      Repo = $parts[2].Trim()
+      Branch = $parts[3].Trim()
+      Staging = $parts[4].Trim()
+      Secrets = $parts[5].Trim()
+      Overall = $parts[6].Trim()
+      FailureCategory = $parts[7].Trim()
+      Evidence = $parts[8].Trim()
+      Owner = $parts[9].Trim()
+      Notes = $parts[10].Trim()
+    }
+  }
+
+  return $null
+}
+
+function Should-SkipLogAppend {
+  param(
+    [string]$Path,
+    [hashtable]$Row,
+    [int]$WindowMinutes = 30
+  )
+
+  if ($WindowMinutes -le 0) {
+    return $false
+  }
+
+  $latest = Get-LatestLogRow -Path $Path
+  if ($null -eq $latest) {
+    return $false
+  }
+
+  if ((([DateTime]::UtcNow - $latest.UtcTime).TotalMinutes) -gt $WindowMinutes) {
+    return $false
+  }
+
+  if ("$($latest.Repo)" -ne "$($Row.Repo)") { return $false }
+  if ("$($latest.Branch)" -ne "$($Row.Branch)") { return $false }
+  if ("$($latest.Staging)" -ne "$($Row.Staging)") { return $false }
+  if ("$($latest.Secrets)" -ne "$($Row.Secrets)") { return $false }
+  if ("$($latest.Overall)" -ne "$($Row.Overall)") { return $false }
+  if ("$($latest.FailureCategory)" -ne "$($Row.FailureCategory)") { return $false }
+
+  return $true
 }
 
 function Get-FirstUsefulLine {
@@ -224,6 +300,9 @@ if ($ManualSmokeMaxAgeDays -lt 1) {
 if ($SecretsMaxAgeDays -lt 1) {
   throw "SecretsMaxAgeDays must be >= 1"
 }
+if ($LogDedupWindowMinutes -lt 0) {
+  throw "LogDedupWindowMinutes must be >= 0"
+}
 if ([string]::IsNullOrWhiteSpace($ManualSmokeResult) -and (
     -not [string]::IsNullOrWhiteSpace($ManualSmokeEvidence) -or
     -not [string]::IsNullOrWhiteSpace($ManualSmokeNotes)
@@ -270,6 +349,7 @@ if (-not $SkipStagingOps) {
     "-Owner", $Owner,
     "-MaxAgeMinutes", "$StagingMaxAgeMinutes",
     "-ManualSmokeMaxAgeDays", "$ManualSmokeMaxAgeDays",
+    "-LogDedupWindowMinutes", "$LogDedupWindowMinutes",
     "-LogFile", $StagingLogFile,
     "-AsJson"
   )
@@ -376,7 +456,7 @@ if (-not [string]::IsNullOrWhiteSpace($secretsResult.Evidence) -and $secretsResu
 $evidence = if ($evidenceItems.Count -eq 0) { "-" } else { ($evidenceItems -join " ; ") }
 
 $utcNow = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-Append-LogRow -Path $OpsHealthLogFile -Row @{
+$logRow = @{
   UtcTime = $utcNow
   Repo = $Repo
   Branch = $Branch
@@ -387,6 +467,11 @@ Append-LogRow -Path $OpsHealthLogFile -Row @{
   Evidence = $evidence
   Owner = $Owner
   Notes = ($notes -join "; ")
+}
+if (-not (Should-SkipLogAppend -Path $OpsHealthLogFile -Row $logRow -WindowMinutes $LogDedupWindowMinutes)) {
+  Append-LogRow -Path $OpsHealthLogFile -Row $logRow
+} elseif (-not $AsJson) {
+  Write-Host ("Skip duplicate ops-health log row (window={0}m)." -f $LogDedupWindowMinutes)
 }
 
 $resultPayload = [PSCustomObject]@{

--- a/scripts/staging-ops-cycle.ps1
+++ b/scripts/staging-ops-cycle.ps1
@@ -15,6 +15,7 @@ param(
   [string]$ManualSmokeNotes = "",
   [int]$ManualSmokeMaxAgeDays = 7,
   [switch]$SkipManualSmokeRecencyGate,
+  [int]$LogDedupWindowMinutes = 30,
   [switch]$AsJson
 )
 
@@ -99,6 +100,90 @@ function Append-LogRow {
     (Escape-MarkdownCell $Row.Notes)
 
   Add-Content -Path $Path -Value $line -Encoding utf8
+}
+
+function Get-LatestLogRow {
+  param([string]$Path)
+
+  if (-not (Test-Path $Path)) {
+    return $null
+  }
+
+  $lines = Get-Content -Path $Path -Encoding utf8
+  for ($index = $lines.Count - 1; $index -ge 0; $index--) {
+    $line = $lines[$index]
+    $trimmed = $line.Trim()
+    if (-not $trimmed.StartsWith("|")) {
+      continue
+    }
+    if ($trimmed -match "^\|\s*-+\s*\|") {
+      continue
+    }
+
+    $parts = $line.Split("|")
+    if ($parts.Count -lt 16) {
+      continue
+    }
+
+    [datetime]$rowUtc = [datetime]::MinValue
+    if (-not [datetime]::TryParse($parts[1].Trim(), [ref]$rowUtc)) {
+      continue
+    }
+
+    return [PSCustomObject]@{
+      UtcTime = $rowUtc.ToUniversalTime()
+      Repo = $parts[2].Trim()
+      Branch = $parts[3].Trim()
+      RunId = $parts[4].Trim()
+      HeadSha = $parts[5].Trim()
+      Preflight = $parts[6].Trim()
+      RunGate = $parts[7].Trim()
+      DeployGate = $parts[8].Trim()
+      VerifyGate = $parts[9].Trim()
+      AgeMin = $parts[10].Trim()
+      Decision = $parts[11].Trim()
+      ManualSmoke = $parts[12].Trim()
+      Evidence = $parts[13].Trim()
+      Owner = $parts[14].Trim()
+      Notes = $parts[15].Trim()
+    }
+  }
+
+  return $null
+}
+
+function Should-SkipLogAppend {
+  param(
+    [string]$Path,
+    [hashtable]$Row,
+    [int]$WindowMinutes = 30
+  )
+
+  if ($WindowMinutes -le 0) {
+    return $false
+  }
+
+  $latest = Get-LatestLogRow -Path $Path
+  if ($null -eq $latest) {
+    return $false
+  }
+
+  if ((([DateTime]::UtcNow - $latest.UtcTime).TotalMinutes) -gt $WindowMinutes) {
+    return $false
+  }
+
+  if ("$($latest.Repo)" -ne "$($Row.Repo)") { return $false }
+  if ("$($latest.Branch)" -ne "$($Row.Branch)") { return $false }
+  if ("$($latest.RunId)" -ne "$($Row.RunId)") { return $false }
+  if ("$($latest.HeadSha)" -ne "$($Row.HeadSha)") { return $false }
+  if ("$($latest.Preflight)" -ne "$($Row.Preflight)") { return $false }
+  if ("$($latest.RunGate)" -ne "$($Row.RunGate)") { return $false }
+  if ("$($latest.DeployGate)" -ne "$($Row.DeployGate)") { return $false }
+  if ("$($latest.VerifyGate)" -ne "$($Row.VerifyGate)") { return $false }
+  if ("$($latest.Decision)" -ne "$($Row.Decision)") { return $false }
+  if ("$($latest.ManualSmoke)" -ne "$($Row.ManualSmoke)") { return $false }
+
+  return $true
 }
 
 function Invoke-PowerShellFile {
@@ -194,6 +279,9 @@ if ($MaxAgeMinutes -lt 0) {
 if ($ManualSmokeMaxAgeDays -lt 1) {
   throw "ManualSmokeMaxAgeDays must be >= 1"
 }
+if ($LogDedupWindowMinutes -lt 0) {
+  throw "LogDedupWindowMinutes must be >= 0"
+}
 if ([string]::IsNullOrWhiteSpace($ManualSmokeResult) -and (
     -not [string]::IsNullOrWhiteSpace($ManualSmokeEvidence) -or
     -not [string]::IsNullOrWhiteSpace($ManualSmokeNotes)
@@ -259,7 +347,7 @@ $statusResult = Invoke-PowerShellFile -ScriptPath $statusScript -Arguments $stat
 if ($statusResult.ExitCode -ne 0) {
   $tail = if ([string]::IsNullOrWhiteSpace($statusResult.Output)) { "status command failed" } else { $statusResult.Output.Split("`n")[-1].Trim() }
   $errorUtc = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-  Append-LogRow -Path $LogFile -Row @{
+  $errorRow = @{
     UtcTime = $errorUtc
     Repo = $Repo
     Branch = $Branch
@@ -275,6 +363,9 @@ if ($statusResult.ExitCode -ne 0) {
     Evidence = "-"
     Owner = $Owner
     Notes = "status error: $tail"
+  }
+  if (-not (Should-SkipLogAppend -Path $LogFile -Row $errorRow -WindowMinutes $LogDedupWindowMinutes)) {
+    Append-LogRow -Path $LogFile -Row $errorRow
   }
   if ($AsJson) {
     [PSCustomObject]@{
@@ -305,7 +396,7 @@ try {
   $statusPayload = $statusResult.Output | ConvertFrom-Json
 } catch {
   $errorUtc = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-  Append-LogRow -Path $LogFile -Row @{
+  $errorRow = @{
     UtcTime = $errorUtc
     Repo = $Repo
     Branch = $Branch
@@ -321,6 +412,9 @@ try {
     Evidence = "-"
     Owner = $Owner
     Notes = "status output is not valid json"
+  }
+  if (-not (Should-SkipLogAppend -Path $LogFile -Row $errorRow -WindowMinutes $LogDedupWindowMinutes)) {
+    Append-LogRow -Path $LogFile -Row $errorRow
   }
   if ($AsJson) {
     [PSCustomObject]@{
@@ -432,7 +526,7 @@ if (-not $manualSmokeOutcomeGate) {
   $notes += "manual smoke outcome gate failed"
 }
 
-Append-LogRow -Path $LogFile -Row @{
+$logRow = @{
   UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
   Repo = $Repo
   Branch = $Branch
@@ -448,6 +542,11 @@ Append-LogRow -Path $LogFile -Row @{
   Evidence = $evidence
   Owner = $Owner
   Notes = ($notes -join "; ")
+}
+if (-not (Should-SkipLogAppend -Path $LogFile -Row $logRow -WindowMinutes $LogDedupWindowMinutes)) {
+  Append-LogRow -Path $LogFile -Row $logRow
+} elseif (-not $AsJson) {
+  Write-Host ("Skip duplicate staging log row (window={0}m)." -f $LogDedupWindowMinutes)
 }
 
 $resultPayload = [PSCustomObject]@{


### PR DESCRIPTION
﻿## Background
- `2026-02-26.md` was not present in the workspace, so this cycle used `2026-02-24.md` as the latest available planning reference.
- The top-priority operational pain point was repeated HOLD/pass rows for the same run state, which makes triage noisier in staging/ops monitoring logs.

## Summary
- add log dedup window support to staging/ops cycle scripts to suppress repeated writes for the same run/gate decision in short intervals
- keep dedup optional/tunable via `-LogDedupWindowMinutes` (default: `30`; `0` disables dedup)
- propagate dedup window from `ops-health-cycle.ps1` to nested `staging-ops-cycle.ps1`
- sync docs (`docs/changelog-dev.md`, `CLAUDE.md`)

## Changed Files
- `scripts/staging-ops-cycle.ps1`
- `scripts/ops-health-cycle.ps1`
- `docs/changelog-dev.md`
- `CLAUDE.md`

## Validation
- PowerShell parse check
  - `[PASS] scripts/staging-ops-cycle.ps1`
  - `[PASS] scripts/ops-health-cycle.ps1`
- functional dedup check (temporary log files)
  - run `staging-ops-cycle` twice against same run context -> row count stable (`1 -> 1`)
  - run `ops-health-cycle` twice (`-SkipSecretsRotation`) -> row count stable (`1 -> 1`)
- merge marker scan
  - `[PASS] no conflict markers in README/docs/CLAUDE`
