### PR TITLE
ci(docs): add doc-sync enforcement to PR gate

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -88,6 +88,21 @@ jobs:
       - run: npx tsc --noEmit
       - run: npm run build
 
+  doc_sync:
+    needs: detect_changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch base branch
+        run: |
+          git fetch --no-tags origin "${{ github.base_ref }}" --depth=1
+      - name: Validate doc sync requirements
+        shell: pwsh
+        run: |
+          ./scripts/check-doc-sync.ps1 -BaseRef "origin/${{ github.base_ref }}" -HeadRef "HEAD"
+
   mobile_ci:
     needs: detect_changes
     if: needs.detect_changes.outputs.mobile == 'true' || needs.detect_changes.outputs.workflows == 'true'
@@ -153,7 +168,8 @@ jobs:
             "scripts/staging-sync-secrets.ps1",
             "scripts/release-preflight.ps1",
             "scripts/new-worktree-task.ps1",
-            "scripts/apply-branch-protection.ps1"
+            "scripts/apply-branch-protection.ps1",
+            "scripts/check-doc-sync.ps1"
           )
 
           $hasErrors = $false
@@ -184,6 +200,7 @@ jobs:
       - detect_changes
       - api_test
       - admin_build
+      - doc_sync
       - mobile_ci
       - mobile_release_check
       - workflow_lint
@@ -194,12 +211,14 @@ jobs:
         env:
           API_TEST_RESULT: ${{ needs.api_test.result }}
           ADMIN_BUILD_RESULT: ${{ needs.admin_build.result }}
+          DOC_SYNC_RESULT: ${{ needs.doc_sync.result }}
           MOBILE_CI_RESULT: ${{ needs.mobile_ci.result }}
           MOBILE_RELEASE_RESULT: ${{ needs.mobile_release_check.result }}
           WORKFLOW_LINT_RESULT: ${{ needs.workflow_lint.result }}
         run: |
           echo "api_test=${API_TEST_RESULT}"
           echo "admin_build=${ADMIN_BUILD_RESULT}"
+          echo "doc_sync=${DOC_SYNC_RESULT}"
           echo "mobile_ci=${MOBILE_CI_RESULT}"
           echo "mobile_release_check=${MOBILE_RELEASE_RESULT}"
           echo "workflow_lint=${WORKFLOW_LINT_RESULT}"
@@ -207,6 +226,7 @@ jobs:
           for result in \
             "${API_TEST_RESULT}" \
             "${ADMIN_BUILD_RESULT}" \
+            "${DOC_SYNC_RESULT}" \
             "${MOBILE_CI_RESULT}" \
             "${MOBILE_RELEASE_RESULT}" \
             "${WORKFLOW_LINT_RESULT}"; do

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -48,7 +48,8 @@ jobs:
             "scripts/staging-sync-secrets.ps1",
             "scripts/release-preflight.ps1",
             "scripts/new-worktree-task.ps1",
-            "scripts/apply-branch-protection.ps1"
+            "scripts/apply-branch-protection.ps1",
+            "scripts/check-doc-sync.ps1"
           )
 
           $hasErrors = $false

--- a/2026-02-26.md
+++ b/2026-02-26.md
@@ -21,7 +21,7 @@ Baseline date: 2026-02-24. This document fixes the next execution order for ongo
    - Auto-warn on missing links/evidence
 6. Improve exception observability
    - Standardize first useful failure line + category code
-7. Strengthen doc sync checks
+7. Strengthen doc sync checks [DONE]
    - Detect required-doc omissions by changed area
 8. Strengthen parallel-work collision guards
    - Automate branch/worktree ownership validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ Run commands from repo root unless noted.
   - `bash -n infra/aws/deploy.sh`
   - `bash -n infra/aws/verify-staging.sh`
 - PowerShell syntax checks are defined in `.github/workflows/workflow-lint.yml`.
+- Doc sync check:
+  - `pwsh -File scripts/check-doc-sync.ps1 -BaseRef origin/develop -HeadRef HEAD`
 
 ## 5) Coding Guidelines (Cross-cutting)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -521,6 +521,13 @@ com.eunhyehymn/
 - **캐시**: npm
 - **실행**: `npm ci` → `npm run test` → `tsc --noEmit` → `npm run build`
 
+### PR Gate (`pr-gate.yml`)
+- **트리거**: PR 이벤트 (`opened`, `synchronize`, `reopened`, `ready_for_review`)
+- **역할**: 변경 영역별 CI 묶음 + 최종 gate 평가
+- **문서 동기화 검사**: `scripts/check-doc-sync.ps1`
+  - non-doc 파일이 변경되면 `docs/changelog-dev.md`, `CLAUDE.md` 동시 변경을 요구
+  - 누락 시 `doc_sync` job 실패로 PR gate 차단
+
 ### Mobile CI (`mobile-ci.yml`)
 - **트리거**: PR 및 develop push (apps/mobile/** 변경 시)
 - **환경**: ubuntu-latest, Flutter stable

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -86,6 +86,21 @@
   - `.github/workflows/pr-gate.yml`
   - Updated `admin_build` job flow to: `npm ci` -> `npm run test` -> `npx tsc --noEmit` -> `npm run build`
 
+### Doc sync gate automation
+- Added changed-file-based doc sync checker
+  - `scripts/check-doc-sync.ps1`
+  - Enforces `docs/changelog-dev.md` + `CLAUDE.md` updates when non-doc files are changed
+  - Supports `-ChangedFiles` input and `git diff` mode via `-BaseRef/-HeadRef`
+- Integrated checker into PR gate
+  - `.github/workflows/pr-gate.yml`
+  - Added `doc_sync` job and included its result in the final `gate` decision
+- Workflow lint coverage update
+  - `.github/workflows/workflow-lint.yml`
+  - Added syntax check target for `scripts/check-doc-sync.ps1`
+- Docs sync
+  - `AGENTS.md`
+  - `CLAUDE.md`
+
 ## 2026-02-23
 
 ### Staging manual smoke recency gate + log automation

--- a/scripts/check-doc-sync.ps1
+++ b/scripts/check-doc-sync.ps1
@@ -1,0 +1,93 @@
+param(
+  [string[]]$ChangedFiles = @(),
+  [string]$BaseRef = "",
+  [string]$HeadRef = "HEAD",
+  [switch]$AsJson
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$requiredDocs = @(
+  "docs/changelog-dev.md",
+  "CLAUDE.md"
+)
+
+function Normalize-Path {
+  param([string]$PathValue)
+  return ($PathValue -replace "\\", "/").Trim()
+}
+
+function Get-ChangedFilesFromGit {
+  param(
+    [string]$DiffBaseRef,
+    [string]$DiffHeadRef
+  )
+
+  if ([string]::IsNullOrWhiteSpace($DiffBaseRef)) {
+    throw "BaseRef is required when ChangedFiles is not provided."
+  }
+
+  $range = "$DiffBaseRef...$DiffHeadRef"
+  $raw = & git diff --name-only $range
+  if ($LASTEXITCODE -ne 0) {
+    throw "Failed to read changed files from git diff range: $range"
+  }
+  return @($raw | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+}
+
+function Is-DocOnlyPath {
+  param([string]$PathValue)
+
+  if ($PathValue -match "^docs/") { return $true }
+  if ($PathValue -in @("README.md", "CLAUDE.md", "AGENTS.md")) { return $true }
+  if ($PathValue -match "^2026-[0-9]{2}-[0-9]{2}\.md$") { return $true }
+  return $false
+}
+
+$files = @($ChangedFiles | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+if ($files.Count -eq 0) {
+  $files = Get-ChangedFilesFromGit -DiffBaseRef $BaseRef -DiffHeadRef $HeadRef
+}
+
+$normalizedFiles = @($files | ForEach-Object { Normalize-Path $_ } | Where-Object { $_ -ne "" } | Select-Object -Unique)
+$nonDocFiles = @($normalizedFiles | Where-Object { -not (Is-DocOnlyPath $_) })
+$requiresDocSync = $nonDocFiles.Count -gt 0
+
+$missingRequiredDocs = @()
+if ($requiresDocSync) {
+  foreach ($required in $requiredDocs) {
+    if (-not ($normalizedFiles -contains $required)) {
+      $missingRequiredDocs += $required
+    }
+  }
+}
+
+$result = [ordered]@{
+  passed = ($missingRequiredDocs.Count -eq 0)
+  requiresDocSync = $requiresDocSync
+  changedFiles = $normalizedFiles
+  nonDocFiles = $nonDocFiles
+  requiredDocs = $requiredDocs
+  missingRequiredDocs = $missingRequiredDocs
+}
+
+if ($AsJson) {
+  $result | ConvertTo-Json -Depth 6
+}
+
+if ($missingRequiredDocs.Count -gt 0) {
+  Write-Host "Doc sync check FAILED."
+  Write-Host "Changed non-doc files:"
+  foreach ($item in $nonDocFiles) {
+    Write-Host ("- " + $item)
+  }
+  Write-Host "Missing required docs:"
+  foreach ($item in $missingRequiredDocs) {
+    Write-Host ("- " + $item)
+  }
+  exit 1
+}
+
+Write-Host "Doc sync check PASSED."
+Write-Host ("requiresDocSync=" + $requiresDocSync)


### PR DESCRIPTION
## Summary
- add `scripts/check-doc-sync.ps1` to enforce required doc updates when non-doc files change
- integrate a new `doc_sync` job into `.github/workflows/pr-gate.yml`
  - fetches PR base branch
  - diffs changed files and fails if `docs/changelog-dev.md` + `CLAUDE.md` are missing
- include `doc_sync` result in final `gate` aggregation
- extend workflow PowerShell syntax checks to include the new script in:
  - `.github/workflows/pr-gate.yml`
  - `.github/workflows/workflow-lint.yml`
- sync docs (`AGENTS.md`, `CLAUDE.md`, `docs/changelog-dev.md`, `2026-02-26.md`)

## Validation
- `./scripts/check-doc-sync.ps1 -ChangedFiles @('apps/api/src/main/java/com/example/Foo.java','docs/changelog-dev.md','CLAUDE.md')`
- `./scripts/check-doc-sync.ps1 -ChangedFiles @('apps/api/src/main/java/com/example/Foo.java')` (expected fail)
- `$files = git diff --name-only; ./scripts/check-doc-sync.ps1 -ChangedFiles $files`
- `rg -n "^(<<<<<<<|=======|>>>>>>>)+$" README.md docs CLAUDE.md AGENTS.md .github/workflows scripts/check-doc-sync.ps1`