### PR TITLE
feat: add staging smoke evidence warning automation

### DIFF
--- a/2026-02-26.md
+++ b/2026-02-26.md
@@ -17,7 +17,7 @@ Baseline date: 2026-02-24. This document fixes the next execution order for ongo
    - Root-cause-based recovery checklist for `play_upload` and `testflight`
 4. Reduce ops alert noise [DONE]
    - Tighten HOLD/ERROR dedup and re-alert rules
-5. Improve staging smoke evidence capture
+5. Improve staging smoke evidence capture [DONE]
    - Auto-warn on missing links/evidence
 6. Improve exception observability
    - Standardize first useful failure line + category code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -789,6 +789,10 @@ develop push → GitHub Actions
   - `scripts/ops-health-issue-alert.ps1`: dedup/re-alert cooldown(`30m`/`480m`/`120m`) + `-ForceAlert` 지원
   - `scripts/ops-health-cycle.ps1`: `-AlertDedupWindowMinutes`, `-AlertHoldReAlertWindowMinutes`, `-AlertErrorReAlertWindowMinutes`, `-AlertForce` 전달
   - `docs/runbook.md`: 알림 볼륨 조정 파라미터 운영 가이드 추가
+- 스테이징 수동 스모크 증빙 경고 자동화 반영 (2026-02-24)
+  - `scripts/staging-ops-cycle.ps1`: `EvidenceStatus(OK|WARN)`/`EvidenceWarnings` 출력 및 `evidence warning:*` 노트 자동 기록
+  - `-ManualSmokeEvidence` 누락/링크 형식 이상 시 경고, 최신 수동 스모크 재사용 경로에서도 증빙 누락 경고
+  - `docs/runbook.md`: 수동 스모크 증빙 누락 시 WARN 기록 동작 명시
 - 스테이징 실가동 체크리스트/런북 동기화
   - `docs/staging-smoke-checklist.md`
   - `docs/runbook.md`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -137,6 +137,17 @@
     - `-AlertErrorReAlertWindowMinutes`
     - `-AlertForce`
 
+### Staging smoke evidence warning automation
+- Added evidence warning detection for manual smoke records
+  - `scripts/staging-ops-cycle.ps1`
+  - New behavior:
+    - emits `EvidenceStatus=OK|WARN` and `EvidenceWarnings` in JSON output
+    - appends `evidence warning:*` note when manual smoke evidence link is missing or not link-like
+    - validates both current manual smoke submission (`-ManualSmokeEvidence`) and latest-record reuse path
+- Updated runbook guidance
+  - `docs/runbook.md`
+  - documented WARN behavior and manual evidence requirement
+
 ## 2026-02-23
 
 ### Staging manual smoke recency gate + log automation

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -37,6 +37,7 @@
   - preflight + 최신 배포 게이트 + 수동 스모크 최신성(기본 7일) 게이트 + `docs/staging-smoke-log.md` 기록을 일괄 수행
   - 수동 스모크 완료 후 결과 기록:
     - `.\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch staging -Owner <담당자> -SkipPreflight -ManualSmokeResult PASS -ManualSmokeEvidence <증빙URL> [-ManualSmokeNotes "<요약>"]`
+    - `-ManualSmokeEvidence` 누락/링크 형식 이상이면 `EvidenceStatus=WARN` + `evidence warning:*` 노트가 로그/JSON에 기록됨
 - [ ] 통합 운영 헬스 사이클 실행(권장)
   - `.\scripts\ops-health-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch staging -Owner <담당자> [-AutoLogin] [-WaitForCompletion]`
   - staging 게이트 + 시크릿 로테이션 점검을 함께 실행하고 `docs/ops-health-log.md`에 결과를 누적

--- a/scripts/staging-ops-cycle.ps1
+++ b/scripts/staging-ops-cycle.ps1
@@ -268,6 +268,48 @@ function Get-LatestManualSmokeRecord {
   return $latest
 }
 
+function Get-ManualSmokeEvidencePortion {
+  param([string]$EvidenceText)
+
+  if ([string]::IsNullOrWhiteSpace($EvidenceText)) {
+    return ""
+  }
+
+  $parts = @($EvidenceText -split ";" | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+  if ($parts.Count -le 1) {
+    return ""
+  }
+
+  return ($parts[1..($parts.Count - 1)] -join " ; ")
+}
+
+function Test-EvidenceReference {
+  param([string]$Value)
+
+  if ([string]::IsNullOrWhiteSpace($Value)) {
+    return $false
+  }
+
+  $trimmed = $Value.Trim()
+  if ($trimmed -eq "-") {
+    return $false
+  }
+  if ($trimmed -match "https?://") {
+    return $true
+  }
+  if ($trimmed -match "\[[^\]]+\]\([^)]+\)") {
+    return $true
+  }
+  if ($trimmed -match "(^|[ ;])(docs|apps|infra|scripts|\.github)/[A-Za-z0-9._/\-]+") {
+    return $true
+  }
+  if ($trimmed -match "(^|[ ;])[A-Za-z0-9._/\-]+#L\d+") {
+    return $true
+  }
+
+  return $false
+}
+
 $script:PowerShellCommand = Get-PowerShellCommand
 if ([string]::IsNullOrWhiteSpace($script:PowerShellCommand)) {
   throw "missing powershell command (powershell.exe/pwsh)"
@@ -291,6 +333,7 @@ if ([string]::IsNullOrWhiteSpace($ManualSmokeResult) -and (
 
 $preflightState = "SKIPPED"
 $notes = @()
+$evidenceWarnings = @()
 
 if (-not $SkipPreflight) {
   $preflightScript = Join-Path $PSScriptRoot "staging-preflight.ps1"
@@ -458,6 +501,11 @@ if (-not [string]::IsNullOrWhiteSpace($ManualSmokeResult)) {
     $manualSmokeOutcomeGate = $false
     $notes += "manual smoke result=FAIL"
   }
+  if ([string]::IsNullOrWhiteSpace($ManualSmokeEvidence)) {
+    $evidenceWarnings += "manual smoke evidence missing"
+  } elseif (-not (Test-EvidenceReference -Value $ManualSmokeEvidence)) {
+    $evidenceWarnings += "manual smoke evidence has no link/reference"
+  }
 } elseif (-not $SkipManualSmokeRecencyGate) {
   $latestManualSmoke = Get-LatestManualSmokeRecord -Path $LogFile -Repo $Repo -Branch $Branch
   if ($null -eq $latestManualSmoke) {
@@ -472,6 +520,13 @@ if (-not [string]::IsNullOrWhiteSpace($ManualSmokeResult)) {
     if ($manualSmokeAgeDays -gt [double]$ManualSmokeMaxAgeDays) {
       $manualSmokeRecencyGate = $false
       $notes += "manual smoke stale(ageDays=$manualSmokeAgeDaysDisplay, maxDays=$ManualSmokeMaxAgeDays)"
+    }
+
+    $latestManualEvidence = Get-ManualSmokeEvidencePortion -EvidenceText "$($latestManualSmoke.Evidence)"
+    if ([string]::IsNullOrWhiteSpace($latestManualEvidence)) {
+      $evidenceWarnings += "latest manual smoke evidence missing"
+    } elseif (-not (Test-EvidenceReference -Value $latestManualEvidence)) {
+      $evidenceWarnings += "latest manual smoke evidence has no link/reference"
     }
   }
 } else {
@@ -526,6 +581,11 @@ if (-not $manualSmokeOutcomeGate) {
   $notes += "manual smoke outcome gate failed"
 }
 
+$evidenceWarnings = @($evidenceWarnings | Select-Object -Unique)
+foreach ($warning in $evidenceWarnings) {
+  $notes += ("evidence warning: " + $warning)
+}
+
 $logRow = @{
   UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
   Repo = $Repo
@@ -563,6 +623,8 @@ $resultPayload = [PSCustomObject]@{
   Decision = $decision
   ManualSmoke = $manualSmoke
   ManualSmokeAgeDays = "$manualSmokeAgeDaysDisplay"
+  EvidenceStatus = $(if ($evidenceWarnings.Count -gt 0) { "WARN" } else { "OK" })
+  EvidenceWarnings = $evidenceWarnings
   Evidence = $evidence
   Owner = $Owner
   Notes = ($notes -join "; ")


### PR DESCRIPTION
﻿## Summary
- add manual-smoke evidence warning detection in `scripts/staging-ops-cycle.ps1`
- emit `EvidenceStatus` (`OK|WARN`) and `EvidenceWarnings` in JSON output
- append `evidence warning:*` notes when manual smoke evidence is missing or non-link-like
- check both current submission (`-ManualSmokeEvidence`) and latest-manual-smoke reuse path
- sync docs/backlog state (`docs/runbook.md`, `docs/changelog-dev.md`, `CLAUDE.md`, `2026-02-26.md`)

## Validation
- `powershell -NoProfile -Command "[void][System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path 'scripts/staging-ops-cycle.ps1'), [ref]$null, [ref]$null)"`
- `powershell -NoProfile -File .\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -LogFile .\.tmp\staging-evidence-missing.md -SkipPreflight -ManualSmokeResult PASS -AsJson` (expected `EvidenceStatus=WARN`)
- `powershell -NoProfile -File .\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -LogFile .\.tmp\staging-evidence-present.md -SkipPreflight -ManualSmokeResult PASS -ManualSmokeEvidence https://example.com/smoke-proof -AsJson` (expected `EvidenceStatus=OK`)
- `./scripts/check-doc-sync.ps1 -ChangedFiles (git diff --cached --name-only)`
