### PR TITLE
ci(pr-gate): enforce admin unit tests in gate job

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -84,6 +84,7 @@ jobs:
           cache: npm
           cache-dependency-path: apps/admin/package-lock.json
       - run: npm ci
+      - run: npm run test
       - run: npx tsc --noEmit
       - run: npm run build
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -767,7 +767,7 @@ develop push → GitHub Actions
   - `.github/workflows/secrets-rotation-scheduled.yml`: workflow_dispatch boolean false 보존
   - `skills/secrets-rotation-auditor/references/commands.md`: 필수 인자 누락 예시 보강
 - 테스트 게이트/유스케이스 예외경로 보강 (2026-02-24)
-  - `apps/admin`: Vitest+jsdom 도입, `tokenStore` 테스트 추가, `admin-ci` 테스트 단계 추가
+  - `apps/admin`: Vitest+jsdom 도입, `tokenStore` 테스트 추가, `admin-ci` + `pr-gate(admin_build)` 테스트 단계 추가
   - `apps/api`: `AdminEventExportJobUseCaseTest`, `RecommendHymnsUseCaseTest` 예외/경계 경로 테스트 추가
 - 운영 스크립트 호환성 후속 반영 (2026-02-24)
   - `scripts/staging-rehearsal.ps1`: preflight 실행기 cross-platform 처리 + 동시 dispatch 환경 run 선택 안정화(earliest/new-run 기준)

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -81,6 +81,11 @@
 - Verification
   - `cd apps/api && ./gradlew test --tests "*AdminEventExportJobUseCaseTest*" --tests "*RecommendHymnsUseCaseTest*" --no-daemon --stacktrace`
 
+### PR gate Admin test enforcement follow-up
+- Fixed CI gap where PR gate did not execute Admin unit tests
+  - `.github/workflows/pr-gate.yml`
+  - Updated `admin_build` job flow to: `npm ci` -> `npm run test` -> `npx tsc --noEmit` -> `npm run build`
+
 ## 2026-02-23
 
 ### Staging manual smoke recency gate + log automation


### PR DESCRIPTION
## Summary
- fix CI gap in `.github/workflows/pr-gate.yml`
- update `admin_build` to run `npm run test` between `npm ci` and `npx tsc --noEmit`
- sync docs (`docs/changelog-dev.md`, `CLAUDE.md`)

## Why
- `admin-ci.yml` had test gating, but `pr-gate.yml` still skipped Admin unit tests
- this could allow a PR to pass required gate checks without running Admin tests

## Validation
- `rg -n "^(<<<<<<<|=======|>>>>>>>)+$" README.md docs CLAUDE.md .github/workflows/pr-gate.yml`
- CI validation is expected from PR checks after this workflow change