### PR TITLE
test(api): harden exception-path coverage for complex use cases

### DIFF
--- a/2026-02-26.md
+++ b/2026-02-26.md
@@ -9,9 +9,9 @@ Baseline date: 2026-02-24. This document fixes the next execution order for ongo
 
 ## Next backlog (1-8)
 
-1. Establish Admin test gate baseline
+1. Establish Admin test gate baseline [DONE]
    - Vitest unit tests + CI enforcement
-2. Strengthen API use case unit tests
+2. Strengthen API use case unit tests [DONE - first pass]
    - Prioritize complex use cases (event export, AI recommendation)
 3. Mobile release credential recovery runbook
    - Root-cause-based recovery checklist for `play_upload` and `testflight`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -699,6 +699,7 @@ develop push → GitHub Actions
 - 비동기 export 결과 정리 배치 (완료/실패 작업 기본 7일 보관 후 정리)
 - 비동기 export 운영 지표 API (`/admin/events/export-jobs/metrics`) + cleanup 실행 이력 기록
 - DB 스키마 Flyway 마이그레이션 (V1~V16)
+- 복잡 유스케이스 예외 경로 테스트 보강 (`AdminEventExportJobUseCaseTest`, `RecommendHymnsUseCaseTest`)
 - 핵심 테스트 스위트 통과 (API/Admin/Mobile)
 
 **Admin 프론트엔드**
@@ -711,6 +712,7 @@ develop push → GitHub Actions
 - Access Token 자동 갱신 (401 → refresh → 재시도, mutex 패턴)
 - 인증 컨텍스트 (`loginWithSocial`, `setTokensAndUser`), 공통 API 클라이언트, 사이드바 레이아웃
 - Dev Login (개발용, 접이식)
+- Vitest 기반 최소 단위 테스트 게이트 도입 (`npm run test`, `tokenStore` 테스트 + CI 연동)
 
 **Mobile 앱 (Flutter MVP)**
 - 소셜 SDK 직접 로그인 (Kakao 모바일, Kakao 웹은 토큰 입력 fallback) + Dev 로그인
@@ -764,6 +766,9 @@ develop push → GitHub Actions
   - `scripts/sync-skills.ps1`: source/destination 경로 겹침 방지 가드 추가
   - `.github/workflows/secrets-rotation-scheduled.yml`: workflow_dispatch boolean false 보존
   - `skills/secrets-rotation-auditor/references/commands.md`: 필수 인자 누락 예시 보강
+- 테스트 게이트/유스케이스 예외경로 보강 (2026-02-24)
+  - `apps/admin`: Vitest+jsdom 도입, `tokenStore` 테스트 추가, `admin-ci` 테스트 단계 추가
+  - `apps/api`: `AdminEventExportJobUseCaseTest`, `RecommendHymnsUseCaseTest` 예외/경계 경로 테스트 추가
 - 운영 스크립트 호환성 후속 반영 (2026-02-24)
   - `scripts/staging-rehearsal.ps1`: preflight 실행기 cross-platform 처리 + 동시 dispatch 환경 run 선택 안정화(earliest/new-run 기준)
   - `scripts/mobile-store-cycle.ps1`: preflight 호출 실행기 cross-platform 처리

--- a/apps/api/src/test/java/com/eunhyehymn/application/usecases/AdminEventExportJobUseCaseTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/application/usecases/AdminEventExportJobUseCaseTest.java
@@ -1,7 +1,9 @@
 package com.eunhyehymn.application.usecases;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.domain.model.Event;
 import com.eunhyehymn.domain.model.EventExportJob;
 import com.eunhyehymn.domain.model.EventExportJobStatus;
@@ -14,6 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 
 class AdminEventExportJobUseCaseTest {
     @Test
@@ -83,6 +86,109 @@ class AdminEventExportJobUseCaseTest {
         assertThat(jobRepository.findQueuedLimitHistory).containsExactly(1, 200);
     }
 
+    @Test
+    void processMarksJobFailedAndTruncatesLongErrorMessage() {
+        InMemoryEventExportJobRepository jobRepository = new InMemoryEventExportJobRepository();
+        NoopEventRepository eventRepository = new NoopEventRepository();
+        AdminEventExportJobUseCase useCase = new AdminEventExportJobUseCase(eventRepository, jobRepository);
+        EventExportJob runningJob = new EventExportJob(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            null,
+            null,
+            null,
+            null,
+            Instant.now(),
+            100,
+            EventExportJobStatus.RUNNING,
+            null,
+            null,
+            null,
+            null,
+            Instant.now(),
+            Instant.now(),
+            null
+        );
+        String longMessage = "x".repeat(700);
+        eventRepository.findRecentException = new RuntimeException(longMessage);
+        jobRepository.claimQueuedResult = Optional.of(runningJob);
+
+        EventExportJob result = useCase.process(runningJob.id());
+
+        assertThat(result.status()).isEqualTo(EventExportJobStatus.FAILED);
+        assertThat(result.errorMessage()).hasSize(500);
+        assertThat(jobRepository.savedJobs).hasSize(1);
+    }
+
+    @Test
+    void getDownloadThrowsConflictWhenJobFailed() {
+        InMemoryEventExportJobRepository jobRepository = new InMemoryEventExportJobRepository();
+        AdminEventExportJobUseCase useCase = new AdminEventExportJobUseCase(new NoopEventRepository(), jobRepository);
+        UUID requestedBy = UUID.randomUUID();
+        EventExportJob failedJob = new EventExportJob(
+            UUID.randomUUID(),
+            requestedBy,
+            null,
+            null,
+            null,
+            null,
+            Instant.now(),
+            100,
+            EventExportJobStatus.FAILED,
+            null,
+            null,
+            null,
+            "Export failed for timeout",
+            Instant.now(),
+            Instant.now(),
+            Instant.now()
+        );
+        jobRepository.findByIdResult = Optional.of(failedJob);
+
+        assertThatThrownBy(() -> useCase.getDownload(failedJob.id(), requestedBy))
+            .isInstanceOf(ApiException.class)
+            .satisfies(throwable -> {
+                ApiException ex = (ApiException) throwable;
+                assertThat(ex.getStatus()).isEqualTo(HttpStatus.CONFLICT);
+                assertThat(ex.getCode()).isEqualTo("export_job_failed");
+                assertThat(ex).hasMessage("Export failed for timeout");
+            });
+    }
+
+    @Test
+    void getDownloadThrowsServerErrorWhenCompletedResultIsMissing() {
+        InMemoryEventExportJobRepository jobRepository = new InMemoryEventExportJobRepository();
+        AdminEventExportJobUseCase useCase = new AdminEventExportJobUseCase(new NoopEventRepository(), jobRepository);
+        UUID requestedBy = UUID.randomUUID();
+        EventExportJob corruptedCompletedJob = new EventExportJob(
+            UUID.randomUUID(),
+            requestedBy,
+            null,
+            null,
+            null,
+            null,
+            Instant.now(),
+            100,
+            EventExportJobStatus.COMPLETED,
+            10L,
+            null,
+            "csv-content",
+            null,
+            Instant.now(),
+            Instant.now(),
+            Instant.now()
+        );
+        jobRepository.findByIdResult = Optional.of(corruptedCompletedJob);
+
+        assertThatThrownBy(() -> useCase.getDownload(corruptedCompletedJob.id(), requestedBy))
+            .isInstanceOf(ApiException.class)
+            .satisfies(throwable -> {
+                ApiException ex = (ApiException) throwable;
+                assertThat(ex.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+                assertThat(ex.getCode()).isEqualTo("export_job_corrupted");
+            });
+    }
+
     private static final class InMemoryEventExportJobRepository implements EventExportJobRepository {
         private Optional<EventExportJob> findByIdResult = Optional.empty();
         private Optional<EventExportJob> claimQueuedResult = Optional.empty();
@@ -130,6 +236,8 @@ class AdminEventExportJobUseCaseTest {
     }
 
     private static final class NoopEventRepository implements EventRepository {
+        private RuntimeException findRecentException;
+
         @Override
         public Event save(Event event) {
             throw new UnsupportedOperationException();
@@ -155,6 +263,9 @@ class AdminEventExportJobUseCaseTest {
             int page,
             int size
         ) {
+            if (findRecentException != null) {
+                throw findRecentException;
+            }
             return List.of();
         }
 

--- a/apps/api/src/test/java/com/eunhyehymn/application/usecases/RecommendHymnsUseCaseTest.java
+++ b/apps/api/src/test/java/com/eunhyehymn/application/usecases/RecommendHymnsUseCaseTest.java
@@ -1,8 +1,11 @@
 package com.eunhyehymn.application.usecases;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.eunhyehymn.application.ports.ExternalAiException;
 import com.eunhyehymn.application.ports.HymnRecommendationClient;
+import com.eunhyehymn.common.error.ApiException;
 import com.eunhyehymn.domain.model.Hymn;
 import com.eunhyehymn.domain.repository.HymnRepository;
 import java.time.Instant;
@@ -10,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 
 class RecommendHymnsUseCaseTest {
     @Test
@@ -57,6 +61,81 @@ class RecommendHymnsUseCaseTest {
         assertThat(result.fallbackUsed()).isFalse();
         assertThat(result.items()).hasSize(1);
         assertThat(result.items().get(0).reason()).isEqualTo("Fits the requested mood.");
+    }
+
+    @Test
+    void throwsBadRequestWhenSituationIsBlank() {
+        HymnRepository hymnRepository = new InMemoryHymnRepository(List.of());
+        RecommendHymnsUseCase useCase = new RecommendHymnsUseCase(
+            hymnRepository,
+            (situation, candidates, maxResults) -> List.of(),
+            25,
+            3,
+            180
+        );
+
+        assertThatThrownBy(() -> useCase.recommend("   ", 3))
+            .isInstanceOf(ApiException.class)
+            .satisfies(throwable -> {
+                ApiException ex = (ApiException) throwable;
+                assertThat(ex.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+                assertThat(ex.getCode()).isEqualTo("validation_error");
+            });
+    }
+
+    @Test
+    void mapsExternalAiExceptionToServiceUnavailable() {
+        UUID hymnId = UUID.randomUUID();
+        HymnRepository hymnRepository = new InMemoryHymnRepository(List.of(
+            new Hymn(hymnId, "Mercy Song", "103", "mercy", true, Instant.now())
+        ));
+        RecommendHymnsUseCase useCase = new RecommendHymnsUseCase(
+            hymnRepository,
+            (situation, candidates, maxResults) -> {
+                throw new ExternalAiException("gateway timeout");
+            },
+            25,
+            3,
+            180
+        );
+
+        assertThatThrownBy(() -> useCase.recommend("mercy prayer", 3))
+            .isInstanceOf(ApiException.class)
+            .satisfies(throwable -> {
+                ApiException ex = (ApiException) throwable;
+                assertThat(ex.getStatus()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+                assertThat(ex.getCode()).isEqualTo("ai_unavailable");
+            });
+    }
+
+    @Test
+    void clampsRequestedResultsAndSanitizesAiReason() {
+        UUID firstHymnId = UUID.randomUUID();
+        UUID secondHymnId = UUID.randomUUID();
+        HymnRepository hymnRepository = new InMemoryHymnRepository(List.of(
+            new Hymn(firstHymnId, "Hope Song", "102", "hope", true, Instant.now()),
+            new Hymn(secondHymnId, "Grace Song", "103", "grace", true, Instant.now())
+        ));
+        String longReason = "r".repeat(200);
+        RecommendHymnsUseCase useCase = new RecommendHymnsUseCase(
+            hymnRepository,
+            (situation, candidates, maxResults) -> List.of(
+                new HymnRecommendationClient.Recommendation(firstHymnId, longReason),
+                new HymnRecommendationClient.Recommendation(firstHymnId, "duplicate should be ignored"),
+                new HymnRecommendationClient.Recommendation(UUID.randomUUID(), "unknown id should be ignored")
+            ),
+            25,
+            3,
+            180
+        );
+
+        RecommendHymnsUseCase.Result result = useCase.recommend("hopeful service", 10);
+
+        assertThat(result.requestedMaxResults()).isEqualTo(5);
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().get(0).id()).isEqualTo(firstHymnId);
+        assertThat(result.items().get(0).reason()).hasSize(140);
+        assertThat(result.fallbackUsed()).isFalse();
     }
 
     private static final class InMemoryHymnRepository implements HymnRepository {

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -65,6 +65,22 @@
   - `docs/LOCAL_SETUP.md`
   - `CLAUDE.md`
 
+### API complex use case test hardening (P1)
+- Added exception-path coverage for event export job use case
+  - `apps/api/src/test/java/com/eunhyehymn/application/usecases/AdminEventExportJobUseCaseTest.java`
+  - Added tests for:
+    - failed processing path with long error-message truncation (500 chars)
+    - `getDownload` failure mapping (`FAILED` -> `409 export_job_failed`)
+    - `getDownload` corruption guard (`COMPLETED` with missing payload -> `500 export_job_corrupted`)
+- Added validation/error-path coverage for AI recommendation use case
+  - `apps/api/src/test/java/com/eunhyehymn/application/usecases/RecommendHymnsUseCaseTest.java`
+  - Added tests for:
+    - blank situation validation (`400 validation_error`)
+    - external AI exception mapping (`503 ai_unavailable`)
+    - result clamp/sanitization behavior (maxResults clamp, duplicate/unknown recommendation filtering, reason length cap)
+- Verification
+  - `cd apps/api && ./gradlew test --tests "*AdminEventExportJobUseCaseTest*" --tests "*RecommendHymnsUseCaseTest*" --no-daemon --stacktrace`
+
 ## 2026-02-23
 
 ### Staging manual smoke recency gate + log automation


### PR DESCRIPTION
## Summary
- add exception-path tests to `AdminEventExportJobUseCaseTest`
  - failed processing long-message truncation (500 chars)
  - `getDownload` failed-state mapping (`export_job_failed`)
  - `getDownload` completed-but-missing-payload guard (`export_job_corrupted`)
- add validation/error-path tests to `RecommendHymnsUseCaseTest`
  - blank situation validation error
  - external AI failure mapping (`ai_unavailable`)
  - result clamp/sanitization and duplicate/unknown recommendation filtering
- sync cycle docs (`docs/changelog-dev.md`, `CLAUDE.md`, `2026-02-26.md`)

## Validation
- `cd apps/api && ./gradlew test --tests "*AdminEventExportJobUseCaseTest*" --tests "*RecommendHymnsUseCaseTest*" --no-daemon --stacktrace`