### PR TITLE
feat: standardize staging exception observability signals

### DIFF
--- a/2026-02-26.md
+++ b/2026-02-26.md
@@ -19,7 +19,7 @@ Baseline date: 2026-02-24. This document fixes the next execution order for ongo
    - Tighten HOLD/ERROR dedup and re-alert rules
 5. Improve staging smoke evidence capture [DONE]
    - Auto-warn on missing links/evidence
-6. Improve exception observability
+6. Improve exception observability [DONE]
    - Standardize first useful failure line + category code
 7. Strengthen doc sync checks [DONE]
    - Detect required-doc omissions by changed area

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -793,6 +793,10 @@ develop push → GitHub Actions
   - `scripts/staging-ops-cycle.ps1`: `EvidenceStatus(OK|WARN)`/`EvidenceWarnings` 출력 및 `evidence warning:*` 노트 자동 기록
   - `-ManualSmokeEvidence` 누락/링크 형식 이상 시 경고, 최신 수동 스모크 재사용 경로에서도 증빙 누락 경고
   - `docs/runbook.md`: 수동 스모크 증빙 누락 시 WARN 기록 동작 명시
+- 스테이징 예외 관측성 표준화 반영 (2026-02-24)
+  - `scripts/staging-ops-cycle.ps1`: `FailureCategory`/`FailureDetail` 추가, first-useful-line 추출 표준화
+  - status 실패 경로에서 `status_command`/`status_json_parse` 카테고리와 핵심 실패 라인(JSON) 유지
+  - 하위 PowerShell 호출 예외를 흡수해 구조화 결과(JSON) 누락 없이 반환
 - 스테이징 실가동 체크리스트/런북 동기화
   - `docs/staging-smoke-checklist.md`
   - `docs/runbook.md`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -148,6 +148,17 @@
   - `docs/runbook.md`
   - documented WARN behavior and manual evidence requirement
 
+### Staging exception observability standardization
+- Standardized failure-line extraction and category/detail output
+  - `scripts/staging-ops-cycle.ps1`
+  - Added shared `Get-FirstUsefulLine` extraction for nested script errors
+  - Added `FailureCategory` and `FailureDetail` fields to JSON output for HOLD/error paths
+  - Added category codes:
+    - `run_conclusion`, `deploy_job`, `verify_step`, `deploy_freshness`
+    - `aws_preflight`, `manual_smoke_recency`, `manual_smoke_failed`, `manual_smoke_evidence_warn`
+    - `status_command`, `status_json_parse`
+  - Hardened nested PowerShell invocation to capture stderr/exception text without losing structured failure output
+
 ## 2026-02-23
 
 ### Staging manual smoke recency gate + log automation

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -38,6 +38,7 @@
   - 수동 스모크 완료 후 결과 기록:
     - `.\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch staging -Owner <담당자> -SkipPreflight -ManualSmokeResult PASS -ManualSmokeEvidence <증빙URL> [-ManualSmokeNotes "<요약>"]`
     - `-ManualSmokeEvidence` 누락/링크 형식 이상이면 `EvidenceStatus=WARN` + `evidence warning:*` 노트가 로그/JSON에 기록됨
+    - 예외/보류 원인은 `FailureCategory` + `FailureDetail`로 JSON에 표준 출력됨
 - [ ] 통합 운영 헬스 사이클 실행(권장)
   - `.\scripts\ops-health-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch staging -Owner <담당자> [-AutoLogin] [-WaitForCompletion]`
   - staging 게이트 + 시크릿 로테이션 점검을 함께 실행하고 `docs/ops-health-log.md`에 결과를 누적

--- a/scripts/ops-health-cycle.ps1
+++ b/scripts/ops-health-cycle.ps1
@@ -248,6 +248,10 @@ function Get-FailureCategory {
 
   if ($Step -eq "staging") {
     if ($null -ne $Json) {
+      $jsonCategory = "$($Json.FailureCategory)"
+      if (-not [string]::IsNullOrWhiteSpace($jsonCategory) -and $jsonCategory -ne "-") {
+        return $jsonCategory
+      }
       $notesText = "$($Json.Notes)"
       if ($Json.ManualSmoke -eq "OVERDUE" -or $notesText -match $manualSmokeRecencyPattern) {
         return "manual_smoke_recency"
@@ -275,6 +279,10 @@ function Get-FailureCategory {
 
   if ($Step -eq "secrets") {
     if ($null -ne $Json) {
+      $jsonCategory = "$($Json.FailureCategory)"
+      if (-not [string]::IsNullOrWhiteSpace($jsonCategory) -and $jsonCategory -ne "-") {
+        return $jsonCategory
+      }
       if ([int]$Json.MissingCount -gt 0) { return "secret_missing" }
       if ([int]$Json.StaleCount -gt 0) { return "secret_stale" }
       if ([int]$Json.UnknownCount -gt 0) { return "secret_unknown" }

--- a/scripts/staging-ops-cycle.ps1
+++ b/scripts/staging-ops-cycle.ps1
@@ -197,11 +197,44 @@ function Invoke-PowerShellFile {
     throw "missing powershell command (powershell.exe/pwsh)"
   }
 
-  $output = & $script:PowerShellCommand -NoProfile -File $ScriptPath @Arguments 2>&1
-  return [PSCustomObject]@{
-    ExitCode = $LASTEXITCODE
-    Output = ($output -join "`n")
+  $exitCode = 0
+  $outputText = ""
+  try {
+    $output = & $script:PowerShellCommand -NoProfile -File $ScriptPath @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    $outputText = ($output -join "`n")
+  } catch {
+    $exitCode = if ($LASTEXITCODE -ne 0) { $LASTEXITCODE } else { 1 }
+    $outputText = "$($_.Exception.Message)"
   }
+
+  return [PSCustomObject]@{
+    ExitCode = $exitCode
+    Output = $outputText
+  }
+}
+
+function Get-FirstUsefulLine {
+  param([string]$Output)
+
+  if ([string]::IsNullOrWhiteSpace($Output)) {
+    return ""
+  }
+
+  $lines = $Output -split "`r?`n" | ForEach-Object { $_.Trim() } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  if ($lines.Count -eq 0) {
+    return ""
+  }
+
+  foreach ($line in $lines) {
+    if ($line -eq "System.Management.Automation.RemoteException") { continue }
+    if ($line -like "At line:*") { continue }
+    if ($line -like "+ CategoryInfo:*") { continue }
+    if ($line -like "+ FullyQualifiedErrorId:*") { continue }
+    return $line
+  }
+
+  return $lines[0]
 }
 
 function Get-LatestManualSmokeRecord {
@@ -310,6 +343,68 @@ function Test-EvidenceReference {
   return $false
 }
 
+function Get-FailureCategoryCode {
+  param(
+    [bool]$RunGate,
+    [bool]$DeployGate,
+    [bool]$VerifyGate,
+    [bool]$AgeGate,
+    [bool]$PreflightGate,
+    [bool]$ManualSmokeRecencyGate,
+    [bool]$ManualSmokeOutcomeGate,
+    [bool]$HasEvidenceWarning
+  )
+
+  if (-not $RunGate) { return "run_conclusion" }
+  if (-not $DeployGate) { return "deploy_job" }
+  if (-not $VerifyGate) { return "verify_step" }
+  if (-not $AgeGate) { return "deploy_freshness" }
+  if (-not $PreflightGate) { return "aws_preflight" }
+  if (-not $ManualSmokeRecencyGate) { return "manual_smoke_recency" }
+  if (-not $ManualSmokeOutcomeGate) { return "manual_smoke_failed" }
+  if ($HasEvidenceWarning) { return "manual_smoke_evidence_warn" }
+
+  return "-"
+}
+
+function Get-FailureDetail {
+  param(
+    [string]$FailureCategory,
+    [string]$RunConclusion,
+    [string]$DeployConclusion,
+    [string]$VerifyConclusion,
+    [string]$RunAgeMinutes,
+    [int]$MaxAgeMinutes,
+    [string[]]$Notes = @(),
+    [string[]]$EvidenceWarnings = @()
+  )
+
+  switch ($FailureCategory) {
+    "run_conclusion" { return ("run conclusion=" + $RunConclusion) }
+    "deploy_job" { return ("deploy=" + $DeployConclusion) }
+    "verify_step" { return ("verify=" + $VerifyConclusion) }
+    "deploy_freshness" { return ("run too old(age=" + $RunAgeMinutes + ", max=" + $MaxAgeMinutes + ")") }
+    "aws_preflight" {
+      $preflightDetail = @($Notes | Where-Object { $_ -like "preflight*" } | Select-Object -First 1)
+      if ($preflightDetail.Count -gt 0) { return "$($preflightDetail[0])" }
+      return "preflight failed"
+    }
+    "manual_smoke_recency" {
+      $recencyDetail = @($Notes | Where-Object { $_ -match "manual smoke (record missing|stale|recency gate failed)" } | Select-Object -First 1)
+      if ($recencyDetail.Count -gt 0) { return "$($recencyDetail[0])" }
+      return "manual smoke recency gate failed"
+    }
+    "manual_smoke_failed" { return "manual smoke outcome gate failed" }
+    "manual_smoke_evidence_warn" {
+      if ($EvidenceWarnings.Count -gt 0) {
+        return ("evidence warning: " + $EvidenceWarnings[0])
+      }
+      return "manual smoke evidence warning"
+    }
+    default { return "-" }
+  }
+}
+
 $script:PowerShellCommand = Get-PowerShellCommand
 if ([string]::IsNullOrWhiteSpace($script:PowerShellCommand)) {
   throw "missing powershell command (powershell.exe/pwsh)"
@@ -388,7 +483,10 @@ if ($WaitForCompletion) {
 
 $statusResult = Invoke-PowerShellFile -ScriptPath $statusScript -Arguments $statusArgs
 if ($statusResult.ExitCode -ne 0) {
-  $tail = if ([string]::IsNullOrWhiteSpace($statusResult.Output)) { "status command failed" } else { $statusResult.Output.Split("`n")[-1].Trim() }
+  $tail = Get-FirstUsefulLine -Output $statusResult.Output
+  if ([string]::IsNullOrWhiteSpace($tail)) {
+    $tail = "status command failed"
+  }
   $errorUtc = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
   $errorRow = @{
     UtcTime = $errorUtc
@@ -425,6 +523,8 @@ if ($statusResult.ExitCode -ne 0) {
       Decision = "HOLD"
       ManualSmoke = "NOT_STARTED"
       ManualSmokeAgeDays = "-"
+      FailureCategory = "status_command"
+      FailureDetail = $tail
       Evidence = "-"
       Owner = $Owner
       Notes = "status error: $tail"
@@ -474,6 +574,8 @@ try {
       Decision = "HOLD"
       ManualSmoke = "NOT_STARTED"
       ManualSmokeAgeDays = "-"
+      FailureCategory = "status_json_parse"
+      FailureDetail = "status output is not valid json"
       Evidence = "-"
       Owner = $Owner
       Notes = "status output is not valid json"
@@ -586,6 +688,26 @@ foreach ($warning in $evidenceWarnings) {
   $notes += ("evidence warning: " + $warning)
 }
 
+$failureCategory = Get-FailureCategoryCode `
+  -RunGate $runGate `
+  -DeployGate $deployGate `
+  -VerifyGate $verifyGate `
+  -AgeGate $ageGate `
+  -PreflightGate $preflightGate `
+  -ManualSmokeRecencyGate $manualSmokeRecencyGate `
+  -ManualSmokeOutcomeGate $manualSmokeOutcomeGate `
+  -HasEvidenceWarning ($evidenceWarnings.Count -gt 0)
+
+$failureDetail = Get-FailureDetail `
+  -FailureCategory $failureCategory `
+  -RunConclusion "$($summary.Conclusion)" `
+  -DeployConclusion "$($summary.DeployJobConclusion)" `
+  -VerifyConclusion "$($summary.VerifyStepConclusion)" `
+  -RunAgeMinutes "$($summary.RunAgeMinutes)" `
+  -MaxAgeMinutes $MaxAgeMinutes `
+  -Notes $notes `
+  -EvidenceWarnings $evidenceWarnings
+
 $logRow = @{
   UtcTime = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
   Repo = $Repo
@@ -623,6 +745,8 @@ $resultPayload = [PSCustomObject]@{
   Decision = $decision
   ManualSmoke = $manualSmoke
   ManualSmokeAgeDays = "$manualSmokeAgeDaysDisplay"
+  FailureCategory = $failureCategory
+  FailureDetail = $failureDetail
   EvidenceStatus = $(if ($evidenceWarnings.Count -gt 0) { "WARN" } else { "OK" })
   EvidenceWarnings = $evidenceWarnings
   Evidence = $evidence
@@ -662,6 +786,10 @@ if ($AsJson) {
   Write-Host ("Decision: {0}" -f $decision)
   Write-Host ("ManualSmoke: {0}" -f $manualSmoke)
   Write-Host ("ManualSmokeAgeDays: {0}" -f $manualSmokeAgeDaysDisplay)
+  Write-Host ("FailureCategory: {0}" -f $failureCategory)
+  if ($failureDetail -ne "-") {
+    Write-Host ("FailureDetail: {0}" -f $failureDetail)
+  }
   Write-Host ("Log: {0}" -f $LogFile)
   Write-Host ""
   Write-Host "Update manual smoke results in:"


### PR DESCRIPTION
﻿## Summary
- standardize staging failure observability in `scripts/staging-ops-cycle.ps1`
- add first-useful-line extraction for nested script failures
- add explicit `FailureCategory` and `FailureDetail` fields to JSON output for HOLD/error paths
- harden nested PowerShell invocation to preserve structured JSON failure output even when stderr/exception records are emitted
- propagate staging `FailureCategory` upstream in `scripts/ops-health-cycle.ps1`
- sync docs/backlog (`docs/changelog-dev.md`, `docs/runbook.md`, `CLAUDE.md`, `2026-02-26.md`)

## Validation
- `powershell -NoProfile -Command "[void][System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path 'scripts/staging-ops-cycle.ps1'), [ref]$null, [ref]$null); [void][System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path 'scripts/ops-health-cycle.ps1'), [ref]$null, [ref]$null)"`
- `powershell -NoProfile -File .\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -LogFile .\.tmp\staging-exception-observe-missing.md -SkipPreflight -ManualSmokeResult PASS -AsJson`
  - verified `FailureCategory=deploy_freshness`, `FailureDetail` populated
- `powershell -NoProfile -File .\scripts\staging-ops-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch non-existent-branch -LogFile .\.tmp\staging-exception-observe-status.md -SkipPreflight -AsJson`
  - verified `FailureCategory=status_command`, `FailureDetail` populated (expected exit code 1)
- `powershell -NoProfile -File .\scripts\ops-health-cycle.ps1 -Repo V4N1LLA/Eunhye_Hymn -Branch develop -SkipSecretsRotation -StagingLogFile .\.tmp\ops-pass-through-staging.md -OpsHealthLogFile .\.tmp\ops-pass-through-health.md -AlertOnFailure -AlertDryRun -AsJson`
  - verified top-level `FailureCategory` pass-through from staging result
- `./scripts/check-doc-sync.ps1 -ChangedFiles (git diff --cached --name-only)`
