### PR TITLE
feat: reduce ops health alert noise with dedup cooldown rules

### DIFF
--- a/2026-02-26.md
+++ b/2026-02-26.md
@@ -15,7 +15,7 @@ Baseline date: 2026-02-24. This document fixes the next execution order for ongo
    - Prioritize complex use cases (event export, AI recommendation)
 3. Mobile release credential recovery runbook [DONE]
    - Root-cause-based recovery checklist for `play_upload` and `testflight`
-4. Reduce ops alert noise
+4. Reduce ops alert noise [DONE]
    - Tighten HOLD/ERROR dedup and re-alert rules
 5. Improve staging smoke evidence capture
    - Auto-warn on missing links/evidence

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -785,6 +785,10 @@ develop push → GitHub Actions
   - `.github/workflows/deploy-staging.yml`, `.github/workflows/ops-health-scheduled.yml`: workflow_dispatch boolean 입력 false 보존식으로 정규화
   - `scripts/staging-rehearsal.ps1`, `scripts/mobile-store-cycle.ps1`: preflight 실패 시 first-useful-line 추출로 로그/예외 원인 가시성 강화
   - `scripts/staging-ops-cycle.ps1`, `scripts/ops-health-cycle.ps1`: `-LogDedupWindowMinutes`(기본 30) 기반 중복 로그 쓰기 억제
+- HOLD/ERROR 알림 노이즈 제어 반영 (2026-02-24)
+  - `scripts/ops-health-issue-alert.ps1`: dedup/re-alert cooldown(`30m`/`480m`/`120m`) + `-ForceAlert` 지원
+  - `scripts/ops-health-cycle.ps1`: `-AlertDedupWindowMinutes`, `-AlertHoldReAlertWindowMinutes`, `-AlertErrorReAlertWindowMinutes`, `-AlertForce` 전달
+  - `docs/runbook.md`: 알림 볼륨 조정 파라미터 운영 가이드 추가
 - 스테이징 실가동 체크리스트/런북 동기화
   - `docs/staging-smoke-checklist.md`
   - `docs/runbook.md`
@@ -826,6 +830,7 @@ develop push → GitHub Actions
   - `.github/workflows/ops-health-scheduled.yml` (주간)
   - `.github/workflows/secrets-rotation-scheduled.yml` (월간)
   - HOLD/ERROR 자동 이슈 알림: `scripts/ops-health-issue-alert.ps1`
+  - 기본 알림 정책: dedup `30m`, HOLD 재알림 `480m`, ERROR 재알림 `120m` (필요 시 `ops-health-cycle.ps1` alert 파라미터로 조정)
 
 **3. 기능 백로그**
 - 비동기 export 운영 지표(실패율/처리시간/정리량) 정례화 완료 (2026-02-14)

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -120,6 +120,23 @@
   - `apps/mobile/README.md`
   - `docs/runbook.md`
 
+### Ops alert noise reduction (HOLD/ERROR)
+- Added alert dedup + re-alert cooldown policy
+  - `scripts/ops-health-issue-alert.ps1`
+  - New options:
+    - `-DedupWindowMinutes` (default 30)
+    - `-HoldReAlertWindowMinutes` (default 480)
+    - `-ErrorReAlertWindowMinutes` (default 120)
+    - `-ForceAlert` (override skip policy)
+  - Existing open issue alerts now skip repeated comments inside dedup/cooldown windows and return explicit skip reason (`dedup_window` / `realert_cooldown`)
+- Added pass-through controls in orchestrator
+  - `scripts/ops-health-cycle.ps1`
+  - New options:
+    - `-AlertDedupWindowMinutes`
+    - `-AlertHoldReAlertWindowMinutes`
+    - `-AlertErrorReAlertWindowMinutes`
+    - `-AlertForce`
+
 ## 2026-02-23
 
 ### Staging manual smoke recency gate + log automation

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -107,6 +107,15 @@
   - 결과는 `docs/ops-health-log.md`에 자동 누적되고, 실패 원인은 `FailureCategory`로 분류됨
   - GitHub Actions 스케줄 실행: `.github/workflows/ops-health-scheduled.yml` (매주 월요일 02:00 UTC)
   - HOLD/ERROR 시 `scripts/ops-health-issue-alert.ps1`가 이슈를 자동 생성/업데이트
+  - 알림 노이즈 정책 기본값:
+    - dedup window: `30m`
+    - HOLD re-alert cooldown: `480m`
+    - ERROR re-alert cooldown: `120m`
+  - 필요 시 다음 파라미터로 조정:
+    - `-AlertDedupWindowMinutes <int>`
+    - `-AlertHoldReAlertWindowMinutes <int>`
+    - `-AlertErrorReAlertWindowMinutes <int>`
+    - `-AlertForce` (긴급 상황에서 쿨다운 무시)
 - 월 1회 시크릿 교체 상태 점검
   - `.\scripts\secrets-rotation-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Owner <담당자> -MaxAgeDays 90`
   - 모바일 릴리즈 시크릿 포함 점검: `.\scripts\secrets-rotation-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Owner <담당자> -MaxAgeDays 90 -IncludeMobileReleaseSecrets`

--- a/scripts/ops-health-cycle.ps1
+++ b/scripts/ops-health-cycle.ps1
@@ -25,6 +25,10 @@ param(
   [switch]$AlertOnFailure,
   [string]$AlertRepo = "",
   [switch]$AlertDryRun,
+  [int]$AlertDedupWindowMinutes = 30,
+  [int]$AlertHoldReAlertWindowMinutes = 480,
+  [int]$AlertErrorReAlertWindowMinutes = 120,
+  [switch]$AlertForce,
   [switch]$AsJson
 )
 
@@ -303,6 +307,15 @@ if ($SecretsMaxAgeDays -lt 1) {
 if ($LogDedupWindowMinutes -lt 0) {
   throw "LogDedupWindowMinutes must be >= 0"
 }
+if ($AlertDedupWindowMinutes -lt 0) {
+  throw "AlertDedupWindowMinutes must be >= 0"
+}
+if ($AlertHoldReAlertWindowMinutes -lt 0) {
+  throw "AlertHoldReAlertWindowMinutes must be >= 0"
+}
+if ($AlertErrorReAlertWindowMinutes -lt 0) {
+  throw "AlertErrorReAlertWindowMinutes must be >= 0"
+}
 if ([string]::IsNullOrWhiteSpace($ManualSmokeResult) -and (
     -not [string]::IsNullOrWhiteSpace($ManualSmokeEvidence) -or
     -not [string]::IsNullOrWhiteSpace($ManualSmokeNotes)
@@ -508,10 +521,16 @@ if ($AlertOnFailure -and $overall -ne "PASS") {
       "-Notes", ($notes -join "; "),
       "-Operator", $Owner,
       "-SourceLog", $OpsHealthLogFile,
+      "-DedupWindowMinutes", "$AlertDedupWindowMinutes",
+      "-HoldReAlertWindowMinutes", "$AlertHoldReAlertWindowMinutes",
+      "-ErrorReAlertWindowMinutes", "$AlertErrorReAlertWindowMinutes",
       "-AsJson"
     )
     if ($AlertDryRun) {
       $alertArgs += "-DryRun"
+    }
+    if ($AlertForce) {
+      $alertArgs += "-ForceAlert"
     }
 
     $alertInvocation = Invoke-PowerShellFile -ScriptPath $alertScript -Arguments $alertArgs

--- a/scripts/ops-health-issue-alert.ps1
+++ b/scripts/ops-health-issue-alert.ps1
@@ -8,6 +8,10 @@ param(
   [string]$Notes = "",
   [string]$Operator = "codex",
   [string]$SourceLog = "docs/ops-health-log.md",
+  [int]$DedupWindowMinutes = 30,
+  [int]$HoldReAlertWindowMinutes = 480,
+  [int]$ErrorReAlertWindowMinutes = 120,
+  [switch]$ForceAlert,
   [switch]$DryRun,
   [switch]$AsJson
 )
@@ -36,7 +40,68 @@ function Normalize-Token {
   return $normalized
 }
 
+function Get-ReAlertWindowMinutes {
+  param(
+    [string]$Overall,
+    [int]$HoldWindowMinutes,
+    [int]$ErrorWindowMinutes
+  )
+
+  if ($Overall -eq "ERROR") {
+    return $ErrorWindowMinutes
+  }
+
+  return $HoldWindowMinutes
+}
+
+function Get-IssueAlertState {
+  param(
+    [string]$Repo,
+    [string]$IssueNumber
+  )
+
+  $issueViewJson = gh issue view $IssueNumber --repo $Repo --json number,url,createdAt,comments
+  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($issueViewJson)) {
+    throw "failed to query issue activity."
+  }
+
+  $issueView = $issueViewJson | ConvertFrom-Json
+
+  [datetime]$lastAlertUtc = [datetime]::MinValue
+  [datetime]$createdUtc = [datetime]::MinValue
+  if ([datetime]::TryParse("$($issueView.createdAt)", [ref]$createdUtc)) {
+    $lastAlertUtc = $createdUtc.ToUniversalTime()
+  }
+
+  foreach ($comment in @($issueView.comments)) {
+    [datetime]$commentUtc = [datetime]::MinValue
+    if ([datetime]::TryParse("$($comment.createdAt)", [ref]$commentUtc)) {
+      $candidateUtc = $commentUtc.ToUniversalTime()
+      if ($candidateUtc -gt $lastAlertUtc) {
+        $lastAlertUtc = $candidateUtc
+      }
+    }
+  }
+
+  return [PSCustomObject]@{
+    IssueNumber = "$($issueView.number)"
+    IssueUrl = "$($issueView.url)"
+    HasLastAlert = ($lastAlertUtc -ne [datetime]::MinValue)
+    LastAlertUtc = $lastAlertUtc
+  }
+}
+
 $utcNow = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+if ($DedupWindowMinutes -lt 0) {
+  throw "DedupWindowMinutes must be >= 0"
+}
+if ($HoldReAlertWindowMinutes -lt 0) {
+  throw "HoldReAlertWindowMinutes must be >= 0"
+}
+if ($ErrorReAlertWindowMinutes -lt 0) {
+  throw "ErrorReAlertWindowMinutes must be >= 0"
+}
 
 $result = [PSCustomObject]@{
   UtcTime = $utcNow
@@ -50,6 +115,12 @@ $result = [PSCustomObject]@{
   IssueNumber = ""
   IssueUrl = ""
   Title = ""
+  SkipReason = ""
+  LastAlertUtc = ""
+  MinutesSinceLastAlert = ""
+  DedupWindowMinutes = $DedupWindowMinutes
+  ReAlertWindowMinutes = ""
+  ForceAlert = [bool]$ForceAlert
 }
 
 if ($Overall -eq "PASS") {
@@ -74,6 +145,8 @@ $categoryToken = Normalize-Token -Value $FailureCategory -Fallback "unknown"
 $branchToken = Normalize-Token -Value $Branch -Fallback "branch"
 $title = "[ops-health][$branchToken][$categoryToken][$Overall]-action-required"
 $result.Title = $title
+$reAlertWindowMinutes = Get-ReAlertWindowMinutes -Overall $Overall -HoldWindowMinutes $HoldReAlertWindowMinutes -ErrorWindowMinutes $ErrorReAlertWindowMinutes
+$result.ReAlertWindowMinutes = $reAlertWindowMinutes
 
 $body = @"
 ### Ops health alert
@@ -92,21 +165,50 @@ $Notes
 "@
 
 $search = "$title in:title"
-$existingJson = gh issue list --repo $Repo --state open --search $search --json number,title,url --limit 1
+$existingJson = gh issue list --repo $Repo --state open --search $search --json number,title,url --limit 50
 if ($LASTEXITCODE -ne 0) {
   throw "failed to query existing issues."
 }
 
-$existing = @()
+$existingCandidates = @()
 if (-not [string]::IsNullOrWhiteSpace($existingJson)) {
-  $existing = $existingJson | ConvertFrom-Json
+  $existingCandidates = $existingJson | ConvertFrom-Json
+}
+$existing = @($existingCandidates | Where-Object { "$($_.title)" -eq $title } | Select-Object -First 1)
+
+$skipAlert = $false
+$skipReason = ""
+if ($existing.Count -gt 0) {
+  $issueState = Get-IssueAlertState -Repo $Repo -IssueNumber "$($existing[0].number)"
+  $result.IssueNumber = "$($issueState.IssueNumber)"
+  $result.IssueUrl = "$($issueState.IssueUrl)"
+
+  if ($issueState.HasLastAlert) {
+    $lastAlertUtc = $issueState.LastAlertUtc.ToString("yyyy-MM-ddTHH:mm:ssZ")
+    $minutesSinceLast = [math]::Round(((Get-Date).ToUniversalTime() - $issueState.LastAlertUtc).TotalMinutes, 1)
+    $result.LastAlertUtc = $lastAlertUtc
+    $result.MinutesSinceLastAlert = "$minutesSinceLast"
+
+    if (-not $ForceAlert) {
+      if ($DedupWindowMinutes -gt 0 -and $minutesSinceLast -lt $DedupWindowMinutes) {
+        $skipAlert = $true
+        $skipReason = "dedup_window"
+      } elseif ($reAlertWindowMinutes -gt 0 -and $minutesSinceLast -lt $reAlertWindowMinutes) {
+        $skipAlert = $true
+        $skipReason = "realert_cooldown"
+      }
+    }
+  }
 }
 
 if ($DryRun) {
   if ($existing.Count -gt 0) {
-    $result.Action = "dryrun_comment"
-    $result.IssueNumber = "$($existing[0].number)"
-    $result.IssueUrl = "$($existing[0].url)"
+    if ($skipAlert) {
+      $result.Action = "dryrun_skipped"
+      $result.SkipReason = $skipReason
+    } else {
+      $result.Action = "dryrun_comment"
+    }
   } else {
     $result.Action = "dryrun_create"
   }
@@ -120,7 +222,19 @@ if ($DryRun) {
 }
 
 if ($existing.Count -gt 0) {
-  $issueNumber = "$($existing[0].number)"
+  if ($skipAlert) {
+    $result.Action = "skipped"
+    $result.SkipReason = $skipReason
+
+    if ($AsJson) {
+      $result | ConvertTo-Json -Depth 6
+    } else {
+      Write-Host ("ops-health alert skipped ({0}): {1}" -f $skipReason, $result.IssueUrl)
+    }
+    exit 0
+  }
+
+  $issueNumber = "$($result.IssueNumber)"
   gh issue comment $issueNumber --repo $Repo --body $body 1>$null
   if ($LASTEXITCODE -ne 0) {
     throw "failed to append issue comment."
@@ -128,7 +242,6 @@ if ($existing.Count -gt 0) {
 
   $result.Action = "commented"
   $result.IssueNumber = $issueNumber
-  $result.IssueUrl = "$($existing[0].url)"
 } else {
   $createdUrl = gh issue create --repo $Repo --title $title --body $body
   if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
﻿## Summary
- add HOLD/ERROR alert dedup and re-alert cooldown policy in `scripts/ops-health-issue-alert.ps1`
- add override controls (`-DedupWindowMinutes`, `-HoldReAlertWindowMinutes`, `-ErrorReAlertWindowMinutes`, `-ForceAlert`) and expose skip metadata (`SkipReason`, `LastAlertUtc`, `MinutesSinceLastAlert`)
- pass alert policy parameters through from `scripts/ops-health-cycle.ps1` (`-AlertDedupWindowMinutes`, `-AlertHoldReAlertWindowMinutes`, `-AlertErrorReAlertWindowMinutes`, `-AlertForce`)
- sync docs and backlog status (`docs/runbook.md`, `docs/changelog-dev.md`, `CLAUDE.md`, `2026-02-26.md`)

## Validation
- `powershell -NoProfile -Command "[void][System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path 'scripts/ops-health-issue-alert.ps1'), [ref]$null, [ref]$null); [void][System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path 'scripts/ops-health-cycle.ps1'), [ref]$null, [ref]$null)"`
- `powershell -NoProfile -File .\scripts\ops-health-issue-alert.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Overall HOLD -FailureCategory deploy_freshness -Evidence docs/ops-health-log.md -Notes "dry-run policy check" -DedupWindowMinutes 15 -HoldReAlertWindowMinutes 120 -ErrorReAlertWindowMinutes 30 -DryRun -AsJson`
- `powershell -NoProfile -File .\scripts\ops-health-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -Owner codex -SkipSecretsRotation -StagingLogFile .\.tmp\staging-smoke-test-log.md -OpsHealthLogFile .\.tmp\ops-health-test-log.md -AlertOnFailure -AlertDryRun -AlertDedupWindowMinutes 15 -AlertHoldReAlertWindowMinutes 120 -AlertErrorReAlertWindowMinutes 30 -AsJson` (expected exit code: 1 because overall=HOLD)
- `./scripts/check-doc-sync.ps1 -ChangedFiles (git diff --cached --name-only)`
