### PR TITLE
feat: add mobile store failure diagnosis and recovery runbook

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -169,7 +169,8 @@ jobs:
             "scripts/release-preflight.ps1",
             "scripts/new-worktree-task.ps1",
             "scripts/apply-branch-protection.ps1",
-            "scripts/check-doc-sync.ps1"
+            "scripts/check-doc-sync.ps1",
+            "scripts/mobile-store-diagnose.ps1"
           )
 
           $hasErrors = $false

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -49,7 +49,8 @@ jobs:
             "scripts/release-preflight.ps1",
             "scripts/new-worktree-task.ps1",
             "scripts/apply-branch-protection.ps1",
-            "scripts/check-doc-sync.ps1"
+            "scripts/check-doc-sync.ps1",
+            "scripts/mobile-store-diagnose.ps1"
           )
 
           $hasErrors = $false

--- a/2026-02-26.md
+++ b/2026-02-26.md
@@ -13,7 +13,7 @@ Baseline date: 2026-02-24. This document fixes the next execution order for ongo
    - Vitest unit tests + CI enforcement
 2. Strengthen API use case unit tests [DONE - first pass]
    - Prioritize complex use cases (event export, AI recommendation)
-3. Mobile release credential recovery runbook
+3. Mobile release credential recovery runbook [DONE]
    - Root-cause-based recovery checklist for `play_upload` and `testflight`
 4. Reduce ops alert noise
    - Tighten HOLD/ERROR dedup and re-alert rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -554,7 +554,9 @@ com.eunhyehymn/
 - **운영 스크립트**:
   - `scripts/mobile-store-preflight.ps1`
   - `scripts/mobile-store-cycle.ps1`
+  - `scripts/mobile-store-diagnose.ps1`
   - 실행 로그: `docs/mobile-store-release-log.md`
+  - 복구 가이드: `docs/mobile-store-recovery.md`
 
 ### Deploy Staging (`deploy-staging.yml`)
 - **트리거**: develop push + `workflow_dispatch`
@@ -839,6 +841,10 @@ develop push → GitHub Actions
 - publish 경로 실검증 실행:
   - Android `play_upload`: run `22329008651` 실패 (Google Play 업로드 단계)
   - iOS `testflight`: run `22329248773` 실패 (Apple 인증서 import 단계)
+- 실패 run 진단/복구 장치 추가 완료 (2026-02-24)
+  - `scripts/mobile-store-diagnose.ps1`: 실패 step 기반 원인 키 + 복구 액션 출력
+  - `scripts/mobile-store-cycle.ps1`: 실패 시 진단 요약(`failure_key`, `failed_step`, `recovery_hint`)을 로그 노트에 자동 반영
+  - `scripts/mobile-store-preflight.ps1`: 실패 체크별 recovery hint 출력
 - 남은 과제:
   - placeholder 시크릿을 실제 스토어 자격증명으로 교체
   - 교체 후 `play_upload`/`testflight` 재실행 및 성공 로그 확보

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -131,7 +131,9 @@ iOS TestFlight secrets:
 Store release cycle helpers:
 - `scripts/mobile-store-preflight.ps1` (mode-based secret/input checks)
 - `scripts/mobile-store-cycle.ps1` (preflight + workflow_dispatch + run watch + log append)
+- `scripts/mobile-store-diagnose.ps1` (failed step diagnosis + recovery actions)
 - `docs/mobile-store-release-log.md` (execution evidence log)
+- `docs/mobile-store-recovery.md` (recovery runbook for failed publish paths)
 - latest publish-path verification (2026-02-23):
   - Android `play_upload`: run `22329008651` failed at Google Play upload step
   - iOS `testflight`: run `22329248773` failed at Apple certificate import step

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -101,6 +101,25 @@
   - `AGENTS.md`
   - `CLAUDE.md`
 
+### Mobile store failure diagnosis + recovery runbook
+- Added failed-run diagnosis script
+  - `scripts/mobile-store-diagnose.ps1`
+  - Extracts failed job/step from GitHub Actions run and maps to recovery actions
+- Enhanced mobile store cycle/preflight diagnostics
+  - `scripts/mobile-store-cycle.ps1`
+    - Appends failure diagnosis (`failure_key`, `failed_step`, `recovery_hint`) to log notes when run fails
+  - `scripts/mobile-store-preflight.ps1`
+    - Prints check-specific recovery hints for missing/invalid prerequisites
+- CI syntax-check coverage update
+  - `.github/workflows/pr-gate.yml`
+  - `.github/workflows/workflow-lint.yml`
+  - Added `scripts/mobile-store-diagnose.ps1` to PowerShell syntax validation target list
+- Added recovery documentation
+  - `docs/mobile-store-recovery.md`
+  - `docs/mobile/README.md`
+  - `apps/mobile/README.md`
+  - `docs/runbook.md`
+
 ## 2026-02-23
 
 ### Staging manual smoke recency gate + log automation

--- a/docs/mobile-store-recovery.md
+++ b/docs/mobile-store-recovery.md
@@ -1,0 +1,40 @@
+# Mobile Store Release Recovery Guide
+
+This guide standardizes recovery steps when `mobile-store-release.yml` fails in `play_upload` or `testflight` mode.
+
+## 1. Quick Start
+
+1. Run preflight checks for the same target/mode.
+   - `.\scripts\mobile-store-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn -Target android -AndroidDistributionMode play_upload`
+   - `.\scripts\mobile-store-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn -Target ios -IosDistributionMode testflight`
+2. Diagnose a failed workflow run.
+   - `.\scripts\mobile-store-diagnose.ps1 -Repo V4N1LLA/Eunhye_Hymn -RunId <run_id>`
+3. Apply credential/config fixes from the diagnosis output.
+4. Re-run `mobile-store-cycle.ps1` with the same target/mode.
+
+## 2. Failure-Step Mapping
+
+| Failed step | Typical root cause | First recovery action |
+|---|---|---|
+| `Upload Android AAB to Google Play` | Service account/package/track permission mismatch | Re-issue `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` and verify package/track |
+| `Validate Android signing secrets` | Missing or empty Android signing secrets | Re-sync `MOBILE_ANDROID_*` and rerun preflight |
+| `Prepare Android keystore` | Corrupted base64 or alias/password mismatch | Re-export keystore base64 and verify alias/password pair |
+| `Import Apple code-sign certificate` | Invalid/expired p12 or wrong password | Re-export p12, rotate `MOBILE_IOS_P12_*`, confirm Team ID match |
+| `Download App Store provisioning profile` | Bundle id/API key entitlement mismatch | Validate `MOBILE_IOS_BUNDLE_ID` + App Store API key scope |
+| `Upload to TestFlight` | App Store Connect auth/metadata mismatch | Verify API key permissions and app record settings |
+
+## 3. Script Responsibilities
+
+- `scripts/mobile-store-preflight.ps1`
+  - checks mode-specific required secrets/inputs before dispatch
+  - prints per-check recovery hints when validation fails
+- `scripts/mobile-store-diagnose.ps1`
+  - reads a failed run from GitHub Actions
+  - resolves failed job/step and emits recovery actions
+- `scripts/mobile-store-cycle.ps1`
+  - appends failure diagnosis (`failure_key`, `failed_step`, `recovery_hint`) to log notes on failure
+
+## 4. Evidence and Logging
+
+- Store cycle logs are appended to `docs/mobile-store-release-log.md`.
+- Keep failed run URLs and diagnosis results in the same cycle for RCA continuity.

--- a/docs/mobile/README.md
+++ b/docs/mobile/README.md
@@ -196,8 +196,12 @@ Android Kakao 콜백 스킴은 `kakao<KAKAO_NATIVE_APP_KEY>`이므로,
   - `.\scripts\mobile-store-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref develop -Target android -AndroidDistributionMode build_only -IosDistributionMode build_only`
   - `.\scripts\mobile-store-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref develop -Target android -AndroidDistributionMode play_upload -IosDistributionMode build_only`
   - `.\scripts\mobile-store-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref develop -Target ios -AndroidDistributionMode build_only -IosDistributionMode testflight`
+- 실패 run 진단:
+  - `.\scripts\mobile-store-diagnose.ps1 -Repo V4N1LLA/Eunhye_Hymn -RunId <run_id>`
 - 실행 로그:
   - `docs/mobile-store-release-log.md`
+- 복구 가이드:
+  - `docs/mobile-store-recovery.md`
 - 최근 검증(2026-02-23):
   - Android `play_upload`: run `22329008651` 실패 (`Upload Android AAB to Google Play`)
   - iOS `testflight`: run `22329248773` 실패 (`Import Apple code-sign certificate`)

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -116,3 +116,16 @@
   - `ai_recommend_requests_total`, `ai_recommend_latency_seconds`, `ai_recommend_fallback_total`
   - 기준: success rate >= 99%, p95 latency <= 2.0s, fallback ratio <= 5%
 - 월 1회 롤백 시나리오 점검
+
+## 10. Mobile Store Failure Recovery
+- Preflight before dispatch:
+  - `.\scripts\mobile-store-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn -Target android -AndroidDistributionMode play_upload`
+  - `.\scripts\mobile-store-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn -Target ios -IosDistributionMode testflight`
+- Diagnose failed run:
+  - `.\scripts\mobile-store-diagnose.ps1 -Repo V4N1LLA/Eunhye_Hymn -RunId <run_id>`
+- Re-run cycle after credential/input fixes:
+  - `.\scripts\mobile-store-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref develop -Target android -AndroidDistributionMode play_upload -IosDistributionMode build_only`
+  - `.\scripts\mobile-store-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Ref develop -Target ios -AndroidDistributionMode build_only -IosDistributionMode testflight`
+- Reference docs:
+  - `docs/mobile-store-recovery.md`
+  - `docs/mobile-store-release-log.md`

--- a/scripts/mobile-store-cycle.ps1
+++ b/scripts/mobile-store-cycle.ps1
@@ -103,6 +103,55 @@ function Get-FirstUsefulLine {
   return $lines[0]
 }
 
+function Build-FailureDiagnosisNote {
+  param(
+    [string]$Repo,
+    [string]$RunId,
+    [string]$DiagnoseScriptPath
+  )
+
+  if ([string]::IsNullOrWhiteSpace($RunId) -or -not (Test-Path $DiagnoseScriptPath)) {
+    return ""
+  }
+
+  $diagnoseResult = Invoke-PowerShellFile -ScriptPath $DiagnoseScriptPath -Arguments @(
+    "-Repo", $Repo,
+    "-RunId", $RunId,
+    "-AsJson"
+  )
+  if ($diagnoseResult.ExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($diagnoseResult.Output)) {
+    return ""
+  }
+
+  try {
+    $diag = $diagnoseResult.Output | ConvertFrom-Json
+    $parts = @()
+
+    if (-not [string]::IsNullOrWhiteSpace("$($diag.failureKey)")) {
+      $parts += ("failure_key=" + $diag.failureKey)
+    }
+    if (-not [string]::IsNullOrWhiteSpace("$($diag.failedStepName)")) {
+      $parts += ("failed_step=" + $diag.failedStepName)
+    }
+
+    $firstRecovery = ""
+    if ($diag.recoveryActions -and $diag.recoveryActions.Count -gt 0) {
+      $firstRecovery = "$($diag.recoveryActions[0])"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($firstRecovery)) {
+      $hint = $firstRecovery.Replace(";", ",")
+      if ($hint.Length -gt 160) {
+        $hint = $hint.Substring(0, 160) + "..."
+      }
+      $parts += ("recovery_hint=" + $hint)
+    }
+
+    return ($parts -join ", ")
+  } catch {
+    return ""
+  }
+}
+
 function Invoke-PowerShellFile {
   param(
     [Parameter(Mandatory = $true)]
@@ -354,6 +403,15 @@ $runInfo = $runView | ConvertFrom-Json
 $conclusion = if ([string]::IsNullOrWhiteSpace($runInfo.conclusion)) { "unknown" } else { $runInfo.conclusion }
 $result = if ($watchExitCode -eq 0 -and $conclusion -eq "success") { "SUCCESS" } else { "FAILED" }
 $notes = "conclusion=$conclusion, head_sha=$($runInfo.headSha)"
+$diagnosisNote = ""
+
+if ($result -ne "SUCCESS") {
+  $diagnoseScript = Join-Path $PSScriptRoot "mobile-store-diagnose.ps1"
+  $diagnosisNote = Build-FailureDiagnosisNote -Repo $Repo -RunId $runId -DiagnoseScriptPath $diagnoseScript
+  if (-not [string]::IsNullOrWhiteSpace($diagnosisNote)) {
+    $notes = "$notes, $diagnosisNote"
+  }
+}
 
 Append-LogRow -Path $LogFile -Row @{
   UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
@@ -379,6 +437,9 @@ Write-Host ("Conclusion: {0}" -f $conclusion)
 Write-Host ("Log: {0}" -f $LogFile)
 
 if ($result -ne "SUCCESS") {
+  if (-not [string]::IsNullOrWhiteSpace($diagnosisNote)) {
+    throw "workflow run failed (run id: $runId), $diagnosisNote"
+  }
   exit 1
 }
 

--- a/scripts/mobile-store-diagnose.ps1
+++ b/scripts/mobile-store-diagnose.ps1
@@ -1,0 +1,187 @@
+param(
+  [string]$Repo = "V4N1LLA/Eunhye_Hymn",
+  [Parameter(Mandatory = $true)][string]$RunId,
+  [switch]$AsJson
+)
+
+$ErrorActionPreference = "Stop"
+
+function Test-CommandExists {
+  param([string]$Name)
+  return $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Resolve-FailureKey {
+  param(
+    [string]$JobName,
+    [string]$StepName
+  )
+
+  if ($StepName -like "*Upload Android AAB to Google Play*") { return "android_play_upload" }
+  if ($StepName -like "*Validate Android signing secrets*") { return "android_signing_secret_validation" }
+  if ($StepName -like "*Prepare Android keystore*") { return "android_keystore_prepare" }
+  if ($StepName -like "*Build Android signed AAB*") { return "android_aab_build" }
+  if ($StepName -like "*Import Apple code-sign certificate*") { return "ios_codesign_certificate_import" }
+  if ($StepName -like "*Download App Store provisioning profile*") { return "ios_profile_download" }
+  if ($StepName -like "*Build iOS signed archive and IPA*") { return "ios_archive_build" }
+  if ($StepName -like "*Upload to TestFlight*") { return "ios_testflight_upload" }
+
+  if ($JobName -eq "android-signed-aab") { return "android_job_failure" }
+  if ($JobName -eq "ios-testflight-upload") { return "ios_job_failure" }
+  return "unknown_failure"
+}
+
+function Get-RecoveryActions {
+  param([string]$FailureKey)
+
+  switch ($FailureKey) {
+    "android_play_upload" {
+      return @(
+        "Verify GOOGLE_PLAY_SERVICE_ACCOUNT_JSON has Play Console release permissions for the package.",
+        "Confirm android_package_name (or GOOGLE_PLAY_PACKAGE_NAME) matches an existing app in Play Console.",
+        "Retry with android_distribution_mode=play_upload after validating track/release status inputs."
+      )
+    }
+    "android_signing_secret_validation" {
+      return @(
+        "Set MOBILE_ANDROID_KEYSTORE_BASE64, MOBILE_ANDROID_KEY_ALIAS, MOBILE_ANDROID_KEY_PASSWORD, and MOBILE_ANDROID_STORE_PASSWORD.",
+        "If play upload mode is used, also set GOOGLE_PLAY_SERVICE_ACCOUNT_JSON and package name input/secret.",
+        "Run scripts/mobile-store-preflight.ps1 again before rerunning the workflow."
+      )
+    }
+    "android_keystore_prepare" {
+      return @(
+        "Regenerate base64 from a valid release keystore and update MOBILE_ANDROID_KEYSTORE_BASE64.",
+        "Validate key alias/password pair against the keystore locally.",
+        "Re-run build_only first to isolate signing before play_upload."
+      )
+    }
+    "android_aab_build" {
+      return @(
+        "Inspect Flutter/Gradle build logs for signing or dependency errors.",
+        "Confirm android/key.properties values map to the imported keystore content.",
+        "Run scripts/build-mobile-apk.ps1 locally with release mode to reproduce quickly."
+      )
+    }
+    "ios_codesign_certificate_import" {
+      return @(
+        "Regenerate MOBILE_IOS_P12_BASE64 from a valid Apple Distribution certificate and verify MOBILE_IOS_P12_PASSWORD.",
+        "Ensure certificate is not expired/revoked and matches MOBILE_IOS_TEAM_ID.",
+        "Retry testflight mode after replacing certificate secrets."
+      )
+    }
+    "ios_profile_download" {
+      return @(
+        "Verify MOBILE_IOS_BUNDLE_ID (or ios_bundle_id input) exists in App Store Connect.",
+        "Check App Store API key secrets have provisioning profile access.",
+        "Confirm Team ID and bundle ID belong to the same Apple Developer team."
+      )
+    }
+    "ios_archive_build" {
+      return @(
+        "Validate provisioning profile specifier and signing identity for the selected bundle id.",
+        "Inspect xcodebuild archive logs for signing mismatch errors.",
+        "Run build_only first to isolate Flutter build issues before signed archive."
+      )
+    }
+    "ios_testflight_upload" {
+      return @(
+        "Verify App Store Connect API credentials and app permissions for upload.",
+        "Ensure the IPA bundle id/version is valid for the target app record.",
+        "Retry with updated release notes and confirmed issuer/key pair."
+      )
+    }
+    "android_job_failure" {
+      return @(
+        "Inspect android-signed-aab job logs for first failed step and exception details.",
+        "Run scripts/mobile-store-preflight.ps1 with the same target/mode before retry.",
+        "Retry in build_only mode first, then switch back to play_upload."
+      )
+    }
+    "ios_job_failure" {
+      return @(
+        "Inspect ios-testflight-upload job logs for first failed step and exception details.",
+        "Re-run scripts/mobile-store-preflight.ps1 with ios testflight settings.",
+        "Validate iOS signing secrets and bundle id before retry."
+      )
+    }
+    default {
+      return @(
+        "Open the failed job log and capture the first failed step/error line.",
+        "Validate mode-specific secrets with scripts/mobile-store-preflight.ps1.",
+        "Update credentials/inputs and rerun the workflow."
+      )
+    }
+  }
+}
+
+if (-not (Test-CommandExists "gh")) {
+  throw "gh CLI is required."
+}
+
+$runJson = gh run view $RunId --repo $Repo --json conclusion,status,url,displayTitle,workflowName,jobs
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($runJson)) {
+  throw "failed to load workflow run details for run id: $RunId"
+}
+
+$runInfo = $runJson | ConvertFrom-Json
+$failedJobs = @($runInfo.jobs | Where-Object { $_.conclusion -in @("failure", "cancelled", "timed_out", "action_required") })
+$failedJobs = @($failedJobs | Sort-Object startedAt)
+
+$failedJob = $null
+$failedStep = $null
+foreach ($job in $failedJobs) {
+  $candidate = @($job.steps | Where-Object { $_.conclusion -eq "failure" } | Sort-Object number | Select-Object -First 1)
+  if ($candidate.Count -gt 0) {
+    $failedJob = $job
+    $failedStep = $candidate[0]
+    break
+  }
+}
+
+if ($null -eq $failedJob -and $failedJobs.Count -gt 0) {
+  $failedJob = $failedJobs[0]
+}
+
+$failedJobName = if ($null -eq $failedJob) { "" } else { "$($failedJob.name)" }
+$failedStepName = if ($null -eq $failedStep) { "" } else { "$($failedStep.name)" }
+$failureKey = Resolve-FailureKey -JobName $failedJobName -StepName $failedStepName
+$recoveryActions = Get-RecoveryActions -FailureKey $failureKey
+
+$result = [ordered]@{
+  runId = "$RunId"
+  workflowName = "$($runInfo.workflowName)"
+  displayTitle = "$($runInfo.displayTitle)"
+  status = "$($runInfo.status)"
+  conclusion = "$($runInfo.conclusion)"
+  url = "$($runInfo.url)"
+  failedJobName = $failedJobName
+  failedJobUrl = if ($null -eq $failedJob) { "" } else { "$($failedJob.url)" }
+  failedStepName = $failedStepName
+  failureKey = $failureKey
+  recoveryActions = $recoveryActions
+}
+
+if ($AsJson) {
+  $result | ConvertTo-Json -Depth 6
+  exit 0
+}
+
+Write-Host "== Mobile Store Run Diagnosis =="
+Write-Host ("RunId: {0}" -f $result.runId)
+Write-Host ("Workflow: {0}" -f $result.workflowName)
+Write-Host ("Conclusion: {0}" -f $result.conclusion)
+if (-not [string]::IsNullOrWhiteSpace($result.failedJobName)) {
+  Write-Host ("Failed Job: {0}" -f $result.failedJobName)
+}
+if (-not [string]::IsNullOrWhiteSpace($result.failedStepName)) {
+  Write-Host ("Failed Step: {0}" -f $result.failedStepName)
+}
+Write-Host ("Failure Key: {0}" -f $result.failureKey)
+Write-Host "Recovery actions:"
+foreach ($action in $result.recoveryActions) {
+  Write-Host ("- " + $action)
+}
+Write-Host ("Run URL: {0}" -f $result.url)
+
+exit 0

--- a/scripts/mobile-store-preflight.ps1
+++ b/scripts/mobile-store-preflight.ps1
@@ -44,6 +44,34 @@ function Add-SecretCheck {
   Add-Check ("secret " + $SecretName) $false ("missing: " + $Reason)
 }
 
+function Get-RecoveryHintForCheck {
+  param([string]$CheckName)
+
+  if ($CheckName -like "secret MOBILE_ANDROID_*") {
+    return "Update Android signing secrets from a valid release keystore and retry preflight."
+  }
+  if ($CheckName -eq "secret GOOGLE_PLAY_SERVICE_ACCOUNT_JSON") {
+    return "Set a Play service account JSON key with upload/release permissions for the target package."
+  }
+  if ($CheckName -eq "android package name") {
+    return "Pass -AndroidPackageName or set GOOGLE_PLAY_PACKAGE_NAME secret."
+  }
+  if ($CheckName -eq "ios bundle id" -or $CheckName -eq "secret MOBILE_IOS_BUNDLE_ID") {
+    return "Pass -IosBundleId or set MOBILE_IOS_BUNDLE_ID to a real App Store bundle id."
+  }
+  if ($CheckName -like "secret MOBILE_IOS_*") {
+    return "Update iOS TestFlight secrets (team, p12, App Store key trio) and retry preflight."
+  }
+  if ($CheckName -eq "gh auth status") {
+    return "Run gh auth login and re-run preflight."
+  }
+  if ($CheckName -eq "gh secret list") {
+    return "Verify repository access and token scope, then re-run preflight."
+  }
+
+  return "Review workflow configuration and corresponding secret/input values."
+}
+
 Add-Check "gh cli" (Test-CommandExists "gh") "required"
 if (-not (Test-CommandExists "gh")) {
   $checks | Format-Table -AutoSize
@@ -120,6 +148,12 @@ $checks | Format-Table -AutoSize
 
 $failed = @($checks | Where-Object { -not $_.Passed })
 if ($failed.Count -gt 0) {
+  Write-Host ""
+  Write-Host "Recovery hints:"
+  foreach ($item in $failed) {
+    $hint = Get-RecoveryHintForCheck -CheckName "$($item.Name)"
+    Write-Host ("- " + $item.Name + ": " + $hint)
+  }
   exit 1
 }
 


### PR DESCRIPTION
﻿## Summary
- add `scripts/mobile-store-diagnose.ps1` to map failed mobile-store runs to recovery actions
- enrich `scripts/mobile-store-cycle.ps1` failure logs with diagnosis (`failure_key`, `failed_step`, `recovery_hint`)
- add recovery hints in `scripts/mobile-store-preflight.ps1` for failed checks
- add `docs/mobile-store-recovery.md` and sync related mobile/runbook/changelog docs
- include the new script in PowerShell syntax checks in PR gate and workflow lint

## Validation
- parser check passed for `scripts/mobile-store-preflight.ps1`, `scripts/mobile-store-cycle.ps1`, `scripts/mobile-store-diagnose.ps1`
- `./scripts/check-doc-sync.ps1 -ChangedFiles (git diff --cached --name-only)`
- `powershell -NoProfile -File .\scripts\mobile-store-diagnose.ps1 -Repo V4N1LLA/Eunhye_Hymn -RunId 22329008651 -AsJson`
- `powershell -NoProfile -File .\scripts\mobile-store-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn -Target android -AndroidDistributionMode play_upload`
- `powershell -NoProfile -File .\scripts\mobile-store-preflight.ps1 -Repo V4N1LLA/Eunhye_Hymn -Target ios -IosDistributionMode testflight`
