### PR TITLE
feat: automate parallel work ownership collision guards

### DIFF
--- a/2026-02-26.md
+++ b/2026-02-26.md
@@ -23,7 +23,7 @@ Baseline date: 2026-02-24. This document fixes the next execution order for ongo
    - Standardize first useful failure line + category code
 7. Strengthen doc sync checks [DONE]
    - Detect required-doc omissions by changed area
-8. Strengthen parallel-work collision guards
+8. Strengthen parallel-work collision guards [DONE]
    - Automate branch/worktree ownership validation
 
 ## Execution rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -797,6 +797,10 @@ develop push → GitHub Actions
   - `scripts/staging-ops-cycle.ps1`: `FailureCategory`/`FailureDetail` 추가, first-useful-line 추출 표준화
   - status 실패 경로에서 `status_command`/`status_json_parse` 카테고리와 핵심 실패 라인(JSON) 유지
   - 하위 PowerShell 호출 예외를 흡수해 구조화 결과(JSON) 누락 없이 반환
+- 병렬 작업 충돌 가드 자동화 반영 (2026-02-24)
+  - `scripts/new-worktree-task.ps1`: branch/worktree/claimed-path 소유권 충돌 사전 검증
+  - `docs/parallel-task-board.md` 자동 upsert(소유자/경로/상태/UTC), 충돌 시 생성 차단
+  - `-AllowClaimedPathConflict`로 예외 허용 가능(기본은 차단)
 - 스테이징 실가동 체크리스트/런북 동기화
   - `docs/staging-smoke-checklist.md`
   - `docs/runbook.md`

--- a/docs/changelog-dev.md
+++ b/docs/changelog-dev.md
@@ -159,6 +159,24 @@
     - `status_command`, `status_json_parse`
   - Hardened nested PowerShell invocation to capture stderr/exception text without losing structured failure output
 
+### Parallel work collision guard automation
+- Upgraded worktree bootstrap with ownership validation
+  - `scripts/new-worktree-task.ps1`
+  - Added ownership/collision parameters:
+    - `-Owner`
+    - `-ClaimedPaths`
+    - `-TaskBoardPath`
+    - `-SkipTaskBoardUpdate`
+    - `-AllowClaimedPathConflict`
+  - Added automated checks before worktree creation:
+    - local/remote branch existence collision
+    - worktree path ownership collision (task board)
+    - claimed path overlap collision (task board active rows)
+  - Added automatic task-board upsert (`in_progress`, UTC timestamp) after successful worktree creation
+- Updated parallel-work docs
+  - `docs/parallel-pr-workflow.md`
+  - `docs/parallel-task-board.md`
+
 ## 2026-02-23
 
 ### Staging manual smoke recency gate + log automation

--- a/docs/parallel-pr-workflow.md
+++ b/docs/parallel-pr-workflow.md
@@ -40,3 +40,22 @@
 1. 먼저 `git fetch origin`
 2. 대상 브랜치 리베이스/머지 후 충돌 해결
 3. 충돌 파일이 공용 정책 파일이면 관련 터미널 담당자와 먼저 합의
+
+## Collision Guard Automation (2026-02-24)
+- `scripts/new-worktree-task.ps1` now validates ownership before creating a worktree.
+- Recommended command:
+
+```powershell
+.\scripts\new-worktree-task.ps1 `
+  -TaskName "admin-user-filter" `
+  -BaseBranch develop `
+  -Owner codex `
+  -ClaimedPaths "apps/admin/src/pages/UserListPage.tsx","docs/runbook.md"
+```
+
+- Guard rules enforced:
+  - block local/remote branch name collisions
+  - block task-board worktree path collisions
+  - block claimed-path overlap with active rows from other owners
+- On success, the script auto-upserts `docs/parallel-task-board.md` with `status=in_progress` and current UTC.
+- Use `-AllowClaimedPathConflict` only for explicit, coordinated exceptions.

--- a/docs/parallel-task-board.md
+++ b/docs/parallel-task-board.md
@@ -5,3 +5,7 @@
 | Owner | Task | Branch | Worktree Path | Claimed Paths | Status | Updated (UTC) |
 |---|---|---|---|---|---|---|
 | example | admin filter | feat/admin-filter | ..\worktrees\feat-admin-filter | apps/admin/src/pages/UserListPage.tsx | in_progress | 2026-02-20T00:00:00Z |
+
+> Managed by `scripts/new-worktree-task.ps1`.
+> Active rows are ownership claims used for branch/worktree/path collision checks.
+> Mark finished work as `done`/`merged`/`closed`/`cancelled` to release claims.

--- a/scripts/new-worktree-task.ps1
+++ b/scripts/new-worktree-task.ps1
@@ -4,7 +4,12 @@ param(
   [string]$BaseBranch = "develop",
   [string]$BranchPrefix = "feat",
   [string]$Remote = "origin",
-  [string]$WorktreesDir = "..\\worktrees"
+  [string]$WorktreesDir = "..\\worktrees",
+  [string]$Owner = "codex",
+  [string[]]$ClaimedPaths = @(),
+  [string]$TaskBoardPath = "docs/parallel-task-board.md",
+  [switch]$SkipTaskBoardUpdate,
+  [switch]$AllowClaimedPathConflict
 )
 
 $ErrorActionPreference = "Stop"
@@ -23,6 +28,232 @@ function New-Slug {
     throw "TaskName produced an empty slug. Use letters/numbers in TaskName."
   }
   return $slug
+}
+
+function Escape-MarkdownCell {
+  param([string]$Value)
+  if ($null -eq $Value) {
+    return ""
+  }
+  return $Value.Replace("|", "\|").Trim()
+}
+
+function Normalize-PathToken {
+  param([string]$Value)
+
+  if ([string]::IsNullOrWhiteSpace($Value)) {
+    return ""
+  }
+
+  $normalized = $Value.Trim()
+  $normalized = $normalized -replace "\\", "/"
+  $normalized = $normalized.Trim("/")
+  return $normalized.ToLowerInvariant()
+}
+
+function Test-PathOverlap {
+  param(
+    [string]$Left,
+    [string]$Right
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Left) -or [string]::IsNullOrWhiteSpace($Right)) {
+    return $false
+  }
+  if ($Left -eq $Right) {
+    return $true
+  }
+  if ($Left.StartsWith($Right + "/")) {
+    return $true
+  }
+  if ($Right.StartsWith($Left + "/")) {
+    return $true
+  }
+  return $false
+}
+
+function Ensure-TaskBoardFile {
+  param([string]$Path)
+
+  $directory = Split-Path -Path $Path -Parent
+  if (-not [string]::IsNullOrWhiteSpace($directory) -and -not (Test-Path $directory)) {
+    New-Item -ItemType Directory -Path $directory -Force | Out-Null
+  }
+
+  if (Test-Path $Path) {
+    return
+  }
+
+  @"
+# Parallel Task Board
+
+Record active parallel work ownership.
+
+| Owner | Task | Branch | Worktree Path | Claimed Paths | Status | Updated (UTC) |
+|---|---|---|---|---|---|---|
+"@ | Set-Content -Path $Path -Encoding utf8
+}
+
+function Get-TaskBoardRows {
+  param([string]$Path)
+
+  Ensure-TaskBoardFile -Path $Path
+
+  $rows = @()
+  $lines = Get-Content -Path $Path -Encoding utf8
+  foreach ($line in $lines) {
+    $trimmed = $line.Trim()
+    if (-not $trimmed.StartsWith("|")) {
+      continue
+    }
+    if ($trimmed -match "^\|\s*-+\s*\|") {
+      continue
+    }
+    if ($trimmed -match "^\|\s*Owner\s*\|") {
+      continue
+    }
+
+    $parts = $line.Split("|")
+    if ($parts.Count -lt 9) {
+      continue
+    }
+
+    $rows += [PSCustomObject]@{
+      Owner = $parts[1].Trim()
+      Task = $parts[2].Trim()
+      Branch = $parts[3].Trim()
+      WorktreePath = $parts[4].Trim()
+      ClaimedPaths = $parts[5].Trim()
+      Status = $parts[6].Trim()
+      UpdatedUtc = $parts[7].Trim()
+    }
+  }
+
+  return $rows
+}
+
+function Get-ClaimedPathTokens {
+  param([string]$Value)
+
+  if ([string]::IsNullOrWhiteSpace($Value) -or $Value.Trim() -eq "-") {
+    return @()
+  }
+
+  $tokens = @()
+  foreach ($piece in ($Value -split "[,;]")) {
+    $normalized = Normalize-PathToken -Value $piece
+    if (-not [string]::IsNullOrWhiteSpace($normalized)) {
+      $tokens += $normalized
+    }
+  }
+  return @($tokens | Select-Object -Unique)
+}
+
+function Test-ActiveStatus {
+  param([string]$Status)
+
+  $token = if ([string]::IsNullOrWhiteSpace($Status)) { "" } else { $Status.Trim().ToLowerInvariant() }
+  if ($token -in @("done", "merged", "closed", "cancelled")) {
+    return $false
+  }
+  return $true
+}
+
+function Assert-NoOwnershipCollision {
+  param(
+    [object[]]$TaskBoardRows,
+    [string]$Owner,
+    [string]$BranchName,
+    [string]$WorktreePath,
+    [string[]]$ClaimedPathTokens,
+    [switch]$AllowClaimedPathConflict
+  )
+
+  $normalizedWorktree = Normalize-PathToken -Value $WorktreePath
+  foreach ($row in $TaskBoardRows) {
+    if (-not (Test-ActiveStatus -Status "$($row.Status)")) {
+      continue
+    }
+
+    $rowOwner = "$($row.Owner)"
+    $rowBranch = "$($row.Branch)"
+    $rowWorktree = Normalize-PathToken -Value "$($row.WorktreePath)"
+
+    if ($rowBranch -eq $BranchName -and $rowOwner -ne $Owner) {
+      throw "Branch collision: $BranchName is already owned by '$rowOwner' in task board."
+    }
+    if (-not [string]::IsNullOrWhiteSpace($rowWorktree) -and $rowWorktree -eq $normalizedWorktree -and $rowOwner -ne $Owner) {
+      throw "Worktree collision: $WorktreePath is already owned by '$rowOwner' in task board."
+    }
+
+    $rowClaims = Get-ClaimedPathTokens -Value "$($row.ClaimedPaths)"
+    foreach ($claim in $ClaimedPathTokens) {
+      foreach ($rowClaim in $rowClaims) {
+        if (Test-PathOverlap -Left $claim -Right $rowClaim) {
+          if ($rowOwner -ne $Owner) {
+            if ($AllowClaimedPathConflict) {
+              Write-Warning ("Claimed path overlap allowed: '{0}' overlaps '{1}' owned by '{2}'." -f $claim, $rowClaim, $rowOwner)
+            } else {
+              throw ("Claimed path collision: '{0}' overlaps '{1}' owned by '{2}'. Use different scope or pass -AllowClaimedPathConflict." -f $claim, $rowClaim, $rowOwner)
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+function Update-TaskBoardRow {
+  param(
+    [string]$Path,
+    [string]$Owner,
+    [string]$TaskName,
+    [string]$BranchName,
+    [string]$WorktreePath,
+    [string[]]$ClaimedPathTokens
+  )
+
+  Ensure-TaskBoardFile -Path $Path
+
+  $updatedUtc = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+  $claimedText = if ($ClaimedPathTokens.Count -eq 0) { "-" } else { ($ClaimedPathTokens -join ", ") }
+  $newRow = "| {0} | {1} | {2} | {3} | {4} | in_progress | {5} |" -f `
+    (Escape-MarkdownCell $Owner),
+    (Escape-MarkdownCell $TaskName),
+    (Escape-MarkdownCell $BranchName),
+    (Escape-MarkdownCell $WorktreePath),
+    (Escape-MarkdownCell $claimedText),
+    (Escape-MarkdownCell $updatedUtc)
+
+  $lines = Get-Content -Path $Path -Encoding utf8
+  $replaced = $false
+  for ($index = 0; $index -lt $lines.Count; $index++) {
+    $line = $lines[$index]
+    $trimmed = $line.Trim()
+    if (-not $trimmed.StartsWith("|")) {
+      continue
+    }
+    if ($trimmed -match "^\|\s*-+\s*\|" -or $trimmed -match "^\|\s*Owner\s*\|") {
+      continue
+    }
+
+    $parts = $line.Split("|")
+    if ($parts.Count -lt 9) {
+      continue
+    }
+
+    if ($parts[3].Trim() -eq $BranchName) {
+      $lines[$index] = $newRow
+      $replaced = $true
+      break
+    }
+  }
+
+  if (-not $replaced) {
+    $lines += $newRow
+  }
+
+  $lines | Set-Content -Path $Path -Encoding utf8
 }
 
 if (-not (Test-CommandExists "git")) {
@@ -46,6 +277,14 @@ if (-not [string]::IsNullOrWhiteSpace($localBranch)) {
   throw "Local branch already exists: $branchName"
 }
 
+$remoteBranch = git ls-remote --heads $Remote $branchName
+if ($LASTEXITCODE -ne 0) {
+  throw "remote branch check failed."
+}
+if (-not [string]::IsNullOrWhiteSpace($remoteBranch)) {
+  throw "Remote branch already exists: $Remote/$branchName"
+}
+
 if (-not (Test-Path $WorktreesDir)) {
   New-Item -ItemType Directory -Path $WorktreesDir | Out-Null
 }
@@ -55,15 +294,55 @@ if (Test-Path $worktreePath) {
   throw "Worktree path already exists: $worktreePath"
 }
 
+$resolvedTaskBoardPath = $TaskBoardPath
+$taskBoardRows = Get-TaskBoardRows -Path $resolvedTaskBoardPath
+$normalizedClaims = @()
+foreach ($item in $ClaimedPaths) {
+  $normalized = Normalize-PathToken -Value $item
+  if (-not [string]::IsNullOrWhiteSpace($normalized)) {
+    $normalizedClaims += $normalized
+  }
+}
+$normalizedClaims = @($normalizedClaims | Select-Object -Unique)
+
+Assert-NoOwnershipCollision `
+  -TaskBoardRows $taskBoardRows `
+  -Owner $Owner `
+  -BranchName $branchName `
+  -WorktreePath $worktreePath `
+  -ClaimedPathTokens $normalizedClaims `
+  -AllowClaimedPathConflict:$AllowClaimedPathConflict
+
 git worktree add $worktreePath -b $branchName $startPoint
 if ($LASTEXITCODE -ne 0) {
   throw "git worktree add failed."
 }
 
+if (-not $SkipTaskBoardUpdate) {
+  Update-TaskBoardRow `
+    -Path $resolvedTaskBoardPath `
+    -Owner $Owner `
+    -TaskName $TaskName `
+    -BranchName $branchName `
+    -WorktreePath $worktreePath `
+    -ClaimedPathTokens $normalizedClaims
+}
+
 Write-Host "Created worktree."
+Write-Host ("Owner:    {0}" -f $Owner)
 Write-Host ("Branch:   {0}" -f $branchName)
 Write-Host ("Path:     {0}" -f (Resolve-Path $worktreePath))
 Write-Host ("Base:     {0}" -f $startPoint)
+if ($normalizedClaims.Count -gt 0) {
+  Write-Host ("Claims:   {0}" -f ($normalizedClaims -join ", "))
+} else {
+  Write-Host "Claims:   -"
+}
+if ($SkipTaskBoardUpdate) {
+  Write-Host ("TaskBoard:{0} (skip update)" -f $resolvedTaskBoardPath)
+} else {
+  Write-Host ("TaskBoard:{0} (updated)" -f $resolvedTaskBoardPath)
+}
 Write-Host ""
 Write-Host "Next:"
 Write-Host ("1) cd `"{0}`"" -f (Resolve-Path $worktreePath))


### PR DESCRIPTION
﻿## Summary
- strengthen `scripts/new-worktree-task.ps1` with automated ownership collision guards
- add task-board aware validation for branch/worktree/claimed-path conflicts
- auto-upsert task ownership row (`in_progress`, UTC) in task board after successful worktree creation
- add ownership-related options: `-Owner`, `-ClaimedPaths`, `-TaskBoardPath`, `-SkipTaskBoardUpdate`, `-AllowClaimedPathConflict`
- sync parallel-work docs and backlog status (`docs/parallel-pr-workflow.md`, `docs/parallel-task-board.md`, `docs/changelog-dev.md`, `CLAUDE.md`, `2026-02-26.md`)

## Validation
- parser check: `scripts/new-worktree-task.ps1`
- creation path test (temp worktree/task-board):
  - `powershell -NoProfile -File .\scripts\new-worktree-task.ps1 -TaskName "parallel-collision-probe-a" -BaseBranch develop -Owner alpha -ClaimedPaths docs/runbook.md -WorktreesDir .\.tmp\parallel-test\worktrees -TaskBoardPath .\.tmp\parallel-test\task-board.md`
- collision blocking test:
  - `powershell -NoProfile -File .\scripts\new-worktree-task.ps1 -TaskName "parallel-collision-probe-b" -BaseBranch develop -Owner beta -ClaimedPaths docs/runbook.md -WorktreesDir .\.tmp\parallel-test\worktrees -TaskBoardPath .\.tmp\parallel-test\task-board.md`
  - expected: claimed path collision error
- skip-update path test:
  - `powershell -NoProfile -File .\scripts\new-worktree-task.ps1 -TaskName "parallel-sanity-a" -BaseBranch develop -Owner codex -ClaimedPaths scripts/new-worktree-task.ps1 -WorktreesDir .\.tmp\parallel-sanity\worktrees -TaskBoardPath .\.tmp\parallel-sanity\task-board.md -SkipTaskBoardUpdate`
- cleanup validation branches/worktrees (`git worktree remove`, `git branch -d`) completed
- `./scripts/check-doc-sync.ps1 -ChangedFiles (git diff --cached --name-only)`
